### PR TITLE
Refactor sidebar into responsive drawer and improve mobile grids

### DIFF
--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -1,39 +1,122 @@
-import React from 'react';
+import React, { useEffect, useMemo, useRef } from 'react';
 import { NavLink, useNavigate } from 'react-router-dom';
-import { LogOut, ChevronsLeft, ChevronsRight, FileText } from 'lucide-react';
+import { LogOut, FileText, X } from 'lucide-react';
 import { useAuth } from '../contexts/AuthContext';
 import { NAV_LINKS } from '../constants';
 import { NotificationCounts } from '../types';
 
 interface SidebarProps {
-  isCollapsed: boolean;
-  toggleSidebar: () => void;
+  isOpen: boolean;
+  onClose: () => void;
   notifications: NotificationCounts | null;
   onReportClick: () => void;
 }
 
-const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, toggleSidebar, notifications, onReportClick }) => {
+const focusableSelectors = [
+  'a[href]',
+  'button:not([disabled])',
+  '[tabindex]:not([tabindex="-1"])',
+].join(',');
+
+const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, notifications, onReportClick }) => {
   const { role, logout } = useAuth();
   const navigate = useNavigate();
+  const sidebarRef = useRef<HTMLDivElement | null>(null);
+  const previouslyFocusedElement = useRef<HTMLElement | null>(null);
 
   const handleLogout = () => {
     logout();
     navigate('/login');
   };
 
-  const visibleNavLinks = NAV_LINKS.filter(link => role?.permissions[link.permissionKey] && role?.permissions[link.permissionKey] !== 'none');
+  const permissions = role?.permissions;
+
+  const visibleNavLinks = useMemo(
+    () => NAV_LINKS.filter(link => permissions?.[link.permissionKey] && permissions?.[link.permissionKey] !== 'none'),
+    [permissions],
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      return;
+    }
+
+    const isDesktop = typeof window !== 'undefined' && window.matchMedia('(min-width: 768px)').matches;
+    if (isDesktop) {
+      return;
+    }
+
+    previouslyFocusedElement.current = document.activeElement as HTMLElement | null;
+    const sidebarElement = sidebarRef.current;
+    const focusable = sidebarElement?.querySelectorAll<HTMLElement>(focusableSelectors);
+    focusable?.[0]?.focus();
+
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+      }
+
+      if (event.key === 'Tab' && focusable && focusable.length > 0) {
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+
+        if (event.shiftKey) {
+          if (document.activeElement === first) {
+            event.preventDefault();
+            last.focus();
+          }
+        } else if (document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+
+    return () => {
+      document.removeEventListener('keydown', handleKeyDown);
+      previouslyFocusedElement.current?.focus?.();
+    };
+  }, [isOpen, onClose]);
+
+  const handleNavLinkClick = () => {
+    const isDesktop = typeof window !== 'undefined' && window.matchMedia('(min-width: 768px)').matches;
+    if (!isDesktop) {
+      onClose();
+    }
+  };
 
   return (
-    <aside className={`flex flex-col bg-brand-secondary text-white transition-all duration-300 ease-in-out ${isCollapsed ? 'w-20' : 'w-64'}`}>
-      <div className={`flex items-center p-4 border-b border-gray-700 ${isCollapsed ? 'justify-center' : 'justify-between'}`}>
-        {!isCollapsed && <span className="text-2xl font-bold text-brand-primary">OUIOUI</span>}
-        <button onClick={toggleSidebar} className="p-2 rounded-full hover:bg-gray-700">
-          {isCollapsed ? <ChevronsRight size={20} /> : <ChevronsLeft size={20} />}
-        </button>
-      </div>
+    <>
+      <div
+        className={`fixed inset-0 z-40 bg-black/50 transition-opacity duration-300 md:hidden ${
+          isOpen ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'
+        }`}
+        aria-hidden={!isOpen}
+        onClick={onClose}
+      />
+      <aside
+        ref={sidebarRef}
+        className={`fixed inset-y-0 left-0 z-50 flex w-72 flex-col bg-brand-secondary text-white shadow-xl transition-transform duration-300 ease-in-out md:static md:z-auto md:w-64 md:translate-x-0 md:shadow-none ${
+          isOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'
+        }`}
+        aria-label="Navigation principale"
+      >
+        <div className="flex items-center justify-between border-b border-white/10 px-6 py-4">
+          <span className="text-2xl font-bold text-brand-primary">OUIOUI</span>
+          <button
+            onClick={onClose}
+            className="rounded-full p-2 text-white transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white md:hidden"
+            aria-label="Fermer le menu"
+          >
+            <X size={20} />
+          </button>
+        </div>
 
-      <nav className="flex-1 px-2 py-4 space-y-2">
-        {visibleNavLinks.map(link => {
+        <nav className="flex-1 space-y-2 overflow-y-auto px-3 py-4">
+          {visibleNavLinks.map(link => {
             let notificationContent = null;
             if (notifications) {
                 if (link.href === '/para-llevar' && (notifications.pendingTakeaway > 0 || notifications.readyTakeaway > 0)) {
@@ -56,31 +139,42 @@ const Sidebar: React.FC<SidebarProps> = ({ isCollapsed, toggleSidebar, notificat
               <NavLink
                 key={link.name}
                 to={link.href}
-                className={({ isActive }) => 
-                  `flex items-center p-3 rounded-lg transition-colors duration-200 ${isCollapsed ? 'justify-center' : ''} ${isActive ? 'bg-brand-primary text-brand-secondary' : 'hover:bg-gray-700'}`
+                onClick={handleNavLinkClick}
+                className={({ isActive }) =>
+                  `flex items-center gap-3 rounded-lg px-4 py-3 font-medium transition-colors duration-200 focus:outline-none focus:ring-2 focus:ring-white/40 ${
+                    isActive ? 'bg-white text-brand-secondary' : 'hover:bg-white/10'
+                  }`
                 }
-                title={isCollapsed ? link.name : ''}
               >
-                <link.icon size={24} />
-                {!isCollapsed && <span className="ml-4 font-semibold">{link.name}</span>}
-                {!isCollapsed && notificationContent && <span className="ml-auto">{notificationContent}</span>}
+                <link.icon size={22} />
+                <span>{link.name}</span>
+                {notificationContent && <span className="ml-auto">{notificationContent}</span>}
               </NavLink>
             );
         })}
-      </nav>
+        </nav>
 
-      <div className="px-2 py-4 border-t border-gray-700 space-y-2">
-         {/* Notifications can be added here */}
-         <button onClick={onReportClick} className={`flex items-center w-full p-3 rounded-lg text-left hover:bg-gray-700 ${isCollapsed ? 'justify-center' : ''}`}>
-           <FileText size={24} />
-           {!isCollapsed && <span className="ml-4 font-semibold">Rapport</span>}
-         </button>
-        <button onClick={handleLogout} className={`flex items-center w-full p-3 rounded-lg text-left text-red-400 hover:bg-red-500 hover:text-white ${isCollapsed ? 'justify-center' : ''}`}>
-          <LogOut size={24} />
-          {!isCollapsed && <span className="ml-4 font-semibold">Déconnexion</span>}
-        </button>
-      </div>
-    </aside>
+        <div className="space-y-2 border-t border-white/10 px-3 py-4">
+          <button
+            onClick={() => {
+              onReportClick();
+              handleNavLinkClick();
+            }}
+            className="flex w-full items-center gap-3 rounded-lg px-4 py-3 text-left transition hover:bg-white/10 focus:outline-none focus:ring-2 focus:ring-white/40"
+          >
+            <FileText size={22} />
+            <span className="font-semibold">Rapport</span>
+          </button>
+          <button
+            onClick={handleLogout}
+            className="flex w-full items-center gap-3 rounded-lg px-4 py-3 text-left text-red-300 transition hover:bg-red-500/20 hover:text-red-100 focus:outline-none focus:ring-2 focus:ring-red-200/80"
+          >
+            <LogOut size={22} />
+            <span className="font-semibold">Déconnexion</span>
+          </button>
+        </div>
+      </aside>
+    </>
   );
 };
 

--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -258,7 +258,7 @@ const Commande: React.FC = () => {
                         ))}
                     </div>
                 </div>
-                <div className="p-4 grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4 overflow-y-auto">
+                <div className="p-4 grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 overflow-y-auto">
                     {filteredProducts.map(product => {
                         const isLowStock = !isProductAvailable(product);
                         const quantityInCart = productQuantitiesInCart[product.id] || 0;

--- a/pages/CommandeClient.tsx
+++ b/pages/CommandeClient.tsx
@@ -282,7 +282,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                                 </button>
                             ))}
                         </div>
-                        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
+                        <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 md:grid-cols-3">
                             {filteredProducts.map(product => (
                                 <div key={product.id} onClick={() => product.estado === 'disponible' && handleProductClick(product)}
                                     className={`border rounded-lg p-3 flex flex-col items-center text-center transition-shadow ${product.estado === 'disponible' ? 'cursor-pointer hover:shadow-lg' : 'opacity-50'}`}>

--- a/pages/Cuisine.tsx
+++ b/pages/Cuisine.tsx
@@ -93,7 +93,7 @@ const Cuisine: React.FC = () => {
             {orders.length === 0 ? (
                 <div className="flex-1 flex items-center justify-center text-2xl text-gray-700">Aucune commande en préparation.</div>
             ) : (
-                <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 flex-1">
+                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 flex-1">
                     {orders.map(order => (
                         <KitchenTicket key={order.id} order={order} onReady={handleMarkAsReady} canMarkReady={canMarkReady} />
                     ))}

--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -129,7 +129,7 @@ const ParaLlevar: React.FC = () => {
     return (
         <div>
             <h1 className="text-3xl font-bold mb-6 text-gray-800">Commandes à Emporter</h1>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-8">
+            <div className="grid grid-cols-1 gap-8 sm:grid-cols-2">
                 {/* Column for validation */}
                 <div className="bg-gray-100 p-4 rounded-xl">
                     <h2 className="text-xl font-bold mb-4 text-center text-blue-700">En Attente de Validation ({pendingOrders.length})</h2>

--- a/pages/Produits.tsx
+++ b/pages/Produits.tsx
@@ -134,7 +134,7 @@ const Produits: React.FC = () => {
                 )}
             </div>
             
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-6">
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                 {filteredProducts.map(p => (
                     <ProductCard 
                         key={p.id} 
@@ -294,7 +294,7 @@ const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSu
         <Modal isOpen={isOpen} onClose={onClose} title={mode === 'add' ? 'Ajouter un Produit' : 'Modifier le Produit'} size="lg">
             <form onSubmit={handleSubmit} className="space-y-4">
                  <div className="max-h-[65vh] overflow-y-auto pr-2 space-y-4">
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                         <div>
                             <label className="block text-sm font-medium text-gray-700">Nom</label>
                             <input type="text" value={formData.nom_produit} onChange={e => setFormData({...formData, nom_produit: e.target.value})} required className="mt-1 block w-full input-field"/>

--- a/pages/ProtectedLayout.tsx
+++ b/pages/ProtectedLayout.tsx
@@ -5,14 +5,16 @@ import { useAuth } from '../contexts/AuthContext';
 import { api } from '../services/api';
 import { NotificationCounts } from '../types';
 import ReportModal from '../components/ReportModal';
+import { Menu } from 'lucide-react';
 
 const ProtectedLayout: React.FC = () => {
-  const [isSidebarCollapsed, setSidebarCollapsed] = useState(false);
+  const [isSidebarOpen, setSidebarOpen] = useState(false);
   const { role } = useAuth();
   const [notifications, setNotifications] = useState<NotificationCounts | null>(null);
   const [isReportModalOpen, setIsReportModalOpen] = useState(false);
-  
-  const toggleSidebar = () => setSidebarCollapsed(!isSidebarCollapsed);
+
+  const openSidebar = () => setSidebarOpen(true);
+  const closeSidebar = () => setSidebarOpen(false);
 
   useEffect(() => {
     const fetchNotifications = async () => {
@@ -36,26 +38,50 @@ const ProtectedLayout: React.FC = () => {
     };
   }, []);
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    const handleResize = () => {
+      if (window.innerWidth >= 768) {
+        setSidebarOpen(false);
+      }
+    };
+
+    window.addEventListener('resize', handleResize);
+    return () => window.removeEventListener('resize', handleResize);
+  }, []);
+
   return (
     <>
-      <div className="flex h-screen bg-gray-100">
-        <Sidebar 
-          isCollapsed={isSidebarCollapsed} 
-          toggleSidebar={toggleSidebar} 
+      <div className="flex min-h-[100dvh] bg-gray-100">
+        <Sidebar
+          isOpen={isSidebarOpen}
+          onClose={closeSidebar}
           notifications={notifications}
           onReportClick={() => setIsReportModalOpen(true)}
         />
-        <div className="flex-1 flex flex-col overflow-hidden">
-          <header className="flex justify-between items-center p-4 bg-white shadow-md">
-            <h1 className="text-2xl font-bold text-gray-800">Bienvenue, {role?.name}</h1>
+        <div className="flex min-h-[100dvh] flex-1 flex-col overflow-hidden">
+          <header className="flex items-center justify-between gap-4 border-b border-gray-200 bg-white px-4 py-3 shadow-md md:px-6 md:py-4">
+            <button
+              type="button"
+              onClick={openSidebar}
+              className="inline-flex items-center justify-center rounded-md p-2 text-gray-700 transition hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-brand-primary md:hidden"
+              aria-label="Ouvrir le menu"
+            >
+              <Menu size={24} />
+            </button>
+            <h1 className="text-xl font-bold text-gray-800 md:text-2xl">Bienvenue, {role?.name}</h1>
+            <div className="h-8 w-8 md:hidden" aria-hidden="true" />
             {/* Add other header elements like user menu here */}
           </header>
-          <main className="flex-1 overflow-x-hidden overflow-y-auto bg-gray-200 p-6">
+          <main className="flex-1 overflow-x-hidden overflow-y-auto bg-gray-200 p-4 md:p-6">
             <Outlet />
           </main>
         </div>
       </div>
-      <ReportModal 
+      <ReportModal
         isOpen={isReportModalOpen}
         onClose={() => setIsReportModalOpen(false)}
       />

--- a/pages/Ventes.tsx
+++ b/pages/Ventes.tsx
@@ -116,7 +116,7 @@ const Ventes: React.FC = () => {
     return (
         <div>
             <h1 className="text-3xl font-bold mb-6 text-gray-800">Plan de Salle</h1>
-            <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5 gap-6">
+            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
                 {tables.map(table => (
                     <TableCard key={table.id} table={table} onServe={handleServeOrder} />
                 ))}


### PR DESCRIPTION
## Summary
- refactor the sidebar into a responsive drawer with accessible focus management and mobile overlay
- update the protected layout header with a hamburger toggle and flexible height handling
- adjust operational page grids for better small-screen responsiveness

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d466294d6c832aac0e21c0aef3a532