### PR TITLE
refactor: centralize styles and configure tailwind

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,34 @@ View your app in AI Studio: https://ai.studio/apps/drive/1meoqOtR5vy-dbHklLN4Aqh
 5. Vérifier immédiatement que la barre latérale met à jour la visibilité des onglets en fonction des nouvelles permissions.
 6. Naviguer sur quelques pages protégées pour confirmer que les restrictions correspondent aux niveaux choisis (`editor`/`readonly`/`none`).
 7. Supprimer un rôle de test et confirmer qu'il disparaît de la liste et que, si le rôle courant est supprimé, l'utilisateur est déconnecté.
+
+## Guide de style rapide
+
+### Palette de couleurs
+
+| Token Tailwind        | Hex      | Usage principal                        |
+|-----------------------|----------|----------------------------------------|
+| `brand-primary`       | `#F9A826`| Couleur d'action principale (CTA, accents chauds) |
+| `brand-primary-dark`  | `#DD8C00`| Survol des actions principales          |
+| `brand-secondary`     | `#2D2D2D`| Texte par défaut, boutons foncés        |
+| `brand-accent`        | `#E63946`| Actions accentuées / alertes            |
+| `status-ready`        | `#2E7D32`| États positifs / succès                 |
+| `status-cooking`      | `#F9A826`| États en préparation                    |
+| `status-waiting`      | `#1976D2`| États en attente                        |
+| `status-paid`         | `#388E3C`| Confirmation de paiement                |
+| `status-unpaid`       | `#D32F2F`| Alerte de paiement manquant             |
+
+### Utilitaires réutilisables (`styles/globals.css`)
+
+- **`ui-card`** : conteneur blanc arrondi avec ombre douce pour cartes et panneaux.
+- **`ui-input`, `ui-select`, `ui-textarea`** : champs de formulaire harmonisés (focus jaune, coins arrondis, placeholder gris).
+- **`ui-btn`** variantes :
+  - `ui-btn-primary` : CTA jaune (texte `brand-secondary`).
+  - `ui-btn-secondary` : bouton neutre gris.
+  - `ui-btn-success` / `ui-btn-info` / `ui-btn-danger` : actions de confirmation, information ou danger.
+  - `ui-btn-accent` : actions fortes (rouge). 
+  - `ui-btn-dark` : fond `brand-secondary` contrasté.
+- **`ui-tag`** : badges arrondis gris clairs.
+- **`text-heading`** : titres de section cohérents (`text-3xl`, gras, `brand-secondary`).
+
+Importez `./styles/globals.css` (déjà référencé dans `index.tsx`) pour bénéficier de ces utilitaires. Préférez ces classes aux combinaisons Tailwind manuelles pour conserver une identité visuelle homogène.

--- a/components/PaymentModal.tsx
+++ b/components/PaymentModal.tsx
@@ -37,7 +37,7 @@ const PaymentModal: React.FC<PaymentModalProps> = ({ isOpen, onClose, order, onF
           <select
             value={paymentMethod}
             onChange={e => setPaymentMethod(e.target.value as Order['payment_method'])}
-            className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-900"
+            className="mt-1 ui-select"
           >
             <option value="efectivo">Efectivo (Espèces)</option>
             <option value="transferencia">Transferencia (Virement)</option>
@@ -48,7 +48,7 @@ const PaymentModal: React.FC<PaymentModalProps> = ({ isOpen, onClose, order, onF
         {paymentMethod === 'transferencia' && (
           <div>
             <label className="block text-sm font-medium text-gray-700">Justificatif (optionnel)</label>
-            <label htmlFor="payment-receipt" className="mt-1 w-full border border-gray-300 p-2 rounded-md shadow-sm flex items-center gap-2 cursor-pointer bg-white text-gray-500">
+            <label htmlFor="payment-receipt" className="mt-1 flex w-full cursor-pointer items-center gap-2 rounded-lg border border-gray-300 bg-white p-2 text-gray-500 shadow-sm hover:bg-gray-50">
               <Upload size={18} />
               <span>{receiptFile ? receiptFile.name : 'Choisir un fichier...'}</span>
             </label>
@@ -57,10 +57,10 @@ const PaymentModal: React.FC<PaymentModalProps> = ({ isOpen, onClose, order, onF
         )}
 
         <div className="pt-4 flex flex-col sm:flex-row gap-3">
-          <button type="button" onClick={onClose} className="w-full bg-gray-200 text-gray-800 font-bold py-3 px-4 rounded-lg hover:bg-gray-300 transition">
+          <button type="button" onClick={onClose} className="w-full ui-btn-secondary py-3">
             Annuler
           </button>
-          <button type="submit" disabled={isSubmitting} className="w-full bg-green-600 text-white font-bold py-3 px-4 rounded-lg hover:bg-green-700 transition disabled:bg-gray-400">
+          <button type="submit" disabled={isSubmitting} className="w-full ui-btn-success py-3 disabled:opacity-60">
             {isSubmitting ? 'Finalisation...' : 'Confirmer Paiement'}
           </button>
         </div>

--- a/index.html
+++ b/index.html
@@ -6,30 +6,6 @@
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>OUIOUITACOS</title>
-    <script src="https://cdn.tailwindcss.com"></script>
-    <style>
-      html {
-        scroll-behavior: smooth;
-      }
-    </style>
-    <script>
-      tailwind.config = {
-        theme: {
-          extend: {
-            colors: {
-              'brand-primary': '#F9A826',
-              'brand-secondary': '#2D2D2D',
-              'brand-accent': '#E63946',
-              'status-ready': '#2E7D32',
-              'status-cooking': '#F9A826',
-              'status-waiting': '#1976D2',
-              'status-paid': '#388E3C',
-              'status-unpaid': '#D32F2F',
-            }
-          }
-        }
-      }
-    </script>
   <script type="importmap">
 {
   "imports": {
@@ -42,9 +18,8 @@
   }
 }
 </script>
-<link rel="stylesheet" href="/index.css">
 </head>
-  <body class="bg-gray-100 antialiased">
+  <body>
     <div id="root"></div>
     <script type="module" src="/index.tsx"></script>
   </body>

--- a/index.tsx
+++ b/index.tsx
@@ -2,6 +2,7 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import './styles/globals.css';
 
 const rootElement = document.getElementById('root');
 if (!rootElement) {

--- a/package.json
+++ b/package.json
@@ -18,6 +18,9 @@
   "devDependencies": {
     "@types/node": "^22.14.0",
     "@vitejs/plugin-react": "^5.0.0",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.16",
     "typescript": "~5.8.2",
     "vite": "^6.2.0"
   }

--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -233,15 +233,15 @@ const Commande: React.FC = () => {
         <>
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 h-[calc(100vh-10rem)]">
             {/* Menu Section */}
-            <div className="lg:col-span-2 bg-white rounded-xl shadow-md flex flex-col">
+            <div className="lg:col-span-2 ui-card flex flex-col">
                 <div className="p-4 border-b">
                     <div className="flex justify-between items-center">
                          <div className="flex items-center gap-4">
-                            <button onClick={handleExitAttempt} className="bg-gray-700 text-white font-bold py-2 px-4 rounded-lg flex items-center gap-2 hover:bg-gray-600 transition" title="Retour au plan de salle">
+                            <button onClick={handleExitAttempt} className="ui-btn-dark" title="Retour au plan de salle">
                                 <ArrowLeft size={20} />
                                 <span className="hidden sm:inline">Plan de Salle</span>
                             </button>
-                            <h2 className="text-2xl font-bold text-gray-900">Table {order.table_nom}</h2>
+                            <h2 className="text-2xl font-semibold text-brand-secondary">Table {order.table_nom}</h2>
                          </div>
                          {order.date_envoi_cuisine && <OrderTimer startTime={order.date_envoi_cuisine} />}
                     </div>
@@ -286,9 +286,9 @@ const Commande: React.FC = () => {
             </div>
 
             {/* Order Summary Section */}
-            <div className="bg-white rounded-xl shadow-md flex flex-col">
+            <div className="ui-card flex flex-col">
                 <div className="p-4 border-b">
-                    <h2 className="text-2xl font-bold text-gray-900">Commande</h2>
+                    <h2 className="text-2xl font-semibold text-brand-secondary">Commande</h2>
                 </div>
                 <div className="flex-1 p-4 space-y-3 overflow-y-auto">
                     {order.items.length === 0 ? <p className="text-gray-500">La commande est vide.</p> :
@@ -308,14 +308,14 @@ const Commande: React.FC = () => {
                             </div>
                              {item.estado === 'en_attente' && (
                                 (editingCommentId === item.id || item.commentaire) ? (
-                                    <input 
+                                    <input
                                         type="text"
                                         placeholder="Ajouter un commentaire..."
                                         value={item.commentaire}
                                         onChange={(e) => handleCommentChange(index, e.target.value)}
                                         onBlur={() => persistCommentChange(index)}
                                         autoFocus
-                                        className="mt-2 w-full text-sm border-gray-300 rounded-md p-1.5 focus:ring-brand-primary focus:border-brand-primary"
+                                        className="mt-2 ui-input text-sm"
                                     />
                                 ) : (
                                     <button onClick={() => setEditingCommentId(item.id)} className="mt-2 text-xs text-blue-600 hover:underline flex items-center gap-1">
@@ -330,13 +330,13 @@ const Commande: React.FC = () => {
                     ))}
                 </div>
                 <div className="p-4 border-t space-y-4">
-                    <div className="flex justify-between text-2xl font-bold text-gray-900">
+                    <div className="flex justify-between text-2xl font-semibold text-brand-secondary">
                         <span>Total</span>
                         <span>{order.total.toFixed(2)} €</span>
                     </div>
 
                     {order.estado_cocina === 'listo' && (
-                         <button onClick={handleServeOrder} className="w-full bg-blue-500 text-white font-bold py-3 rounded-lg flex items-center justify-center space-x-2 hover:bg-blue-600 transition">
+                        <button onClick={handleServeOrder} className="w-full ui-btn-info justify-center py-3">
                             <Check size={20} /><span>Entregada</span>
                         </button>
                     )}
@@ -344,12 +344,12 @@ const Commande: React.FC = () => {
                     <div className="flex space-x-2">
                         <button onClick={handleSendToKitchen}
                             disabled={!order.items.some(i => i.estado === 'en_attente')}
-                            className="flex-1 bg-orange-500 text-white font-bold py-3 rounded-lg flex items-center justify-center space-x-2 hover:bg-orange-600 disabled:bg-gray-400 disabled:cursor-not-allowed">
+                            className="flex-1 ui-btn-accent justify-center py-3 disabled:opacity-60">
                             <Send size={20} /><span>Envoyer en Cuisine</span>
                         </button>
-                         <button onClick={() => setIsPaymentModalOpen(true)}
-                                 disabled={order.estado_cocina !== 'servido'}
-                                 className="flex-1 bg-green-600 text-white font-bold py-3 rounded-lg flex items-center justify-center space-x-2 hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed">
+                        <button onClick={() => setIsPaymentModalOpen(true)}
+                                disabled={order.estado_cocina !== 'servido'}
+                                className="flex-1 ui-btn-success justify-center py-3 disabled:opacity-60">
                             <DollarSign size={20} /><span>Finaliser</span>
                         </button>
                     </div>
@@ -369,10 +369,10 @@ const Commande: React.FC = () => {
         >
             <p className="text-gray-700">Vous avez des articles non envoyés en cuisine. Si vous quittez, ils seront annulés. Voulez-vous continuer ?</p>
             <div className="flex justify-end gap-4 mt-6">
-                <button onClick={() => setExitConfirmOpen(false)} className="bg-gray-200 text-gray-800 font-bold py-2 px-4 rounded-lg hover:bg-gray-300">
+                <button onClick={() => setExitConfirmOpen(false)} className="ui-btn-secondary">
                     Non, rester
                 </button>
-                <button onClick={handleConfirmExit} className="bg-red-600 text-white font-bold py-2 px-4 rounded-lg hover:bg-red-700">
+                <button onClick={handleConfirmExit} className="ui-btn-danger">
                     Oui, quitter
                 </button>
             </div>

--- a/pages/Dashboard.tsx
+++ b/pages/Dashboard.tsx
@@ -7,7 +7,7 @@ import Modal from '../components/Modal';
 import RoleManager from '../components/RoleManager';
 
 const MainStatCard: React.FC<{ title: string; value: string; icon: React.ReactNode }> = ({ title, value, icon }) => (
-    <div className="bg-white p-6 rounded-xl shadow-md flex items-center space-x-4">
+    <div className="ui-card p-6 flex items-center space-x-4">
         <div className="p-4 bg-brand-primary/20 text-brand-primary rounded-full">
             {icon}
         </div>
@@ -19,7 +19,7 @@ const MainStatCard: React.FC<{ title: string; value: string; icon: React.ReactNo
 );
 
 const OpStatCard: React.FC<{ title: string; value: string | number; icon: React.ReactNode; onClick?: () => void }> = ({ title, value, icon, onClick }) => (
-    <div className={`bg-white p-4 rounded-xl shadow-md flex items-center space-x-3 ${onClick ? 'cursor-pointer hover:bg-gray-50' : ''}`} onClick={onClick}>
+    <div className={`ui-card p-4 flex items-center space-x-3 ${onClick ? 'cursor-pointer hover:bg-gray-50' : ''}`} onClick={onClick}>
         <div className="p-3 bg-gray-100 text-gray-600 rounded-lg">
             {icon}
         </div>
@@ -68,7 +68,7 @@ const Dashboard: React.FC = () => {
             <div className="flex justify-end">
                 <button
                     onClick={() => setRoleManagerOpen(true)}
-                    className="inline-flex items-center rounded-md bg-brand-primary px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-primary/90"
+                    className="ui-btn-primary"
                 >
                     <Shield className="mr-2 h-4 w-4" />
                     Gestion des rôles
@@ -97,7 +97,7 @@ const Dashboard: React.FC = () => {
             </div>
 
             {/* Block 3: Weekly Sales Chart */}
-            <div className="bg-white p-6 rounded-xl shadow-md">
+            <div className="ui-card p-6">
                 <h3 className="text-lg font-semibold mb-4 text-gray-900">Ventes Hebdomadaires</h3>
                 <ResponsiveContainer width="100%" height={300}>
                     <BarChart data={stats.ventes7Jours}>
@@ -113,7 +113,7 @@ const Dashboard: React.FC = () => {
             </div>
             
             {/* Block 4: Sales Pie Chart */}
-            <div className="bg-white p-6 rounded-xl shadow-md">
+            <div className="ui-card p-6">
                 <div className="flex justify-between items-center mb-4">
                     <h3 className="text-lg font-semibold text-gray-900">Répartition des Ventes</h3>
                     <div className="flex p-1 bg-gray-200 rounded-lg">

--- a/pages/Ingredients.tsx
+++ b/pages/Ingredients.tsx
@@ -59,7 +59,7 @@ const Ingredients: React.FC = () => {
 
     return (
         <div className="space-y-6">
-            <h1 className="text-3xl font-bold text-gray-800">Gestion des Ingrédients</h1>
+            <h1 className="text-heading">Gestion des Ingrédients</h1>
 
             <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
                 <div className="relative w-full sm:w-auto">
@@ -69,11 +69,11 @@ const Ingredients: React.FC = () => {
                         placeholder="Rechercher un ingrédient..."
                         value={searchTerm}
                         onChange={(e) => setSearchTerm(e.target.value)}
-                        className="pl-10 pr-4 py-2 border rounded-lg w-full sm:w-64 text-gray-900"
+                        className="ui-input pl-10 sm:w-64"
                     />
                 </div>
                 {canEdit && (
-                    <button onClick={() => handleOpenModal('add')} className="w-full sm:w-auto bg-brand-primary text-brand-secondary font-bold py-2 px-4 rounded-lg flex items-center justify-center gap-2 hover:bg-yellow-400 transition">
+                    <button onClick={() => handleOpenModal('add')} className="w-full sm:w-auto ui-btn-primary">
                         <PlusCircle size={20} />
                         Ajouter un ingrédient
                     </button>
@@ -81,7 +81,7 @@ const Ingredients: React.FC = () => {
             </div>
 
             {loading ? <p className="text-gray-800">Chargement...</p> : error ? <p className="text-red-500">{error}</p> : (
-                <div className="bg-white p-4 rounded-xl shadow-md overflow-x-auto">
+                <div className="ui-card p-4 overflow-x-auto">
                     <table className="w-full text-left">
                         <thead className="border-b">
                             <tr>
@@ -186,11 +186,11 @@ const AddEditIngredientModal: React.FC<{ isOpen: boolean; onClose: () => void; o
             <form onSubmit={handleSubmit} className="space-y-4">
                 <div>
                     <label htmlFor="nom" className="block text-sm font-medium text-gray-700">Nom</label>
-                    <input type="text" id="nom" value={formData.nom} onChange={e => setFormData({...formData, nom: e.target.value})} required className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-900"/>
+                    <input type="text" id="nom" value={formData.nom} onChange={e => setFormData({...formData, nom: e.target.value})} required className="mt-1 ui-input"/>
                 </div>
                 <div>
                     <label htmlFor="unite" className="block text-sm font-medium text-gray-700">Unité</label>
-                    <select id="unite" value={formData.unite} onChange={e => setFormData({...formData, unite: e.target.value as Ingredient['unite']})} required className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-900">
+                    <select id="unite" value={formData.unite} onChange={e => setFormData({...formData, unite: e.target.value as Ingredient['unite']})} required className="mt-1 ui-select">
                         <option value="g">Grammes (g)</option>
                         <option value="kg">Kilogrammes (kg)</option>
                         <option value="ml">Millilitres (ml)</option>
@@ -200,11 +200,11 @@ const AddEditIngredientModal: React.FC<{ isOpen: boolean; onClose: () => void; o
                 </div>
                  <div>
                     <label htmlFor="stock_minimum" className="block text-sm font-medium text-gray-700">Stock Minimum</label>
-                    <input type="number" id="stock_minimum" min="0" value={formData.stock_minimum} onChange={e => setFormData({...formData, stock_minimum: parseFloat(e.target.value)})} required className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-900"/>
+                    <input type="number" id="stock_minimum" min="0" value={formData.stock_minimum} onChange={e => setFormData({...formData, stock_minimum: parseFloat(e.target.value)})} required className="mt-1 ui-input"/>
                 </div>
                 <div className="flex flex-col sm:flex-row gap-3 pt-4">
-                    <button type="button" onClick={onClose} className="w-full bg-gray-200 text-gray-800 font-bold py-3 px-4 rounded-lg hover:bg-gray-300 transition">Annuler</button>
-                    <button type="submit" disabled={isSubmitting} className="w-full bg-brand-primary text-brand-secondary font-bold py-3 px-4 rounded-lg transition hover:bg-yellow-400 disabled:bg-gray-300">{isSubmitting ? 'Sauvegarde...' : 'Sauvegarder'}</button>
+                    <button type="button" onClick={onClose} className="w-full ui-btn-secondary py-3">Annuler</button>
+                    <button type="submit" disabled={isSubmitting} className="w-full ui-btn-primary py-3 disabled:opacity-60">{isSubmitting ? 'Sauvegarde...' : 'Sauvegarder'}</button>
                 </div>
             </form>
         </Modal>
@@ -234,17 +234,17 @@ const ResupplyModal: React.FC<{ isOpen: boolean; onClose: () => void; onSuccess:
     return (
         <Modal isOpen={isOpen} onClose={onClose} title={`Réapprovisionner: ${ingredient.nom}`}>
             <form onSubmit={handleSubmit} className="space-y-4">
-                 <div>
+                <div>
                     <label htmlFor="quantity" className="block text-sm font-medium text-gray-700">Quantité Achetée ({ingredient.unite})</label>
-                    <input type="number" id="quantity" min="0.01" step="0.01" value={quantity} onChange={e => setQuantity(parseFloat(e.target.value))} required className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-900"/>
+                    <input type="number" id="quantity" min="0.01" step="0.01" value={quantity} onChange={e => setQuantity(parseFloat(e.target.value))} required className="mt-1 ui-input"/>
                 </div>
                 <div>
                     <label htmlFor="unitPrice" className="block text-sm font-medium text-gray-700">Prix par Unité (€/{ingredient.unite})</label>
-                    <input type="number" id="unitPrice" min="0" step="0.01" value={unitPrice} onChange={e => setUnitPrice(parseFloat(e.target.value))} required className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-900"/>
+                    <input type="number" id="unitPrice" min="0" step="0.01" value={unitPrice} onChange={e => setUnitPrice(parseFloat(e.target.value))} required className="mt-1 ui-input"/>
                 </div>
                 <div className="flex flex-col sm:flex-row gap-3 pt-4">
-                    <button type="button" onClick={onClose} className="w-full bg-gray-200 text-gray-800 font-bold py-3 px-4 rounded-lg hover:bg-gray-300 transition">Annuler</button>
-                    <button type="submit" disabled={isSubmitting} className="w-full bg-green-600 text-white font-bold py-3 px-4 rounded-lg transition hover:bg-green-700 disabled:bg-gray-300">{isSubmitting ? 'Ajout...' : 'Ajouter au Stock'}</button>
+                    <button type="button" onClick={onClose} className="w-full ui-btn-secondary py-3">Annuler</button>
+                    <button type="submit" disabled={isSubmitting} className="w-full ui-btn-success py-3 disabled:opacity-60">{isSubmitting ? 'Ajout...' : 'Ajouter au Stock'}</button>
                 </div>
             </form>
         </Modal>
@@ -271,8 +271,8 @@ const DeleteModal: React.FC<{ isOpen: boolean; onClose: () => void; onSuccess: (
         <Modal isOpen={isOpen} onClose={onClose} title="Confirmer la Suppression">
             <p className="text-gray-700">Êtes-vous sûr de vouloir supprimer l'ingrédient <strong className="text-gray-900">{ingredient.nom}</strong> ? Cette action est irréversible.</p>
             <div className="flex flex-col sm:flex-row gap-3 pt-6">
-                <button type="button" onClick={onClose} className="w-full bg-gray-200 text-gray-800 font-bold py-3 px-4 rounded-lg hover:bg-gray-300 transition">Annuler</button>
-                <button onClick={handleDelete} disabled={isSubmitting} className="w-full bg-red-600 text-white font-bold py-3 px-4 rounded-lg transition hover:bg-red-700 disabled:bg-gray-300">{isSubmitting ? 'Suppression...' : 'Supprimer'}</button>
+                <button type="button" onClick={onClose} className="w-full ui-btn-secondary py-3">Annuler</button>
+                <button onClick={handleDelete} disabled={isSubmitting} className="w-full ui-btn-danger py-3 disabled:opacity-60">{isSubmitting ? 'Suppression...' : 'Supprimer'}</button>
             </div>
         </Modal>
     );

--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -9,7 +9,7 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
 
     return (
         <>
-            <div className="bg-white p-4 rounded-lg shadow-md space-y-3">
+            <div className="ui-card p-4 space-y-3">
                 <div className="flex justify-between items-start border-b pb-2">
                     <div>
                         <h4 className="font-bold text-lg text-gray-900">Commande #{order.id.slice(-6)}</h4>
@@ -36,10 +36,10 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                     {order.statut === 'pendiente_validacion' && onValidate && (
                         <>
                             <button onClick={() => setIsReceiptModalOpen(true)} className="w-full text-sm text-blue-600 hover:underline flex items-center justify-center"><Eye size={16} className="mr-1"/> Voir Justificatif</button>
-                            <button 
-                                onClick={() => onValidate(order.id)} 
+                            <button
+                                onClick={() => onValidate(order.id)}
                                 disabled={isProcessing}
-                                className="w-full bg-blue-500 text-white font-bold py-3 rounded-lg uppercase hover:bg-blue-600 transition disabled:bg-gray-400"
+                                className="w-full ui-btn-info uppercase"
                             >
                                 {isProcessing ? 'Validation...' : 'Valider'}
                             </button>
@@ -48,10 +48,10 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                     {order.estado_cocina === 'listo' && onDeliver && (
                          <>
                             <span className="text-sm text-green-600 flex items-center justify-center font-semibold"><Clock size={16} className="mr-1"/> Prête depuis {Math.round((Date.now() - (order.date_listo_cuisine || Date.now()))/60000)} min</span>
-                            <button 
+                            <button
                                 onClick={() => onDeliver(order.id)}
                                 disabled={isProcessing}
-                                className="w-full bg-green-500 text-white font-bold py-3 rounded-lg uppercase hover:bg-green-600 transition disabled:bg-gray-400"
+                                className="w-full ui-btn-success uppercase"
                             >
                                 {isProcessing ? '...' : 'Entregada'}
                             </button>
@@ -128,7 +128,7 @@ const ParaLlevar: React.FC = () => {
 
     return (
         <div>
-            <h1 className="text-3xl font-bold mb-6 text-gray-800">Commandes à Emporter</h1>
+            <h1 className="text-heading mb-6">Commandes à Emporter</h1>
             <div className="grid grid-cols-1 gap-8 sm:grid-cols-2">
                 {/* Column for validation */}
                 <div className="bg-gray-100 p-4 rounded-xl">

--- a/pages/Produits.tsx
+++ b/pages/Produits.tsx
@@ -98,9 +98,9 @@ const Produits: React.FC = () => {
 
     return (
         <div className="space-y-6">
-            <h1 className="text-3xl font-bold text-gray-800">Gestion des Produits</h1>
+            <h1 className="text-heading">Gestion des Produits</h1>
             
-            <div className="bg-white p-4 rounded-xl shadow-md flex flex-col sm:flex-row justify-between items-center gap-4">
+            <div className="ui-card p-4 flex flex-col sm:flex-row justify-between items-center gap-4">
                 <div className="flex flex-col sm:flex-row gap-4 w-full">
                     <div className="relative flex-grow">
                         <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={20} />
@@ -109,13 +109,13 @@ const Produits: React.FC = () => {
                             placeholder="Rechercher un produit..."
                             value={searchTerm}
                             onChange={e => setSearchTerm(e.target.value)}
-                            className="pl-10 pr-4 py-2 border rounded-lg w-full text-gray-900"
+                            className="ui-input pl-10"
                         />
                     </div>
                     <select
                         value={categoryFilter}
                         onChange={e => setCategoryFilter(e.target.value)}
-                        className="border rounded-lg py-2 px-4 text-gray-900"
+                        className="ui-select sm:w-56"
                     >
                         <option value="all">Toutes les catégories</option>
                         {categories.map(cat => <option key={cat.id} value={cat.id}>{cat.nom}</option>)}
@@ -123,10 +123,10 @@ const Produits: React.FC = () => {
                 </div>
                 {canEdit && (
                     <div className="flex gap-2 w-full sm:w-auto">
-                        <button onClick={() => setCategoryModalOpen(true)} className="flex-1 sm:flex-initial bg-gray-200 text-gray-800 font-bold py-2 px-4 rounded-lg flex items-center justify-center gap-2 hover:bg-gray-300 transition">
+                        <button onClick={() => setCategoryModalOpen(true)} className="flex-1 sm:flex-initial ui-btn-secondary">
                             <Settings size={20} />
                         </button>
-                        <button onClick={() => handleOpenModal('product', 'add')} className="flex-1 sm:flex-initial bg-brand-primary text-brand-secondary font-bold py-2 px-4 rounded-lg flex items-center justify-center gap-2 hover:bg-yellow-400 transition">
+                        <button onClick={() => handleOpenModal('product', 'add')} className="flex-1 sm:flex-initial ui-btn-primary">
                             <PlusCircle size={20} />
                             Ajouter Produit
                         </button>
@@ -190,7 +190,7 @@ const ProductCard: React.FC<{ product: Product; category?: Category; onEdit: () 
     const marginPercentage = product.prix_vente > 0 ? (margin / product.prix_vente) * 100 : 0;
 
     return (
-        <div className="bg-white rounded-xl shadow-md flex flex-col overflow-hidden">
+        <div className="ui-card flex flex-col overflow-hidden">
             <img src={product.image} alt={product.nom_produit} className="w-full h-40 object-cover" />
             <div className="p-4 flex flex-col flex-grow">
                 <div className="flex justify-between items-start">
@@ -297,21 +297,21 @@ const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSu
                     <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
                         <div>
                             <label className="block text-sm font-medium text-gray-700">Nom</label>
-                            <input type="text" value={formData.nom_produit} onChange={e => setFormData({...formData, nom_produit: e.target.value})} required className="mt-1 block w-full input-field"/>
+                            <input type="text" value={formData.nom_produit} onChange={e => setFormData({...formData, nom_produit: e.target.value})} required className="mt-1 ui-input"/>
                         </div>
-                         <div>
+                        <div>
                             <label className="block text-sm font-medium text-gray-700">Prix de Vente (€)</label>
-                            <input type="number" step="0.01" min="0" value={formData.prix_vente} onChange={e => setFormData({...formData, prix_vente: parseFloat(e.target.value)})} required className="mt-1 block w-full input-field"/>
+                            <input type="number" step="0.01" min="0" value={formData.prix_vente} onChange={e => setFormData({...formData, prix_vente: parseFloat(e.target.value)})} required className="mt-1 ui-input"/>
                         </div>
-                         <div>
+                        <div>
                             <label className="block text-sm font-medium text-gray-700">Catégorie</label>
-                            <select value={formData.categoria_id} onChange={e => setFormData({...formData, categoria_id: e.target.value})} required className="mt-1 block w-full input-field">
+                            <select value={formData.categoria_id} onChange={e => setFormData({...formData, categoria_id: e.target.value})} required className="mt-1 ui-select">
                                 {categories.map(c => <option key={c.id} value={c.id}>{c.nom}</option>)}
                             </select>
                         </div>
                         <div>
                             <label className="block text-sm font-medium text-gray-700">Statut</label>
-                            <select value={formData.estado} onChange={e => setFormData({...formData, estado: e.target.value as Product['estado']})} required className="mt-1 block w-full input-field">
+                            <select value={formData.estado} onChange={e => setFormData({...formData, estado: e.target.value as Product['estado']})} required className="mt-1 ui-select">
                                 <option value="disponible">Disponible</option>
                                 <option value="agotado_temporal">Rupture (Temp.)</option>
                                 <option value="agotado_indefinido">Indisponible</option>
@@ -325,7 +325,7 @@ const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSu
                             rows={3}
                             value={formData.description}
                             onChange={e => setFormData({...formData, description: e.target.value})}
-                            className="mt-1 block w-full input-field"
+                            className="mt-1 ui-textarea"
                             placeholder="Courte description du produit..."
                         />
                     </div>
@@ -356,10 +356,10 @@ const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSu
                             {formData.recipe.map((item, index) => (
                                 <div key={index} className="flex items-center gap-2">
                                     <GripVertical className="text-gray-400 cursor-move" size={16}/>
-                                    <select value={item.ingredient_id} onChange={e => handleRecipeChange(index, 'ingredient_id', e.target.value)} className="input-field flex-grow">
+                                    <select value={item.ingredient_id} onChange={e => handleRecipeChange(index, 'ingredient_id', e.target.value)} className="ui-select flex-grow">
                                         {ingredients.map(i => <option key={i.id} value={i.id}>{i.nom}</option>)}
                                     </select>
-                                    <input type="number" placeholder="Qté" value={item.qte_utilisee} onChange={e => handleRecipeChange(index, 'qte_utilisee', e.target.value)} className="input-field w-24" />
+                                    <input type="number" placeholder="Qté" value={item.qte_utilisee} onChange={e => handleRecipeChange(index, 'qte_utilisee', e.target.value)} className="ui-input w-24" />
                                     <span className="text-gray-500 text-sm w-12">{ingredients.find(i => i.id === item.ingredient_id)?.unite === 'kg' ? 'g' : ingredients.find(i => i.id === item.ingredient_id)?.unite}</span>
                                     <button type="button" onClick={() => removeRecipeItem(index)} className="p-1 text-red-500 hover:bg-red-100 rounded-full"><Trash2 size={16}/></button>
                                 </div>
@@ -370,8 +370,8 @@ const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSu
                 </div>
 
                 <div className="flex flex-col sm:flex-row justify-end gap-3 pt-4 border-t">
-                    <button type="button" onClick={onClose} className="w-full sm:w-auto bg-gray-200 text-gray-800 font-bold py-3 px-4 rounded-lg hover:bg-gray-300 transition">Annuler</button>
-                    <button type="submit" disabled={isSubmitting || formData.recipe.length === 0} className="w-full sm:w-auto bg-brand-primary text-brand-secondary font-bold py-3 px-4 rounded-lg transition hover:bg-yellow-400 disabled:bg-gray-400 disabled:cursor-not-allowed">{isSubmitting ? 'Sauvegarde...' : 'Sauvegarder'}</button>
+                    <button type="button" onClick={onClose} className="w-full sm:w-auto ui-btn-secondary py-3">Annuler</button>
+                    <button type="submit" disabled={isSubmitting || formData.recipe.length === 0} className="w-full sm:w-auto ui-btn-primary py-3 disabled:opacity-60">{isSubmitting ? 'Sauvegarde...' : 'Sauvegarder'}</button>
                 </div>
             </form>
         </Modal>
@@ -406,8 +406,8 @@ const ManageCategoriesModal: React.FC<{ isOpen: boolean; onClose: () => void; on
         <Modal isOpen={isOpen} onClose={onClose} title="Gérer les Catégories">
             <div className="space-y-4">
                 <div className="flex gap-2">
-                    <input type="text" value={newCategoryName} onChange={e => setNewCategoryName(e.target.value)} placeholder="Nom de la nouvelle catégorie" className="input-field flex-grow" />
-                    <button onClick={handleAdd} className="bg-brand-primary text-brand-secondary font-bold px-4 rounded-lg">Ajouter</button>
+                    <input type="text" value={newCategoryName} onChange={e => setNewCategoryName(e.target.value)} placeholder="Nom de la nouvelle catégorie" className="ui-input flex-grow" />
+                    <button onClick={handleAdd} className="ui-btn-primary px-4">Ajouter</button>
                 </div>
                 {error && <p className="text-red-500 text-sm">{error}</p>}
                 <ul className="space-y-2 max-h-60 overflow-y-auto">
@@ -419,7 +419,7 @@ const ManageCategoriesModal: React.FC<{ isOpen: boolean; onClose: () => void; on
                     ))}
                 </ul>
                  <div className="pt-4 flex">
-                    <button type="button" onClick={onClose} className="w-full bg-gray-200 text-gray-800 font-bold py-3 px-4 rounded-lg hover:bg-gray-300 transition">Fermer</button>
+                    <button type="button" onClick={onClose} className="w-full ui-btn-secondary py-3">Fermer</button>
                 </div>
             </div>
         </Modal>
@@ -446,8 +446,8 @@ const DeleteProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSuc
         <Modal isOpen={isOpen} onClose={onClose} title="Confirmer la Suppression">
             <p className="text-gray-700">Êtes-vous sûr de vouloir supprimer le produit <strong className="text-gray-900">{product.nom_produit}</strong> ? Cette action est irréversible.</p>
             <div className="flex flex-col sm:flex-row justify-end gap-3 pt-6">
-                <button type="button" onClick={onClose} className="w-full sm:w-auto bg-gray-200 text-gray-800 font-bold py-3 px-4 rounded-lg hover:bg-gray-300 transition">Annuler</button>
-                <button onClick={handleDelete} disabled={isSubmitting} className="w-full sm:w-auto bg-red-600 text-white font-bold py-3 px-4 rounded-lg transition hover:bg-red-700 disabled:bg-gray-300">{isSubmitting ? 'Suppression...' : 'Supprimer'}</button>
+                <button type="button" onClick={onClose} className="w-full sm:w-auto ui-btn-secondary py-3">Annuler</button>
+                <button onClick={handleDelete} disabled={isSubmitting} className="w-full sm:w-auto ui-btn-danger py-3">{isSubmitting ? 'Suppression...' : 'Supprimer'}</button>
             </div>
         </Modal>
     );
@@ -457,28 +457,6 @@ const DeleteProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSuc
 const HelpCircle: React.FC<{ size: number }> = ({ size }) => (
     <svg xmlns="http://www.w3.org/2000/svg" width={size} height={size} viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round"><circle cx="12" cy="12" r="10"></circle><path d="M9.09 9a3 3 0 0 1 5.83 1c0 2-3 3-3 3"></path><line x1="12" y1="17" x2="12.01" y2="17"></line></svg>
 );
-
-
-// Add a general style for input fields in a global style or here for simplicity
-const globalStyles = `
-.input-field {
-    border: 1px solid #D1D5DB;
-    border-radius: 0.5rem;
-    box-shadow: 0 1px 2px 0 rgba(0, 0, 0, 0.05);
-    padding: 0.5rem 0.75rem;
-    color: #111827;
-    background-color: white;
-}
-.input-field:focus {
-    outline: none;
-    --tw-ring-color: #F9A826;
-    border-color: #F9A826;
-    box-shadow: 0 0 0 2px var(--tw-ring-color);
-}
-`;
-const styleSheet = document.createElement("style");
-styleSheet.innerText = globalStyles;
-document.head.appendChild(styleSheet);
 
 
 export default Produits;

--- a/postcss.config.js
+++ b/postcss.config.js
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1,0 +1,81 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+@layer base {
+  html {
+    scroll-behavior: smooth;
+  }
+
+  body {
+    @apply bg-gray-100 text-brand-secondary antialiased;
+  }
+}
+
+@layer components {
+  .ui-card {
+    @apply rounded-xl bg-white shadow-md;
+  }
+
+  .ui-card-section {
+    @apply border-t border-gray-100;
+  }
+
+  .ui-input {
+    @apply w-full rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary placeholder:text-gray-400;
+  }
+
+  .ui-textarea {
+    @apply w-full resize-y rounded-lg border border-gray-300 bg-white px-3 py-2 text-sm text-gray-900 shadow-sm transition focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary placeholder:text-gray-400;
+  }
+
+  .ui-select {
+    @apply w-full appearance-none rounded-lg border border-gray-300 bg-white px-3 py-2 pr-8 text-sm text-gray-900 shadow-sm transition focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary;
+  }
+
+  .ui-btn {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60;
+  }
+
+  .ui-btn-primary {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 bg-brand-primary text-brand-secondary hover:bg-brand-primary-dark;
+  }
+
+  .ui-btn-secondary {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 bg-gray-200 text-gray-800 hover:bg-gray-300;
+  }
+
+  .ui-btn-ghost {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 text-gray-600 hover:bg-gray-100 hover:text-brand-secondary;
+  }
+
+  .ui-btn-danger {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 bg-red-600 text-white hover:bg-red-700;
+  }
+
+  .ui-btn-success {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 bg-status-ready text-white hover:bg-status-ready/90;
+  }
+
+  .ui-btn-info {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 bg-status-waiting text-white hover:bg-status-waiting/90;
+  }
+
+  .ui-btn-accent {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 bg-brand-accent text-white hover:bg-brand-accent/90;
+  }
+
+  .ui-btn-dark {
+    @apply inline-flex items-center justify-center gap-2 rounded-lg px-4 py-2 font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-primary focus-visible:ring-offset-2 disabled:cursor-not-allowed disabled:opacity-60 bg-brand-secondary text-white hover:bg-brand-secondary/90;
+  }
+
+  .ui-tag {
+    @apply inline-flex items-center rounded-full bg-gray-100 px-3 py-1 text-xs font-semibold text-gray-600;
+  }
+}
+
+@layer utilities {
+  .text-heading {
+    @apply text-3xl font-bold text-brand-secondary;
+  }
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,0 +1,31 @@
+/** @type {import('tailwindcss').Config} */
+export default {
+  content: [
+    './index.html',
+    './index.tsx',
+    './App.tsx',
+    './components/**/*.{ts,tsx,js,jsx}',
+    './pages/**/*.{ts,tsx,js,jsx}',
+    './contexts/**/*.{ts,tsx,js,jsx}',
+    './services/**/*.{ts,tsx,js,jsx}',
+    './types/**/*.{ts,tsx,js,jsx}',
+    './constants/**/*.{ts,tsx,js,jsx}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        'brand-primary': '#F9A826',
+        'brand-primary-dark': '#DD8C00',
+        'brand-secondary': '#2D2D2D',
+        'brand-accent': '#E63946',
+        'brand-surface': '#FFFFFF',
+        'status-ready': '#2E7D32',
+        'status-cooking': '#F9A826',
+        'status-waiting': '#1976D2',
+        'status-paid': '#388E3C',
+        'status-unpaid': '#D32F2F'
+      }
+    }
+  },
+  plugins: []
+};


### PR DESCRIPTION
## Summary
- configure Tailwind build (postcss + tailwind.config) and create shared globals.css with brand palette
- refactor key pages/components to use the new button, input, and card utilities instead of duplicated class lists
- remove the Tailwind CDN script, import the shared stylesheet, and document the palette/utilities in the README style guide

## Testing
- npm install *(fails: registry returns 403 for autoprefixer in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68d469a1cbc4832abb5d228943d54a47