### PR TITLE
Normalize Supabase URL configuration

### DIFF
--- a/services/supabaseClient.ts
+++ b/services/supabaseClient.ts
@@ -5,6 +5,25 @@ type SupabaseEnv = {
   anonKey: string;
 };
 
+const normalizeSupabaseUrl = (rawUrl: string): string => {
+  try {
+    const parsed = new URL(rawUrl);
+    const sanitizedPath = parsed.pathname.replace(/\/+$/, '');
+
+    if (sanitizedPath && sanitizedPath !== '/') {
+      const invalidSegment = sanitizedPath === '' ? '/' : sanitizedPath;
+      throw new Error(
+        `VITE_SUPABASE_URL must point to the project root (e.g. https://xxxx.supabase.co). Remove the path "${invalidSegment}" to avoid cross-origin errors.`,
+      );
+    }
+
+    return parsed.origin;
+  } catch (error) {
+    const details = error instanceof Error ? ` ${error.message}` : '';
+    throw new Error(`Invalid VITE_SUPABASE_URL provided.${details}`.trim());
+  }
+};
+
 const getSupabaseEnv = (): SupabaseEnv => {
   const url = import.meta.env.VITE_SUPABASE_URL as string | undefined;
   const anonKey = import.meta.env.VITE_SUPABASE_ANON_KEY as string | undefined;
@@ -17,7 +36,7 @@ const getSupabaseEnv = (): SupabaseEnv => {
     throw new Error('VITE_SUPABASE_ANON_KEY is not defined. Please configure your Supabase environment variables.');
   }
 
-  return { url, anonKey };
+  return { url: normalizeSupabaseUrl(url), anonKey };
 };
 
 const { url, anonKey } = getSupabaseEnv();


### PR DESCRIPTION
## Summary
- validate and normalize the Supabase URL env var so it only uses the project root origin
- surface a clear error when a path segment (such as /rest/v1) is supplied, preventing CORB issues caused by hitting the wrong endpoint

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d527525754832aa86c0c412c0b8ae9