### PR TITLE
Implement Supabase storage uploads for images

### DIFF
--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -1,6 +1,7 @@
 import React, { useEffect, useState, useCallback, useMemo } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { api } from '../services/api';
+import { uploadPaymentReceipt } from '../services/storage';
 import { Order, Product, Category, OrderItem, Ingredient } from '../types';
 import { PlusCircle, MinusCircle, Send, DollarSign, AlertTriangle, Check, ArrowLeft, MessageSquare } from 'lucide-react';
 import OrderTimer from '../components/OrderTimer';
@@ -204,13 +205,16 @@ const Commande: React.FC = () => {
     const handleFinalizeOrder = async (paymentMethod: Order['payment_method'], receiptFile?: File | null) => {
         if (!order) return;
         try {
-            const receiptUrl = receiptFile ? `https://fake-storage.com/${receiptFile.name}` : undefined;
+            let receiptUrl = order.payment_receipt_url ?? undefined;
+            if (receiptFile) {
+                receiptUrl = await uploadPaymentReceipt(receiptFile, { orderId: order.id });
+            }
             await api.finalizeOrder(order.id, paymentMethod, receiptUrl);
             alert("Commande finalisée avec succès !");
             navigate('/ventes');
         } catch (error) {
             console.error("Failed to finalize order", error);
-            alert("Erreur lors de la finalisation.");
+            alert("Erreur lors de la finalisation ou du téléversement du justificatif.");
         }
     };
     

--- a/services/api.ts
+++ b/services/api.ts
@@ -1,4 +1,5 @@
 import { supabase } from './supabaseClient';
+import { DEFAULT_PRODUCT_IMAGE } from './storage';
 import {
   Role,
   Table,
@@ -215,7 +216,7 @@ const mapProductRow = (row: SupabaseProductRow, ingredientMap?: Map<string, Ingr
     prix_vente: row.prix_vente,
     categoria_id: row.categoria_id,
     estado: row.estado,
-    image: row.image ?? '',
+    image: row.image && row.image.trim() ? row.image : DEFAULT_PRODUCT_IMAGE,
     recipe,
   };
 
@@ -1325,7 +1326,7 @@ export const api = {
         prix_vente: product.prix_vente,
         categoria_id: product.categoria_id,
         estado: product.estado,
-        image: product.image,
+        image: product.image && product.image.trim() ? product.image : DEFAULT_PRODUCT_IMAGE,
       })
       .select('id')
       .single();
@@ -1352,18 +1353,34 @@ export const api = {
   updateProduct: async (productId: string, updates: Partial<Product>): Promise<Product> => {
     const { recipe, ...rest } = updates;
 
-    if (Object.keys(rest).length > 0) {
-      await supabase
-        .from('products')
-        .update({
-          nom_produit: rest.nom_produit,
-          description: rest.description ?? null,
-          prix_vente: rest.prix_vente,
-          categoria_id: rest.categoria_id,
-          estado: rest.estado,
-          image: rest.image,
-        })
-        .eq('id', productId);
+    const updatePayload: Record<string, unknown> = {};
+
+    if (rest.nom_produit !== undefined) {
+      updatePayload.nom_produit = rest.nom_produit;
+    }
+
+    if (rest.description !== undefined) {
+      updatePayload.description = rest.description ?? null;
+    }
+
+    if (rest.prix_vente !== undefined) {
+      updatePayload.prix_vente = rest.prix_vente;
+    }
+
+    if (rest.categoria_id !== undefined) {
+      updatePayload.categoria_id = rest.categoria_id;
+    }
+
+    if (rest.estado !== undefined) {
+      updatePayload.estado = rest.estado;
+    }
+
+    if (rest.image !== undefined) {
+      updatePayload.image = rest.image && rest.image.trim() ? rest.image : DEFAULT_PRODUCT_IMAGE;
+    }
+
+    if (Object.keys(updatePayload).length > 0) {
+      await supabase.from('products').update(updatePayload).eq('id', productId);
     }
 
     if (recipe) {

--- a/services/storage.ts
+++ b/services/storage.ts
@@ -1,0 +1,122 @@
+import { supabase } from './supabaseClient';
+
+const PRODUCT_IMAGES_BUCKET = 'product-images';
+const PAYMENT_RECEIPTS_BUCKET = 'payment-receipts';
+
+const removeDiacritics = (value: string): string =>
+  value
+    .normalize('NFD')
+    .replace(/[\u0300-\u036f]/g, '')
+    .normalize('NFC');
+
+const slugify = (value: string): string =>
+  removeDiacritics(value)
+    .toLowerCase()
+    .replace(/[^a-z0-9-]+/g, '-')
+    .replace(/^-+|-+$/g, '');
+
+const sanitizeSegment = (value: string | undefined, fallback: string): string => {
+  if (!value) {
+    return fallback;
+  }
+  const slug = slugify(value);
+  return slug || fallback;
+};
+
+const getExtensionFromMime = (mime: string): string | undefined => {
+  const map: Record<string, string> = {
+    'image/jpeg': 'jpg',
+    'image/jpg': 'jpg',
+    'image/png': 'png',
+    'image/gif': 'gif',
+    'image/webp': 'webp',
+    'image/svg+xml': 'svg',
+    'application/pdf': 'pdf',
+  };
+  return map[mime.toLowerCase()];
+};
+
+const getFileExtension = (file: File | Blob, fallback: string): string => {
+  if (file instanceof File) {
+    const parts = file.name.split('.');
+    if (parts.length > 1) {
+      const ext = parts.pop();
+      if (ext) {
+        return ext.toLowerCase();
+      }
+    }
+  }
+
+  if ('type' in file && file.type) {
+    const fromMime = getExtensionFromMime(file.type);
+    if (fromMime) {
+      return fromMime;
+    }
+  }
+
+  return fallback;
+};
+
+const generateId = (): string => {
+  if (typeof crypto !== 'undefined' && 'randomUUID' in crypto) {
+    return crypto.randomUUID();
+  }
+  return Math.random().toString(36).slice(2, 10);
+};
+
+const uploadToBucket = async (
+  bucket: string,
+  path: string,
+  file: File | Blob,
+  contentType?: string,
+): Promise<string> => {
+  const { error } = await supabase.storage.from(bucket).upload(path, file, {
+    cacheControl: '3600',
+    upsert: true,
+    contentType: contentType ?? ('type' in file ? file.type : undefined) ?? 'application/octet-stream',
+  });
+
+  if (error) {
+    throw new Error(`Échec du téléversement vers Supabase Storage : ${error.message}`);
+  }
+
+  const { data } = supabase.storage.from(bucket).getPublicUrl(path);
+  if (!data?.publicUrl) {
+    throw new Error('Impossible de récupérer l\'URL publique du fichier téléversé.');
+  }
+
+  return data.publicUrl;
+};
+
+export const DEFAULT_PRODUCT_IMAGE =
+  'https://images.unsplash.com/photo-1612874470043-48a770f27b8d?auto=format&fit=crop&w=800&q=80';
+
+export const uploadProductImage = async (
+  file: File | Blob,
+  productName?: string,
+): Promise<string> => {
+  const folder = sanitizeSegment(productName, 'produits');
+  const extension = getFileExtension(file, 'jpg');
+  const path = `${folder}/${generateId()}.${extension}`;
+  return uploadToBucket(PRODUCT_IMAGES_BUCKET, path, file);
+};
+
+export type ReceiptUploadOptions = {
+  orderId?: string;
+  customerReference?: string;
+};
+
+export const uploadPaymentReceipt = async (
+  file: File | Blob,
+  options?: ReceiptUploadOptions,
+): Promise<string> => {
+  const baseFolder = options?.orderId
+    ? `orders/${sanitizeSegment(options.orderId, 'commande')}`
+    : options?.customerReference
+    ? `customers/${sanitizeSegment(options.customerReference, 'client')}`
+    : 'misc';
+
+  const extension = getFileExtension(file, 'jpg');
+  const path = `${baseFolder}/${generateId()}.${extension}`;
+  return uploadToBucket(PAYMENT_RECEIPTS_BUCKET, path, file);
+};


### PR DESCRIPTION
## Summary
- replace the sample image helper with a Supabase Storage service that uploads product photos and payment receipts and exposes a default product image fallback
- update the product management modal to push selected files to storage before saving and reuse the stored URL when editing
- store client and staff payment proofs in storage when validating orders so receipts stay available online

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d52a8a7770832a986c3ed0036c6060