### PR TITLE
Fix missing product image normalizer import

### DIFF
--- a/services/api.ts
+++ b/services/api.ts
@@ -1,5 +1,6 @@
 import { supabase } from './supabaseClient';
 import { normalizeCloudinaryImageUrl, resolveProductImageUrl } from './cloudinary';
+import { normalizeProductImageInput } from './productImage';
 
 import {
   Role,


### PR DESCRIPTION
## Summary
- import the product image normalization helper in the Supabase API service

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d540baa400832a8127bb4c25a46401