### PR TITLE
Allow configuring role home pages

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,6 +13,7 @@ import Produits from './pages/Produits';
 import CommandeClient from './pages/CommandeClient';
 import NotFound from './pages/NotFound';
 import ResumeVentes from './pages/ResumeVentes';
+import { NAV_LINKS } from './constants';
 
 const isPermissionGranted = (permission?: string) =>
   permission === 'editor' || permission === 'readonly';
@@ -33,14 +34,14 @@ const AppRoutes: React.FC = () => {
     const getHomeRedirect = () => {
         if (!role) return '/login';
 
-        const dashboardPermission = role.permissions['/dashboard'];
-        if (isPermissionGranted(dashboardPermission)) return '/dashboard';
+        if (role.homePage && isPermissionGranted(role.permissions[role.homePage])) {
+            return role.homePage;
+        }
 
-        const ventesPermission = role.permissions['/ventes'];
-        if (isPermissionGranted(ventesPermission)) return '/ventes';
-
-        const cocinaPermission = role.permissions['/cocina'];
-        if (isPermissionGranted(cocinaPermission)) return '/cocina';
+        const fallbackLink = NAV_LINKS.find(link => isPermissionGranted(role.permissions[link.permissionKey]));
+        if (fallbackLink) {
+            return fallbackLink.href;
+        }
         return '/login';
     };
 

--- a/components/RoleManager.tsx
+++ b/components/RoleManager.tsx
@@ -17,8 +17,12 @@ interface RoleFormState {
   id?: string;
   name: string;
   pin: string;
+  homePage: string;
   permissions: Role['permissions'];
 }
+
+const DEFAULT_HOME_PAGE = NAV_LINKS[0]?.permissionKey ?? '/dashboard';
+const isPermissionGranted = (permission?: PermissionLevel) => permission === 'editor' || permission === 'readonly';
 
 const ensureNavPermissions = (permissions?: Role['permissions']): Role['permissions'] => {
   const base: Role['permissions'] = { ...(permissions || {}) };
@@ -30,14 +34,25 @@ const ensureNavPermissions = (permissions?: Role['permissions']): Role['permissi
   return base;
 };
 
+const getDefaultHomePage = (permissions: Role['permissions']): string => {
+  const accessibleLink = NAV_LINKS.find(link => isPermissionGranted(permissions[link.permissionKey]));
+  return accessibleLink?.permissionKey ?? DEFAULT_HOME_PAGE;
+};
+
+const createEmptyFormState = (): RoleFormState => {
+  const permissions = ensureNavPermissions();
+  return {
+    name: '',
+    pin: '',
+    permissions,
+    homePage: getDefaultHomePage(permissions),
+  };
+};
+
 const RoleManager: React.FC<RoleManagerProps> = ({ isOpen, onClose }) => {
   const { refreshRole, role: currentRole } = useAuth();
   const [roles, setRoles] = useState<Role[]>([]);
-  const [formState, setFormState] = useState<RoleFormState>(() => ({
-    name: '',
-    pin: '',
-    permissions: ensureNavPermissions(),
-  }));
+  const [formState, setFormState] = useState<RoleFormState>(createEmptyFormState);
   const [mode, setMode] = useState<'create' | 'edit'>('create');
   const [isFetching, setIsFetching] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -60,6 +75,11 @@ const RoleManager: React.FC<RoleManagerProps> = ({ isOpen, onClose }) => {
     return [...navKeys, ...Array.from(extraKeys)];
   }, [roles]);
 
+  const hasAccessibleHomePage = useMemo(
+    () => NAV_LINKS.some(link => isPermissionGranted(formState.permissions[link.permissionKey])),
+    [formState.permissions],
+  );
+
   const loadRoles = useCallback(async () => {
     setIsFetching(true);
     try {
@@ -76,11 +96,7 @@ const RoleManager: React.FC<RoleManagerProps> = ({ isOpen, onClose }) => {
 
   const resetForm = useCallback(() => {
     setMode('create');
-    setFormState({
-      name: '',
-      pin: '',
-      permissions: ensureNavPermissions(),
-    });
+    setFormState(createEmptyFormState());
   }, []);
 
   useEffect(() => {
@@ -92,6 +108,25 @@ const RoleManager: React.FC<RoleManagerProps> = ({ isOpen, onClose }) => {
     resetForm();
     loadRoles();
   }, [isOpen, loadRoles, resetForm]);
+
+  useEffect(() => {
+    setFormState(prev => {
+      const currentHomePage = prev.homePage;
+      if (isPermissionGranted(prev.permissions[currentHomePage])) {
+        return prev;
+      }
+
+      const fallbackHomePage = getDefaultHomePage(prev.permissions);
+      if (fallbackHomePage === currentHomePage) {
+        return prev;
+      }
+
+      return {
+        ...prev,
+        homePage: fallbackHomePage,
+      };
+    });
+  }, [formState.permissions]);
 
   const getPermissionLabel = useCallback((key: string) => {
     const navLink = NAV_LINKS.find(link => link.permissionKey === key);
@@ -116,13 +151,22 @@ const RoleManager: React.FC<RoleManagerProps> = ({ isOpen, onClose }) => {
     }));
   };
 
+  const handleHomePageChange = (value: string) => {
+    setFormState(prev => ({
+      ...prev,
+      homePage: value,
+    }));
+  };
+
   const handleSelectRole = (role: Role) => {
+    const permissions = ensureNavPermissions(role.permissions);
     setMode('edit');
     setFormState({
       id: role.id,
       name: role.name,
       pin: role.pin ?? '',
-      permissions: ensureNavPermissions(role.permissions),
+      permissions,
+      homePage: role.homePage ?? getDefaultHomePage(permissions),
     });
     setStatusMessage(null);
     setErrorMessage(null);
@@ -168,11 +212,17 @@ const RoleManager: React.FC<RoleManagerProps> = ({ isOpen, onClose }) => {
     setIsSubmitting(true);
 
     try {
+      const permissions = ensureNavPermissions(formState.permissions);
+      const resolvedHomePage = isPermissionGranted(permissions[formState.homePage])
+        ? formState.homePage
+        : getDefaultHomePage(permissions);
+
       if (mode === 'create') {
         await api.createRole({
           name: formState.name.trim(),
           pin: formState.pin.trim(),
-          permissions: ensureNavPermissions(formState.permissions),
+          permissions,
+          homePage: resolvedHomePage,
         });
         setStatusMessage('Rôle créé avec succès.');
         await loadRoles();
@@ -182,14 +232,17 @@ const RoleManager: React.FC<RoleManagerProps> = ({ isOpen, onClose }) => {
         const updatedRole = await api.updateRole(formState.id, {
           name: formState.name.trim(),
           pin: formState.pin.trim(),
-          permissions: ensureNavPermissions(formState.permissions),
+          permissions,
+          homePage: resolvedHomePage,
         });
         setStatusMessage('Rôle mis à jour avec succès.');
+        const nextPermissions = ensureNavPermissions(updatedRole.permissions);
         setFormState({
           id: updatedRole.id,
           name: updatedRole.name,
           pin: updatedRole.pin ?? '',
-          permissions: ensureNavPermissions(updatedRole.permissions),
+          permissions: nextPermissions,
+          homePage: updatedRole.homePage ?? getDefaultHomePage(nextPermissions),
         });
         await loadRoles();
         if (currentRole?.id === updatedRole.id) {
@@ -253,7 +306,10 @@ const RoleManager: React.FC<RoleManagerProps> = ({ isOpen, onClose }) => {
                   >
                     <div>
                       <p className="font-semibold text-gray-800">{role.name}</p>
-                    <p className="text-xs text-gray-500">PIN : {role.pin ?? '—'}</p>
+                      <p className="text-xs text-gray-500">PIN : {role.pin ?? '—'}</p>
+                      {role.homePage && (
+                        <p className="text-xs text-gray-500">Accueil : {getPermissionLabel(role.homePage)}</p>
+                      )}
                     </div>
                     <div className="flex space-x-2">
                       <button
@@ -309,6 +365,33 @@ const RoleManager: React.FC<RoleManagerProps> = ({ isOpen, onClose }) => {
                   className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
                   placeholder="Ex. 1234"
                 />
+              </div>
+              <div>
+                <label htmlFor="role-home-page" className="mb-1 block text-sm font-medium text-gray-700">
+                  Page d'accueil par défaut
+                </label>
+                <select
+                  id="role-home-page"
+                  name="homePage"
+                  value={formState.homePage}
+                  onChange={event => handleHomePageChange(event.target.value)}
+                  disabled={!hasAccessibleHomePage}
+                  className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary disabled:cursor-not-allowed disabled:bg-gray-100"
+                >
+                  {NAV_LINKS.map(link => {
+                    const canAccess = isPermissionGranted(formState.permissions[link.permissionKey]);
+                    return (
+                      <option key={link.permissionKey} value={link.permissionKey} disabled={!canAccess}>
+                        {getPermissionLabel(link.permissionKey)}{!canAccess ? ' (accès requis)' : ''}
+                      </option>
+                    );
+                  })}
+                </select>
+                {hasAccessibleHomePage ? (
+                  <p className="mt-1 text-xs text-gray-500">Les pages sans permission sont désactivées.</p>
+                ) : (
+                  <p className="mt-1 text-xs text-red-600">Accordez au moins une permission pour choisir une page d'accueil.</p>
+                )}
               </div>
               <div>
                 <p className="mb-2 text-sm font-semibold text-gray-800">Permissions par page</p>

--- a/services/api.ts
+++ b/services/api.ts
@@ -23,6 +23,7 @@ type SupabaseRoleRow = {
   name: string;
   pin?: string | null;
   permissions: Role['permissions'] | null;
+  home_page?: string | null;
 };
 
 type SupabaseTableRow = {
@@ -179,6 +180,7 @@ const mapRoleRow = (row: SupabaseRoleRow, includePin: boolean): Role => {
   const role: Role = {
     id: row.id,
     name: row.name,
+    homePage: row.home_page ?? undefined,
     permissions: row.permissions ?? {},
   };
 
@@ -523,7 +525,7 @@ export const api = {
   getRoles: async (): Promise<Role[]> => {
     const response = await supabase
       .from('roles')
-      .select('id, name, pin, permissions')
+      .select('id, name, pin, permissions, home_page')
       .order('name');
     const rows = unwrap<SupabaseRoleRow[]>(response as SupabaseResponse<SupabaseRoleRow[]>);
     return rows.map(row => mapRoleRow(row, true));
@@ -532,7 +534,7 @@ export const api = {
   getRoleById: async (roleId: string): Promise<Role | null> => {
     const response = await supabase
       .from('roles')
-      .select('id, name, permissions')
+      .select('id, name, permissions, home_page')
       .eq('id', roleId)
       .maybeSingle();
     const row = unwrapMaybe<SupabaseRoleRow>(response as SupabaseResponse<SupabaseRoleRow | null>);
@@ -546,8 +548,9 @@ export const api = {
         name: payload.name,
         pin: payload.pin,
         permissions: payload.permissions,
+        home_page: payload.homePage ?? null,
       })
-      .select('id, name, pin, permissions')
+      .select('id, name, pin, permissions, home_page')
       .single();
     const row = unwrap<SupabaseRoleRow>(response as SupabaseResponse<SupabaseRoleRow>);
     notificationsService.publish('notifications_updated');
@@ -561,9 +564,10 @@ export const api = {
         name: updates.name,
         pin: updates.pin,
         permissions: updates.permissions,
+        home_page: updates.homePage ?? null,
       })
       .eq('id', roleId)
-      .select('id, name, pin, permissions')
+      .select('id, name, pin, permissions, home_page')
       .single();
     const row = unwrap<SupabaseRoleRow>(response as SupabaseResponse<SupabaseRoleRow>);
     notificationsService.publish('notifications_updated');
@@ -579,7 +583,7 @@ export const api = {
   loginWithPin: async (pin: string): Promise<Role | null> => {
     const response = await supabase
       .from('roles')
-      .select('id, name, permissions')
+      .select('id, name, permissions, home_page')
       .eq('pin', pin)
       .maybeSingle();
     const row = unwrapMaybe<SupabaseRoleRow>(response as SupabaseResponse<SupabaseRoleRow | null>);

--- a/types/index.ts
+++ b/types/index.ts
@@ -4,6 +4,7 @@ export interface Role {
   id: string;
   name: string;
   pin?: string;
+  homePage?: string;
   permissions: {
     [key: string]: 'editor' | 'readonly' | 'none';
   };


### PR DESCRIPTION
## Summary
- add a default home page selector to the role management modal with validation of accessible pages
- persist the selected home page for each role via the API and Role type
- redirect users to their configured home page on login, falling back to the first allowed route

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d54981f5cc832ab54dab5e105fa0e8