### PR TITLE
Limit kitchen send to pending items

### DIFF
--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -197,9 +197,14 @@ const Commande: React.FC = () => {
     }
 
     const handleSendToKitchen = async () => {
-        if (!order || !order.items.some(i => i.estado === 'en_attente')) return;
+        if (!order) return;
+
+        const pendingItems = order.items.filter(item => item.estado === 'en_attente');
+        if (pendingItems.length === 0) return;
+
+        const itemsToSend = pendingItems.map(item => item.id);
         try {
-            const updatedOrder = await api.sendOrderToKitchen(order.id);
+            const updatedOrder = await api.sendOrderToKitchen(order.id, itemsToSend);
             setOrder(updatedOrder);
             setOriginalOrder(JSON.parse(JSON.stringify(updatedOrder)));
             navigate('/ventes');


### PR DESCRIPTION
## Summary
- ensure sending an order to the kitchen only targets items that are still pending
- update the table status back to `occupee` when new items are sent to the kitchen
- pass the pending item identifiers from the order page when sending to the kitchen

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d561eef1e8832abcbef0aa9cf19ae9