### PR TITLE
Apply themed sections and status styling to login and sales pages

### DIFF
--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -8,36 +8,46 @@ import { Mail, MapPin, Phone, Menu, X } from 'lucide-react';
 import CustomerOrderTracker from '../components/CustomerOrderTracker';
 
 const PinInput: React.FC<{ pin: string; onPinChange: (pin: string) => void; pinLength: number }> = ({ pin, onPinChange, pinLength }) => {
-    const handleKeyClick = (key: string) => {
-        if (pin.length < pinLength) {
-            onPinChange(pin + key);
-        }
-    };
-    const handleDelete = () => {
-        onPinChange(pin.slice(0, -1));
-    };
+  const handleKeyClick = (key: string) => {
+    if (pin.length < pinLength) {
+      onPinChange(pin + key);
+    }
+  };
 
-    return (
-        <div className="flex flex-col items-center">
-            <div className="flex space-x-2 md:space-x-4 mb-4">
-                {Array.from({ length: pinLength }).map((_, i) => (
-                    <div key={i} className="w-10 h-12 md:w-12 md:h-14 bg-gray-200 rounded-md flex items-center justify-center text-2xl font-bold">
-                        {pin[i] ? '•' : ''}
-                    </div>
-                ))}
-            </div>
-            <div className="grid grid-cols-3 gap-4">
-                {[...Array(9)].map((_, i) => (
-                    <button type="button" key={i + 1} onClick={() => handleKeyClick(String(i + 1))} className="w-16 h-16 rounded-full bg-gray-100 text-2xl font-bold hover:bg-gray-200 transition">
-                        {i + 1}
-                    </button>
-                ))}
-                <div /> 
-                <button type="button" onClick={() => handleKeyClick('0')} className="w-16 h-16 rounded-full bg-gray-100 text-2xl font-bold hover:bg-gray-200 transition">0</button>
-                <button type="button" onClick={handleDelete} className="w-16 h-16 rounded-full bg-gray-100 text-xl font-bold hover:bg-gray-200 transition flex items-center justify-center">DEL</button>
-            </div>
-        </div>
-    );
+  const handleDelete = () => {
+    onPinChange(pin.slice(0, -1));
+  };
+
+  return (
+    <div className="pin-input" aria-label="Clavier numérique">
+      <div className="pin-indicator" role="presentation">
+        {Array.from({ length: pinLength }).map((_, index) => (
+          <div key={index} className="pin-indicator__slot" aria-hidden="true">
+            {pin[index] ? '•' : ''}
+          </div>
+        ))}
+      </div>
+      <div className="pin-pad">
+        {[...Array(9)].map((_, index) => (
+          <button
+            type="button"
+            key={index + 1}
+            onClick={() => handleKeyClick(String(index + 1))}
+            className="pin-pad__button"
+          >
+            {index + 1}
+          </button>
+        ))}
+        <div aria-hidden="true" />
+        <button type="button" onClick={() => handleKeyClick('0')} className="pin-pad__button">
+          0
+        </button>
+        <button type="button" onClick={handleDelete} className="pin-pad__button pin-pad__button--muted">
+          DEL
+        </button>
+      </div>
+    </div>
+  );
 };
 
 
@@ -104,141 +114,147 @@ const Login: React.FC = () => {
   };
 
   return (
-    <div className="bg-gray-100 text-brand-secondary">
-      <header className="sticky top-0 z-50 p-4 text-white bg-brand-secondary/90 backdrop-blur-sm transition-all duration-300">
-        <div className="container mx-auto flex justify-between items-center">
-            <a href="#accueil" className="text-3xl font-bold text-brand-primary">OUIOUITACOS</a>
-            <nav className="hidden md:flex space-x-6 items-center">
-                <a href="#accueil" className="hover:text-brand-primary transition">Accueil</a>
-                <a href="#apropos" className="hover:text-brand-primary transition">A Propos</a>
-                <a href="#menu" className="hover:text-brand-primary transition">Menu</a>
-                <a href="#contact" className="hover:text-brand-primary transition">Contact</a>
-                <button onClick={() => setIsModalOpen(true)} className="bg-brand-primary text-brand-secondary font-bold py-2 px-4 rounded-full hover:bg-yellow-400 transition">
-                Staff Login
-                </button>
-            </nav>
-            <div className="md:hidden">
-                <button onClick={() => setMobileMenuOpen(true)} className="p-2">
-                    <Menu size={28} />
-                </button>
-            </div>
+    <div className="login-page">
+      <header className="login-header">
+        <div className="layout-container login-header__inner">
+          <a href="#accueil" className="login-brand">OUIOUITACOS</a>
+          <nav className="login-nav" aria-label="Navigation principale">
+            <a href="#accueil" className="login-nav__link">Accueil</a>
+            <a href="#apropos" className="login-nav__link">À propos</a>
+            <a href="#menu" className="login-nav__link">Menu</a>
+            <a href="#contact" className="login-nav__link">Contact</a>
+            <button type="button" onClick={() => setIsModalOpen(true)} className="ui-btn ui-btn-accent login-nav__cta">
+              Staff Login
+            </button>
+          </nav>
+          <button type="button" onClick={() => setMobileMenuOpen(true)} className="login-header__menu" aria-label="Ouvrir le menu">
+            <Menu size={24} />
+          </button>
         </div>
       </header>
-      
+
       {isMobileMenuOpen && (
-        <div className="fixed inset-0 z-50 bg-brand-secondary text-white flex flex-col items-center justify-center md:hidden">
-            <button onClick={() => setMobileMenuOpen(false)} className="absolute top-4 right-4 p-2">
-                <X size={32} />
+        <div className="login-menu-overlay" role="dialog" aria-modal="true">
+          <button type="button" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__close" aria-label="Fermer le menu">
+            <X size={28} />
+          </button>
+          <nav className="login-menu-overlay__nav" aria-label="Navigation mobile">
+            <a href="#accueil" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">Accueil</a>
+            <a href="#apropos" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">À propos</a>
+            <a href="#menu" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">Menu</a>
+            <a href="#contact" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">Contact</a>
+            <button
+              type="button"
+              onClick={() => {
+                setIsModalOpen(true);
+                setMobileMenuOpen(false);
+              }}
+              className="ui-btn ui-btn-accent hero-cta"
+            >
+              Staff Login
             </button>
-            <nav className="flex flex-col items-center space-y-8">
-                <a href="#accueil" onClick={() => setMobileMenuOpen(false)} className="text-3xl hover:text-brand-primary transition">Accueil</a>
-                <a href="#apropos" onClick={() => setMobileMenuOpen(false)} className="text-3xl hover:text-brand-primary transition">A Propos</a>
-                <a href="#menu" onClick={() => setMobileMenuOpen(false)} className="text-3xl hover:text-brand-primary transition">Menu</a>
-                <a href="#contact" onClick={() => setMobileMenuOpen(false)} className="text-3xl hover:text-brand-primary transition">Contact</a>
-                <button 
-                    onClick={() => {
-                        setIsModalOpen(true);
-                        setMobileMenuOpen(false);
-                    }} 
-                    className="mt-8 bg-brand-primary text-brand-secondary font-bold py-3 px-6 rounded-full hover:bg-yellow-400 transition text-2xl"
-                >
-                    Staff Login
-                </button>
-            </nav>
+          </nav>
         </div>
       )}
 
       <main>
-        <section id="accueil" className="h-screen bg-cover bg-center flex flex-col" style={{ backgroundImage: "url('https://picsum.photos/seed/tacosbg/1920/1080')" }}>
+        <section
+          id="accueil"
+          className="section section-hero"
+          style={{ backgroundImage: "url('https://picsum.photos/seed/tacosbg/1920/1080')" }}
+        >
+          <div className="section-hero__inner">
             {activeOrderId ? (
-                <CustomerOrderTracker orderId={activeOrderId} onNewOrderClick={handleNewOrder} variant="hero" />
+              <CustomerOrderTracker orderId={activeOrderId} onNewOrderClick={handleNewOrder} variant="hero" />
             ) : (
-                <div className="flex-1 flex flex-col justify-center items-center text-center text-white p-4 bg-black bg-opacity-60">
-                    <h2 className="text-5xl md:text-6xl font-extrabold mb-4 drop-shadow-lg">Le Goût Authentique du Mexique</h2>
-                    <p className="text-lg md:text-xl max-w-2xl mb-8 drop-shadow-md">Des tacos préparés avec passion, des ingrédients frais et une touche de tradition.</p>
-                    <button onClick={() => navigate('/commande-client')} className="bg-brand-accent text-white font-bold py-4 px-8 rounded-full text-lg hover:bg-red-700 transition transform hover:scale-105">
-                        Commander en ligne
-                    </button>
-                </div>
+              <div className="hero-content">
+                <h2 className="hero-title">Le Goût Authentique du Mexique</h2>
+                <p className="hero-subtitle">
+                  Des tacos préparés avec passion, des ingrédients frais et une touche de tradition pour un voyage gustatif inoubliable.
+                </p>
+                <button onClick={() => navigate('/commande-client')} className="ui-btn ui-btn-accent hero-cta">
+                  Commander en ligne
+                </button>
+              </div>
             )}
+          </div>
         </section>
 
-        <section id="apropos" className="py-20 bg-white">
-          <div className="container mx-auto text-center max-w-4xl px-4">
-            <h2 className="text-4xl font-bold mb-4 text-brand-secondary">Notre Histoire</h2>
-            <p className="text-lg text-gray-600 leading-relaxed">
-              Fondé par des passionnés de la cuisine mexicaine, OUIOUITACOS est né d'un désir simple : partager le goût authentique des tacos faits maison. Chaque recette est un héritage familial, chaque ingrédient est choisi avec soin, et chaque plat est préparé avec le cœur. Venez découvrir une explosion de saveurs qui vous transportera directement dans les rues de Mexico.
+        <section id="apropos" className="section section-surface">
+          <div className="section-inner section-inner--center">
+            <h2 className="section-title">Notre Histoire</h2>
+            <p className="section-text section-text--muted">
+              Fondé par des passionnés de la cuisine mexicaine, OUIOUITACOS est né d'un désir simple : partager le goût authentique des tacos faits maison.
+              Chaque recette est un héritage familial, chaque ingrédient est choisi avec soin, et chaque plat est préparé avec le cœur. Venez découvrir une explosion de saveurs qui vous transportera directement dans les rues de Mexico.
             </p>
           </div>
         </section>
 
-        <section id="menu" className="py-20 bg-gray-50">
-            <div className="container mx-auto text-center px-4">
-                <h2 className="text-4xl font-bold mb-8 text-brand-secondary">Nos Best-Sellers</h2>
-                {menuLoading ? <p>Chargement du menu...</p> : (
-                <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8">
-                    {products.map(product => (
-                    <div key={product.id} className="bg-white rounded-lg shadow-lg overflow-hidden flex flex-col">
-                        <img src={product.image} alt={product.nom_produit} className="w-full h-48 object-cover"/>
-                        <div className="p-4 flex flex-col flex-grow">
-                        <h3 className="text-xl font-bold mb-2 text-gray-900">{product.nom_produit}</h3>
-                        <p className="text-gray-600 text-sm mb-4 flex-grow">{product.description}</p>
-                        <p className="text-lg font-bold text-brand-primary mt-auto">{product.prix_vente.toFixed(2)} €</p>
-                        </div>
+        <section id="menu" className="section section-muted">
+          <div className="section-inner section-inner--wide section-inner--center">
+            <h2 className="section-title">Nos Best-sellers</h2>
+            {menuLoading ? (
+              <p className="section-text section-text--muted">Chargement du menu...</p>
+            ) : (
+              <div className="menu-grid">
+                {products.map(product => (
+                  <article key={product.id} className="ui-card menu-card">
+                    <img src={product.image} alt={product.nom_produit} className="menu-card__media" />
+                    <div className="menu-card__body">
+                      <h3 className="menu-card__title">{product.nom_produit}</h3>
+                      <p className="menu-card__description">{product.description}</p>
+                      <p className="menu-card__price">{product.prix_vente.toFixed(2)} €</p>
                     </div>
-                    ))}
-                </div>
-                )}
-                <button onClick={() => navigate('/commande-client')} className="mt-12 bg-brand-primary text-brand-secondary font-bold py-3 px-8 rounded-full text-lg hover:bg-yellow-400 transition transform hover:scale-105">
-                    Voir le Menu Complet & Commander
-                </button>
+                  </article>
+                ))}
+              </div>
+            )}
+            <div className="section-actions">
+              <button onClick={() => navigate('/commande-client')} className="ui-btn ui-btn-primary hero-cta">
+                Voir le menu complet & Commander
+              </button>
             </div>
+          </div>
         </section>
 
-        <section id="contact" className="py-20 bg-white">
-            <div className="container mx-auto text-center max-w-4xl px-4">
-                <h2 className="text-4xl font-bold mb-8 text-brand-secondary">Contactez-nous</h2>
-                <div className="flex flex-col md:flex-row justify-center items-center gap-8 md:gap-16">
-                    <div className="flex items-center gap-4">
-                        <MapPin size={40} className="text-brand-accent"/>
-                        <div>
-                            <h3 className="text-xl font-semibold">Adresse</h3>
-                            <p className="text-gray-600">123 Rue du Taco, 75000 Paris</p>
-                        </div>
-                    </div>
-                    <div className="flex items-center gap-4">
-                        <Phone size={40} className="text-brand-accent"/>
-                        <div>
-                            <h3 className="text-xl font-semibold">Téléphone</h3>
-                            <p className="text-gray-600">01 23 45 67 89</p>
-                        </div>
-                    </div>
-                     <div className="flex items-center gap-4">
-                        <Mail size={40} className="text-brand-accent"/>
-                        <div>
-                            <h3 className="text-xl font-semibold">Email</h3>
-                            <p className="text-gray-600">contact@ouiouitacos.fr</p>
-                        </div>
-                    </div>
-                </div>
+        <section id="contact" className="section section-surface">
+          <div className="section-inner section-inner--wide section-inner--center">
+            <h2 className="section-title">Contactez-nous</h2>
+            <div className="contact-grid">
+              <div className="contact-card">
+                <MapPin className="contact-card__icon" />
+                <h3 className="contact-card__title">Adresse</h3>
+                <p className="contact-card__text">123 Rue du Taco, 75000 Paris</p>
+              </div>
+              <div className="contact-card">
+                <Phone className="contact-card__icon" />
+                <h3 className="contact-card__title">Téléphone</h3>
+                <p className="contact-card__text">01 23 45 67 89</p>
+              </div>
+              <div className="contact-card">
+                <Mail className="contact-card__icon" />
+                <h3 className="contact-card__title">Email</h3>
+                <p className="contact-card__text">contact@ouiouitacos.fr</p>
+              </div>
             </div>
+          </div>
         </section>
       </main>
 
-      <footer className="bg-brand-secondary text-white py-8">
-        <div className="container mx-auto text-center">
-            <p>&copy; {new Date().getFullYear()} OUIOUITACOS. Tous droits réservés.</p>
+      <footer className="site-footer">
+        <div className="layout-container site-footer__inner">
+          <p>&copy; {new Date().getFullYear()} OUIOUITACOS. Tous droits réservés.</p>
         </div>
       </footer>
 
       <Modal isOpen={isModalOpen} onClose={() => { setIsModalOpen(false); setPin(''); setError(''); }} title="Entrez votre PIN">
-         <form onSubmit={handleFormSubmit} className="space-y-6">
-            <PinInput pin={pin} onPinChange={setPin} pinLength={6} />
-            {error && <p className="text-red-500 text-center h-5">{error}</p>}
-            <button type="submit" disabled={loading || pin.length !== 6} className="w-full bg-brand-primary text-brand-secondary font-bold py-3 px-4 rounded-lg hover:bg-yellow-400 transition disabled:bg-gray-300">
-              {loading ? 'Connexion...' : 'Valider'}
-            </button>
-          </form>
+        <form onSubmit={handleFormSubmit} className="modal-form">
+          <PinInput pin={pin} onPinChange={setPin} pinLength={6} />
+          <p className="modal-form__error" role="alert" aria-live="assertive">{error}</p>
+          <button type="submit" disabled={loading || pin.length !== 6} className="ui-btn ui-btn-primary ui-btn--block" data-state={loading ? 'loading' : 'idle'}>
+            {loading ? 'Connexion...' : 'Valider'}
+          </button>
+        </form>
       </Modal>
     </div>
   );

--- a/pages/Ventes.tsx
+++ b/pages/Ventes.tsx
@@ -6,78 +6,85 @@ import { Table } from '../types';
 import OrderTimer from '../components/OrderTimer';
 
 const getTableStatus = (table: Table) => {
-    if (table.statut === 'libre') {
-        return { text: 'Libre', Icon: <Armchair size={60} className="text-green-600" />, styles: 'bg-green-100 border-green-500 text-green-800' };
+  if (table.statut === 'libre') {
+    return { text: 'Libre', statusClass: 'status--free', Icon: Armchair };
+  }
+
+  if (table.statut === 'a_payer') {
+    if (table.estado_cocina === 'servido') {
+      return { text: 'À encaisser', statusClass: 'status--payment', Icon: DollarSign };
     }
-    if (table.statut === 'a_payer') {
-        if (table.estado_cocina === 'servido') {
-            return { text: 'Para Pagar', Icon: <DollarSign size={60} className="text-red-600" />, styles: 'bg-red-100 border-red-500 text-red-800' };
-        }
-        return { text: 'Para Entregar', Icon: <HandPlatter size={60} className="text-blue-600" />, styles: 'bg-blue-100 border-blue-500 text-blue-800' };
+    return { text: 'À servir', statusClass: 'status--ready', Icon: HandPlatter };
+  }
+
+  if (table.statut === 'occupee') {
+    if (table.estado_cocina === 'recibido') {
+      return { text: 'En cuisine', statusClass: 'status--preparing', Icon: Utensils };
     }
-    if (table.statut === 'occupee') {
-        if (table.estado_cocina === 'recibido') {
-           return { text: 'En Cuisine', Icon: <Utensils size={60} className="text-yellow-600" />, styles: 'bg-yellow-100 border-yellow-500 text-yellow-800' };
-        }
-        return { text: 'Occupée', Icon: <Utensils size={60} className="text-yellow-600" />, styles: 'bg-yellow-100 border-yellow-500 text-yellow-800' };
-    }
-    return { text: 'Inconnu', Icon: <Armchair size={60} className="text-gray-600" />, styles: 'bg-gray-100 border-gray-400' };
+    return { text: 'En service', statusClass: 'status--serving', Icon: Utensils };
+  }
+
+  return { text: 'Inconnu', statusClass: 'status--unknown', Icon: Armchair };
 };
 
 
 const TableCard: React.FC<{ table: Table; onServe: (orderId: string) => void }> = ({ table, onServe }) => {
-    const navigate = useNavigate();
-    const { text, Icon, styles } = getTableStatus(table);
+  const navigate = useNavigate();
+  const { text, statusClass, Icon } = getTableStatus(table);
 
-    const handleClick = (e: React.MouseEvent) => {
-        if ((e.target as HTMLElement).closest('.entregada-button')) {
-            return;
-        }
-        navigate(`/commande/${table.id}`);
-    };
+  const handleCardClick = () => {
+    navigate(`/commande/${table.id}`);
+  };
 
-    const handleServeClick = (e: React.MouseEvent) => {
-        e.stopPropagation();
-        if (table.commandeId) {
-            onServe(table.commandeId);
-        }
-    };
+  const handleCardKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if (event.key === 'Enter' || event.key === ' ') {
+      event.preventDefault();
+      handleCardClick();
+    }
+  };
 
-    return (
-        <div 
-            onClick={handleClick}
-            className={`rounded-lg border-2 p-4 flex flex-col items-center justify-between cursor-pointer transition-transform transform hover:scale-105 ${styles}`}
-        >
-            <div className="flex justify-between w-full items-start">
-                 <h3 className="text-2xl font-bold">{table.nom}</h3>
-                 {table.date_envoi_cuisine && table.statut !== 'libre' && (
-                    <OrderTimer startTime={table.date_envoi_cuisine} />
-                 )}
-            </div>
+  const handleServeClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    if (table.commandeId) {
+      onServe(table.commandeId);
+    }
+  };
 
-            <div className="flex-grow flex flex-col items-center justify-center my-4 text-center">
-                {Icon}
-                <p className="font-bold text-lg mt-2">{text}</p>
-            </div>
-            
-            <div className="w-full text-center">
-                {table.statut !== 'libre' ? (
-                    <p className="text-sm font-semibold">Couverts: {table.couverts}</p>
-                ) : (
-                    <p className="text-sm">Capacité: {table.capacite}</p>
-                )}
-                
-                {table.estado_cocina === 'listo' && (
-                    <button
-                        onClick={handleServeClick}
-                        className="entregada-button uppercase w-full mt-3 bg-blue-500 text-white font-bold py-3 px-4 rounded-lg hover:bg-blue-600 transition"
-                    >
-                        ENTREGADA
-                    </button>
-                )}
-            </div>
-        </div>
-    );
+  return (
+    <div
+      onClick={handleCardClick}
+      onKeyDown={handleCardKeyDown}
+      className={`ui-card status-card ${statusClass}`}
+      role="button"
+      tabIndex={0}
+    >
+      <div className="status-card__header">
+        <h3 className="status-card__title">{table.nom}</h3>
+        {table.date_envoi_cuisine && table.statut !== 'libre' && (
+          <OrderTimer startTime={table.date_envoi_cuisine} />
+        )}
+      </div>
+
+      <div className="status-card__body">
+        <Icon size={56} className="status-card__icon" />
+        <p className="status-card__state">{text}</p>
+      </div>
+
+      <div className="status-card__footer">
+        {table.statut !== 'libre' ? (
+          <p className="status-card__meta">Couverts : {table.couverts}</p>
+        ) : (
+          <p className="status-card__meta">Capacité : {table.capacite}</p>
+        )}
+
+        {table.estado_cocina === 'listo' && (
+          <button type="button" onClick={handleServeClick} className="ui-btn ui-btn-accent status-card__cta">
+            ENTREGADA
+          </button>
+        )}
+      </div>
+    </div>
+  );
 };
 
 const Ventes: React.FC = () => {
@@ -115,12 +122,12 @@ const Ventes: React.FC = () => {
         }
     };
 
-    if (loading) return <div className="text-gray-800">Chargement du plan de salle...</div>;
+    if (loading) return <p className="section-text section-text--muted">Chargement du plan de salle...</p>;
 
     return (
         <div>
-            <h1 className="text-3xl font-bold mb-6 text-gray-800">Plan de Salle</h1>
-            <div className="grid grid-cols-1 gap-6 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 xl:grid-cols-5">
+            <h1 className="section-title">Plan de salle</h1>
+            <div className="status-grid">
                 {tables.map(table => (
                     <TableCard key={table.id} table={table} onServe={handleServeOrder} />
                 ))}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -55,6 +55,606 @@ body {
   -webkit-font-smoothing: antialiased;
 }
 
+.layout-container {
+  width: min(1120px, 100%);
+  margin: 0 auto;
+  padding-inline: clamp(1.25rem, 4vw, 3rem);
+}
+
+.section {
+  padding-block: clamp(3rem, 8vw, 6rem);
+}
+
+.section-inner {
+  width: min(960px, 100%);
+  margin: 0 auto;
+  padding-inline: clamp(1.25rem, 4vw, 3rem);
+}
+
+.section-inner--wide {
+  width: min(1120px, 100%);
+}
+
+.section-inner--center {
+  text-align: center;
+}
+
+.section-hero {
+  position: relative;
+  min-height: min(100dvh, 880px);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  color: var(--color-surface);
+  background-size: cover;
+  background-position: center;
+  overflow: hidden;
+}
+
+.section-hero::before {
+  content: '';
+  position: absolute;
+  inset: 0;
+  background: linear-gradient(145deg, rgba(15, 23, 42, 0.78) 0%, rgba(15, 23, 42, 0.42) 52%, rgba(37, 99, 235, 0.35) 100%);
+  backdrop-filter: saturate(140%) blur(4px);
+}
+
+.section-hero__inner {
+  position: relative;
+  z-index: 1;
+  width: min(1120px, 100%);
+  padding-inline: clamp(1.5rem, 5vw, 4rem);
+  padding-block: clamp(2.5rem, 6vw, 4.5rem);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(1.5rem, 4vw, 2.5rem);
+}
+
+.hero-content {
+  max-width: 720px;
+  text-align: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: clamp(1.25rem, 3vw, 2rem);
+}
+
+.hero-title {
+  font-size: clamp(2.75rem, 6vw, 3.75rem);
+  line-height: 1.1;
+  letter-spacing: -0.015em;
+  color: var(--color-surface);
+  text-shadow: 0 20px 40px rgba(15, 23, 42, 0.35);
+  margin: 0;
+}
+
+.hero-subtitle {
+  font-size: clamp(1.125rem, 2.5vw, 1.5rem);
+  color: color-mix(in srgb, var(--color-surface) 80%, transparent);
+  max-width: 42ch;
+  margin: 0;
+}
+
+.hero-cta {
+  font-size: var(--font-size-lg);
+  padding-inline: clamp(1.75rem, 5vw, 2.75rem);
+  padding-block: clamp(0.85rem, 2.75vw, 1.15rem);
+  border-radius: 999px;
+}
+
+.section-surface {
+  background: var(--color-surface);
+}
+
+.section-muted {
+  background: color-mix(in srgb, var(--color-bg-muted) 80%, var(--color-surface) 20%);
+}
+
+.section-title {
+  font-size: clamp(2.25rem, 4vw, 2.75rem);
+  line-height: 1.1;
+  letter-spacing: -0.01em;
+  color: var(--color-heading);
+  margin-bottom: clamp(0.75rem, 2vw, 1.25rem);
+}
+
+.section-text {
+  font-size: clamp(1rem, 1.85vw, 1.15rem);
+  color: var(--color-text);
+  line-height: var(--line-height-relaxed);
+  margin: 0;
+}
+
+.section-text--muted {
+  color: var(--color-text-muted);
+}
+
+.section-actions {
+  margin-top: clamp(2rem, 4vw, 3rem);
+  display: flex;
+  justify-content: center;
+}
+
+.menu-grid {
+  display: grid;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+.menu-card {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  overflow: hidden;
+}
+
+.menu-card__media {
+  width: 100%;
+  height: 200px;
+  object-fit: cover;
+}
+
+.menu-card__body {
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  flex: 1;
+}
+
+.menu-card__title {
+  font-size: var(--font-size-xl);
+  color: var(--color-heading);
+  margin: 0;
+}
+
+.menu-card__description {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  flex: 1;
+  margin: 0;
+}
+
+.menu-card__price {
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  color: var(--color-accent);
+}
+
+.contact-grid {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  align-items: stretch;
+}
+
+.contact-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  text-align: center;
+  gap: 0.65rem;
+  padding: clamp(1.5rem, 4vw, 2rem);
+  border-radius: 1rem;
+  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 75%, transparent);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.08);
+}
+
+.contact-card__icon {
+  width: 2.75rem;
+  height: 2.75rem;
+  color: var(--color-accent);
+}
+
+.contact-card__title {
+  font-size: var(--font-size-lg);
+  color: var(--color-heading);
+  margin: 0;
+}
+
+.contact-card__text {
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+  margin: 0;
+}
+
+.site-footer {
+  background: color-mix(in srgb, var(--color-heading) 94%, transparent);
+  color: var(--color-surface);
+  padding-block: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.site-footer__inner {
+  text-align: center;
+  font-size: var(--font-size-sm);
+  letter-spacing: 0.015em;
+}
+
+.login-page {
+  min-height: 100dvh;
+  display: flex;
+  flex-direction: column;
+  background: linear-gradient(175deg, color-mix(in srgb, var(--color-bg) 85%, transparent) 0%,
+      color-mix(in srgb, var(--color-bg-muted) 92%, transparent) 100%);
+}
+
+.login-header {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  backdrop-filter: blur(12px);
+  background: color-mix(in srgb, var(--color-heading) 88%, transparent);
+  border-bottom: 1px solid color-mix(in srgb, var(--color-border) 75%, transparent);
+  color: var(--color-surface);
+  padding-block: 1rem;
+}
+
+.login-header__inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1.25rem;
+}
+
+.login-brand {
+  font-size: clamp(1.75rem, 4vw, 2.25rem);
+  font-weight: 800;
+  letter-spacing: -0.01em;
+  color: var(--color-accent);
+}
+
+.login-nav {
+  display: none;
+  align-items: center;
+  gap: clamp(1.5rem, 3vw, 2.5rem);
+}
+
+.login-nav__link {
+  font-size: var(--font-size-sm);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-weight: 600;
+  color: color-mix(in srgb, var(--color-surface) 82%, transparent);
+  transition: color 0.2s ease, opacity 0.2s ease;
+}
+
+.login-nav__link:hover,
+.login-nav__link:focus-visible {
+  color: var(--color-surface);
+  opacity: 1;
+  outline: none;
+}
+
+.login-nav__cta {
+  font-size: var(--font-size-sm);
+  padding-inline: clamp(1.15rem, 3vw, 1.75rem);
+  padding-block: 0.65rem;
+  border-radius: 999px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.login-header__menu {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 2.75rem;
+  height: 2.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid color-mix(in srgb, var(--color-surface) 18%, transparent);
+  background: color-mix(in srgb, var(--color-heading) 65%, transparent);
+  color: color-mix(in srgb, var(--color-surface) 80%, transparent);
+  transition: transform 0.2s ease, border-color 0.2s ease, color 0.2s ease;
+}
+
+.login-header__menu:hover,
+.login-header__menu:focus-visible {
+  transform: translateY(-1px);
+  color: var(--color-surface);
+  border-color: color-mix(in srgb, var(--color-surface) 30%, transparent);
+  outline: none;
+}
+
+.login-menu-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 60;
+  background: color-mix(in srgb, var(--color-heading) 90%, transparent);
+  color: var(--color-surface);
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 2rem;
+  padding: clamp(2rem, 6vw, 3rem);
+}
+
+.login-menu-overlay__close {
+  position: absolute;
+  top: clamp(1rem, 4vw, 1.5rem);
+  right: clamp(1rem, 4vw, 1.5rem);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.875rem;
+  border: 1px solid color-mix(in srgb, var(--color-surface) 25%, transparent);
+  background: transparent;
+  color: var(--color-surface);
+}
+
+.login-menu-overlay__nav {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 1.75rem;
+  font-size: clamp(1.5rem, 5vw, 2rem);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.login-menu-overlay__link {
+  color: color-mix(in srgb, var(--color-surface) 85%, transparent);
+}
+
+.login-menu-overlay__link:hover,
+.login-menu-overlay__link:focus-visible {
+  color: var(--color-surface);
+  outline: none;
+}
+
+.pin-input {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.pin-pad {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 1rem;
+}
+
+.pin-pad__button {
+  height: 3.5rem;
+  border-radius: 999px;
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  color: var(--color-heading);
+  transition: transform 0.2s ease, box-shadow 0.2s ease, background-color 0.2s ease;
+}
+
+.pin-pad__button:hover,
+.pin-pad__button:focus-visible {
+  transform: translateY(-1px);
+  background: var(--color-surface);
+  box-shadow: var(--shadow-focus);
+  outline: none;
+}
+
+.pin-pad__button:active {
+  transform: translateY(0);
+}
+
+.pin-pad__button--muted {
+  color: var(--color-text-muted);
+}
+
+.pin-indicator {
+  display: flex;
+  gap: clamp(0.5rem, 2vw, 0.75rem);
+  margin-bottom: 1.5rem;
+}
+
+.pin-indicator__slot {
+  width: clamp(2.5rem, 6vw, 3rem);
+  height: clamp(3rem, 7vw, 3.5rem);
+  border-radius: 0.75rem;
+  background: color-mix(in srgb, var(--color-surface) 90%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: var(--font-size-xl);
+  font-weight: 700;
+  color: var(--color-heading);
+}
+
+.modal-form {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.modal-form__error {
+  min-height: 1.5rem;
+  margin: 0;
+  text-align: center;
+  font-size: var(--font-size-sm);
+  color: var(--color-danger);
+}
+
+.status-card {
+  position: relative;
+  cursor: pointer;
+  padding: clamp(1.5rem, 3vw, 2rem);
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+  min-height: 280px;
+  transition: transform 0.25s ease;
+}
+
+.status-card:hover {
+  transform: translateY(-4px);
+}
+
+.status-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.status-card__body {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 0.85rem;
+  text-align: center;
+  margin-block: clamp(1rem, 3vw, 1.5rem);
+}
+
+.status-card__title {
+  font-size: clamp(1.35rem, 2.5vw, 1.65rem);
+  margin: 0;
+}
+
+.status-card__icon {
+  width: clamp(3rem, 6vw, 3.5rem);
+  height: clamp(3rem, 6vw, 3.5rem);
+}
+
+.status-card__state {
+  font-size: var(--font-size-lg);
+  font-weight: 700;
+  margin: 0;
+}
+
+.status-card__meta {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  letter-spacing: 0.02em;
+}
+
+.status-card__cta {
+  margin-top: auto;
+  width: 100%;
+}
+
+.status-card__footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-size: var(--font-size-sm);
+}
+
+.status-grid {
+  display: grid;
+  gap: clamp(1.25rem, 3vw, 2rem);
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+.status--free {
+  border-color: color-mix(in srgb, var(--color-success) 45%, var(--color-border));
+  background: color-mix(in srgb, var(--color-success) 12%, var(--color-surface));
+  color: color-mix(in srgb, var(--color-success) 55%, var(--color-heading));
+}
+
+.status--free .status-card__icon {
+  color: var(--color-success);
+}
+
+.status--serving {
+  border-color: color-mix(in srgb, var(--color-warning) 45%, var(--color-border));
+  background: color-mix(in srgb, var(--color-warning) 18%, var(--color-surface));
+  color: color-mix(in srgb, var(--color-warning) 60%, var(--color-heading));
+}
+
+.status--serving .status-card__icon {
+  color: var(--color-warning);
+}
+
+.status--preparing {
+  border-color: color-mix(in srgb, var(--color-info) 45%, var(--color-border));
+  background: color-mix(in srgb, var(--color-info) 16%, var(--color-surface));
+  color: color-mix(in srgb, var(--color-info) 60%, var(--color-heading));
+}
+
+.status--preparing .status-card__icon {
+  color: var(--color-info);
+}
+
+.status--ready {
+  border-color: color-mix(in srgb, var(--color-accent) 55%, var(--color-border));
+  background: color-mix(in srgb, var(--color-accent) 18%, var(--color-surface));
+  color: color-mix(in srgb, var(--color-accent) 62%, var(--color-heading));
+}
+
+.status--ready .status-card__icon {
+  color: var(--color-accent);
+}
+
+.status--payment {
+  border-color: color-mix(in srgb, var(--color-danger) 50%, var(--color-border));
+  background: color-mix(in srgb, var(--color-danger) 14%, var(--color-surface));
+  color: color-mix(in srgb, var(--color-danger) 65%, var(--color-heading));
+}
+
+.status--payment .status-card__icon {
+  color: var(--color-danger);
+}
+
+.status--unknown {
+  border-color: color-mix(in srgb, var(--color-border-strong) 70%, var(--color-border));
+  background: color-mix(in srgb, var(--color-border) 20%, var(--color-surface));
+  color: var(--color-text-muted);
+}
+
+.status--unknown .status-card__icon {
+  color: var(--color-text-muted);
+}
+
+.status--free .status-card__meta,
+.status--serving .status-card__meta,
+.status--preparing .status-card__meta,
+.status--ready .status-card__meta,
+.status--payment .status-card__meta {
+  color: color-mix(in srgb, currentColor 62%, var(--color-heading));
+}
+
+.status--unknown .status-card__meta {
+  color: var(--color-text-muted);
+}
+
+@media (min-width: 768px) {
+  .login-nav {
+    display: flex;
+  }
+
+  .login-header__menu {
+    display: none;
+  }
+
+  .hero-content {
+    text-align: left;
+    align-items: flex-start;
+  }
+
+  .section-hero__inner {
+    align-items: flex-start;
+  }
+}
+
+@media (min-width: 1024px) {
+  .hero-title {
+    font-size: clamp(3.5rem, 4vw, 4.25rem);
+  }
+
+  .section-title {
+    font-size: clamp(2.5rem, 3.5vw, 3rem);
+  }
+}
+
 .app-shell {
   display: flex;
   min-height: 100dvh;
@@ -416,6 +1016,11 @@ p {
   border-color: var(--color-border-strong);
   box-shadow: var(--shadow-card-hover);
   transform: translateY(-2px);
+}
+
+.ui-btn--block {
+  width: 100%;
+  justify-content: center;
 }
 
 .ui-card-section {


### PR DESCRIPTION
## Summary
- add reusable section, hero, and layout helpers plus status palette in the global stylesheet
- restyle the public login landing page with themed sections, updated typography, and ui-btn/ui-card usage
- align the sales plan cards with theme status classes and accessible button/card variants

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d568c09000832a8a64150296c95eaa