### PR TITLE
Handle unsent table exits and enhance customer order UX

### DIFF
--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -240,6 +240,11 @@ const Commande: React.FC = () => {
     };
     
     const handleExitAttempt = () => {
+        if (order && order.estado_cocina === 'no_enviado' && order.items.length > 0) {
+            setExitConfirmOpen(true);
+            return;
+        }
+
         if (hasUnsentChanges) {
             setExitConfirmOpen(true);
         } else {
@@ -248,11 +253,18 @@ const Commande: React.FC = () => {
     };
 
     const handleConfirmExit = async () => {
-        if (originalOrder && !isOrderSynced(originalOrder)) {
-            await updateOrderItems(originalOrder.items);
+        try {
+            if (order && order.estado_cocina === 'no_enviado') {
+                await api.cancelUnsentTableOrder(order.id);
+            } else if (originalOrder && !isOrderSynced(originalOrder)) {
+                await updateOrderItems(originalOrder.items);
+            }
+        } catch (error) {
+            console.error('Failed to cancel unsent order before exiting', error);
+        } finally {
+            setExitConfirmOpen(false);
+            navigate('/ventes');
         }
-        setExitConfirmOpen(false);
-        navigate('/ventes');
     };
 
     if (loading) return <div className="text-center p-10 text-gray-800">Chargement de la commande...</div>;

--- a/services/customerOrderStorage.ts
+++ b/services/customerOrderStorage.ts
@@ -1,0 +1,98 @@
+export type ActiveCustomerOrder = {
+  orderId: string;
+  expiresAt?: number;
+};
+
+const STORAGE_KEY = 'active-customer-order';
+const LEGACY_KEY = 'active-customer-order-id';
+export const ONE_DAY_IN_MS = 24 * 60 * 60 * 1000;
+
+const parseStoredOrder = (raw: string | null): ActiveCustomerOrder | null => {
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as ActiveCustomerOrder;
+    if (parsed && typeof parsed.orderId === 'string' && parsed.orderId.trim().length > 0) {
+      return parsed;
+    }
+  } catch (error) {
+    console.error('Failed to parse stored active order', error);
+  }
+
+  return null;
+};
+
+const persistActiveOrder = (payload: ActiveCustomerOrder | null) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    if (!payload) {
+      window.localStorage.removeItem(STORAGE_KEY);
+      window.localStorage.removeItem(LEGACY_KEY);
+      return;
+    }
+
+    window.localStorage.setItem(STORAGE_KEY, JSON.stringify(payload));
+    window.localStorage.removeItem(LEGACY_KEY);
+  } catch (error) {
+    console.error('Failed to persist active order', error);
+  }
+};
+
+export const getActiveCustomerOrder = (): ActiveCustomerOrder | null => {
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  const stored = parseStoredOrder(window.localStorage.getItem(STORAGE_KEY));
+  if (stored) {
+    if (stored.expiresAt && stored.expiresAt <= Date.now()) {
+      persistActiveOrder(null);
+      return null;
+    }
+    return stored;
+  }
+
+  const legacyId = window.localStorage.getItem(LEGACY_KEY);
+  if (legacyId && legacyId.trim().length > 0) {
+    const payload: ActiveCustomerOrder = { orderId: legacyId };
+    persistActiveOrder(payload);
+    return payload;
+  }
+
+  return null;
+};
+
+export const storeActiveCustomerOrder = (orderId: string, expiresAt?: number) => {
+  if (!orderId) {
+    persistActiveOrder(null);
+    return;
+  }
+
+  const payload: ActiveCustomerOrder = expiresAt
+    ? { orderId, expiresAt }
+    : { orderId };
+
+  persistActiveOrder(payload);
+};
+
+export const clearActiveCustomerOrder = () => {
+  persistActiveOrder(null);
+};
+
+export const extendActiveCustomerOrder = (durationMs: number) => {
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  const current = getActiveCustomerOrder();
+  if (!current) {
+    return;
+  }
+
+  storeActiveCustomerOrder(current.orderId, Date.now() + durationMs);
+};

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -144,6 +144,79 @@ body {
   border-radius: 999px;
 }
 
+.hero-history {
+  width: 100%;
+  max-width: 680px;
+  margin-top: clamp(1rem, 2.5vw, 1.75rem);
+  padding: clamp(1rem, 3vw, 1.75rem);
+  border-radius: 1.25rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: linear-gradient(135deg, rgba(15, 23, 42, 0.75) 0%, rgba(30, 41, 59, 0.62) 100%);
+  box-shadow: 0 24px 55px rgba(2, 6, 23, 0.42);
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+.hero-history__title {
+  font-size: clamp(1.05rem, 2vw, 1.25rem);
+  font-weight: 700;
+  color: var(--color-surface);
+  margin: 0;
+}
+
+.hero-history__list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.hero-history__item {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.hero-history__meta {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.hero-history__date {
+  color: var(--color-surface);
+  font-weight: 600;
+  margin: 0;
+}
+
+.hero-history__details {
+  color: color-mix(in srgb, var(--color-surface) 70%, transparent);
+  font-size: 0.9rem;
+  margin: 0;
+}
+
+.hero-history__cta {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.45rem 1.25rem;
+  border-radius: 999px;
+  border: 1px solid rgba(253, 224, 71, 0.55);
+  background: rgba(253, 224, 71, 0.18);
+  color: var(--color-surface);
+  font-size: 0.9rem;
+  font-weight: 600;
+  transition: transform 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.hero-history__cta:hover {
+  background: rgba(253, 224, 71, 0.32);
+  transform: translateY(-1px);
+  box-shadow: 0 12px 22px rgba(253, 224, 71, 0.28);
+}
+
 .section-surface {
   background: var(--color-surface);
 }
@@ -158,6 +231,15 @@ body {
   letter-spacing: -0.01em;
   color: var(--color-heading);
   margin-bottom: clamp(0.75rem, 2vw, 1.25rem);
+}
+
+.app-content__inner .section-title {
+  color: color-mix(in srgb, var(--color-surface) 94%, transparent);
+}
+
+.app-content__inner .section-text,
+.app-content__inner .section-text--muted {
+  color: color-mix(in srgb, var(--color-surface) 78%, transparent);
 }
 
 .section-text {
@@ -555,13 +637,18 @@ body {
 }
 
 .status--free {
-  border-color: color-mix(in srgb, var(--color-success) 45%, var(--color-border));
-  background: color-mix(in srgb, var(--color-success) 12%, var(--color-surface));
-  color: color-mix(in srgb, var(--color-success) 55%, var(--color-heading));
+  border-color: rgba(34, 197, 94, 0.45);
+  background: linear-gradient(160deg, rgba(34, 197, 94, 0.22) 0%, rgba(22, 163, 74, 0.08) 100%);
+  color: #166534;
+  box-shadow: 0 18px 36px rgba(22, 163, 74, 0.22);
 }
 
 .status--free .status-card__icon {
-  color: var(--color-success);
+  color: #22c55e;
+}
+
+.status--free .status-card__state {
+  color: #15803d;
 }
 
 .status--serving {
@@ -728,19 +815,23 @@ body {
   overflow-y: auto;
   overflow-x: hidden;
   padding: clamp(1rem, 2.5vw + 0.75rem, 3rem);
-  background: linear-gradient(165deg, color-mix(in srgb, var(--color-bg-muted) 85%, transparent) 0%,
-      color-mix(in srgb, var(--color-bg) 80%, transparent) 100%);
+  background:
+    radial-gradient(circle at 15% 20%, rgba(59, 130, 246, 0.25) 0%, rgba(15, 23, 42, 0) 38%),
+    radial-gradient(circle at 85% 10%, rgba(249, 115, 22, 0.22) 0%, rgba(15, 23, 42, 0) 36%),
+    linear-gradient(180deg, #0f172a 0%, #020617 100%);
 }
 
 .app-content__inner {
   margin: 0 auto;
   width: min(1120px, 100%);
   min-height: calc(100dvh - clamp(4.75rem, 6vw + 3rem, 7rem));
-  background: var(--color-surface);
+  background: rgba(15, 23, 42, 0.55);
   border-radius: 1.25rem;
-  border: 1px solid color-mix(in srgb, var(--color-border) 80%, transparent);
-  box-shadow: 0 25px 50px rgba(15, 23, 42, 0.12);
+  border: 1px solid rgba(148, 163, 184, 0.18);
+  box-shadow: 0 38px 90px rgba(2, 6, 23, 0.55);
+  backdrop-filter: blur(12px);
   padding: clamp(1.25rem, 3vw + 0.75rem, 2.75rem);
+  color: color-mix(in srgb, var(--color-surface) 88%, transparent);
 }
 
 .app-sidebar {
@@ -1010,6 +1101,7 @@ p {
   border: 1px solid var(--color-border);
   box-shadow: var(--shadow-card);
   transition: transform 0.2s ease, box-shadow 0.2s ease, border-color 0.2s ease;
+  color: var(--color-text);
 }
 
 .ui-card:hover {


### PR DESCRIPTION
## Summary
- add an API escape hatch and UI prompts so leaving an unsent table order cancels it and frees the table with refreshed "libre" styling
- persist customer takeaway orders with a 24-hour expiry, show a green "Terminée" badge when delivered, and queue reorders from history
- apply a stylized dark backdrop for the back-office screens and surface recent customer orders on the landing "Commander en ligne" section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d56e247dd8832aba08026c9cad658a