### PR TITLE
Ajuste des indicateurs et timers pour les commandes à emporter

### DIFF
--- a/components/CustomerOrderTracker.tsx
+++ b/components/CustomerOrderTracker.tsx
@@ -45,7 +45,13 @@ const CustomerOrderTracker: React.FC<CustomerOrderTrackerProps> = ({ orderId, on
 
     const getCurrentStepIndex = useCallback((order: Order | null): number => {
         if (!order) return -1;
-        if (order.statut === 'finalisee' || order.estado_cocina === 'servido') return 3;
+        if (
+            order.statut === 'finalisee' ||
+            order.estado_cocina === 'servido' ||
+            (order.type === 'a_emporter' && order.estado_cocina === 'listo')
+        ) {
+            return 3;
+        }
         if (order.estado_cocina === 'listo') return 2;
         if (order.estado_cocina === 'recibido') return 1;
         if (order.statut === 'pendiente_validacion') return 0;
@@ -92,7 +98,10 @@ const CustomerOrderTracker: React.FC<CustomerOrderTrackerProps> = ({ orderId, on
         };
     }, [orderId]);
 
-    const isOrderCompleted = order?.statut === 'finalisee' || order?.estado_cocina === 'servido';
+    const isOrderCompleted =
+        order?.statut === 'finalisee' ||
+        order?.estado_cocina === 'servido' ||
+        (order?.type === 'a_emporter' && order?.estado_cocina === 'listo');
 
     const containerClasses = variant === 'page'
       ? "container mx-auto p-4 lg:p-8"

--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -1,17 +1,15 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { api } from '../services/api';
 import { Order, OrderItem } from '../types';
-import { Clock, Eye, User, MapPin } from 'lucide-react';
+import { Eye, User, MapPin } from 'lucide-react';
 import Modal from '../components/Modal';
 import OrderTimer from '../components/OrderTimer';
-import { formatElapsedSince } from '../utils/time';
 
 const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => void, onDeliver?: (orderId: string) => void, isProcessing?: boolean }> = ({ order, onValidate, onDeliver, isProcessing }) => {
     const [isReceiptModalOpen, setIsReceiptModalOpen] = useState(false);
 
     const displayName = order.table_nom || `Commande #${order.id.slice(-6)}`;
     const timerStart = order.date_envoi_cuisine || order.date_creation;
-    const readySince = order.date_listo_cuisine ? formatElapsedSince(order.date_listo_cuisine) : null;
 
     return (
         <>
@@ -56,9 +54,6 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                     )}
                     {order.estado_cocina === 'listo' && onDeliver && (
                          <>
-                            {readySince && (
-                                <span className="text-sm text-green-600 flex items-center justify-center font-semibold"><Clock size={16} className="mr-1"/> Prête depuis {readySince}</span>
-                            )}
                             <button
                                 onClick={() => onDeliver(order.id)}
                                 disabled={isProcessing}

--- a/pages/Ventes.tsx
+++ b/pages/Ventes.tsx
@@ -61,7 +61,9 @@ const TableCard: React.FC<{ table: Table; onServe: (orderId: string) => void }> 
       <div className="status-card__header">
         <h3 className="status-card__title">{table.nom}</h3>
         {table.date_envoi_cuisine && table.statut !== 'libre' && (
-          <OrderTimer startTime={table.date_envoi_cuisine} />
+          <div className="status-card__timer">
+            <OrderTimer startTime={table.date_envoi_cuisine} className="w-full justify-center" />
+          </div>
         )}
       </div>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -579,9 +579,15 @@ body {
 
 .status-card__header {
   display: flex;
+  flex-direction: column;
   align-items: flex-start;
-  justify-content: space-between;
-  gap: 1rem;
+  gap: 0.75rem;
+}
+
+.status-card__timer {
+  width: 100%;
+  display: flex;
+  justify-content: center;
 }
 
 .status-card__body {


### PR DESCRIPTION
## Summary
- mark the customer tracker as completed when takeaway orders are ready in the kitchen
- stack table card headers so timers display on their own line
- keep a single mm:ss timer in the takeaway view and drop the duplicate "prête depuis" message

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d5a0c870d0832ab19163320feb9852