### PR TITLE
Improve kitchen ticket grouping and table styling

### DIFF
--- a/components/OrderTimer.tsx
+++ b/components/OrderTimer.tsx
@@ -21,9 +21,9 @@ const OrderTimer: React.FC<OrderTimerProps> = ({ startTime, className = '' }) =>
   const timerString = formatMillisecondsToMinutesSeconds(elapsed);
 
   const getTimerColor = () => {
-    if (minutes >= 20) return 'bg-red-500 text-white';
-    if (minutes >= 10) return 'bg-yellow-400 text-black';
-    return 'bg-white text-brand-secondary';
+    if (minutes >= 20) return 'bg-red-500 text-white shadow-lg';
+    if (minutes >= 10) return 'bg-yellow-400 text-black shadow-md';
+    return 'bg-brand-primary text-brand-secondary shadow-md ring-1 ring-black/5';
   };
 
   return (

--- a/pages/Cuisine.tsx
+++ b/pages/Cuisine.tsx
@@ -1,23 +1,28 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { ChefHat } from 'lucide-react';
 import { api } from '../services/api';
-import { Order, OrderItem } from '../types';
+import { KitchenTicket as KitchenTicketOrder, OrderItem } from '../types';
 import { useAuth } from '../contexts/AuthContext';
 import OrderTimer from '../components/OrderTimer';
 import { getOrderUrgencyClass } from '../utils/orderUrgency';
 
-const KitchenTicket: React.FC<{ order: Order; onReady: (orderId: string) => void; canMarkReady: boolean }> = ({ order, onReady, canMarkReady }) => {
+const KitchenTicketCard: React.FC<{ order: KitchenTicketOrder; onReady: (orderId: string) => void; canMarkReady: boolean }> = ({ order, onReady, canMarkReady }) => {
 
     return (
         <div className={`rounded-lg border shadow-md flex flex-col h-full ${getOrderUrgencyClass(order.date_envoi_cuisine || Date.now())}`}>
             <header className="bg-brand-secondary text-white p-3 rounded-t-lg">
                 <div className="flex flex-col gap-2">
                     <h3 className="text-xl font-bold w-full">{order.table_nom || `À emporter #${order.id.slice(-4)}`}</h3>
-                    <OrderTimer startTime={order.date_envoi_cuisine || Date.now()} className="w-full justify-center" />
+                    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1">
+                        <OrderTimer startTime={order.date_envoi_cuisine || Date.now()} className="w-full justify-center sm:w-auto" />
+                        <p className="text-xs text-white/80 text-center sm:text-right">
+                            Envoyé {new Date(order.date_envoi_cuisine || Date.now()).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}
+                        </p>
+                    </div>
                 </div>
             </header>
             <div className="p-3 space-y-2 flex-1 overflow-y-auto">
-                {order.items.filter(i => i.estado === 'enviado').map((item: OrderItem) => (
+                {order.items.map((item: OrderItem) => (
                     <div key={item.id} className="p-2 bg-gray-50 rounded">
                         <p className="font-bold text-lg text-gray-900">{item.quantite}x {item.nom_produit}</p>
                         {item.commentaire && <p className="text-sm text-gray-600 italic pl-2">- {item.commentaire}</p>}
@@ -41,7 +46,7 @@ const Cuisine: React.FC = () => {
     // FIX: Define state for orders and loading within the component.
     // The errors "Cannot find name 'loading'" and "Cannot find name 'setLoading'"
     // suggest these state definitions were missing or out of scope.
-    const [orders, setOrders] = useState<Order[]>([]);
+    const [orders, setOrders] = useState<KitchenTicketOrder[]>([]);
     const [loading, setLoading] = useState(true);
     const { role } = useAuth();
     
@@ -53,7 +58,7 @@ const Cuisine: React.FC = () => {
     const fetchOrders = useCallback(async () => {
         try {
             const data = await api.getKitchenOrders();
-            setOrders(data.sort((a,b) => (a.date_envoi_cuisine || 0) - (b.date_envoi_cuisine || 0)));
+            setOrders(data);
         // FIX: The caught exception variable in a catch block defines its scope.
         // The error "Cannot find name 'error'" suggests a mismatch, for example,
         // `catch (e)` but then using `error`. Using `catch (error)` makes the `error`
@@ -95,7 +100,7 @@ const Cuisine: React.FC = () => {
             ) : (
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 flex-1">
                     {orders.map(order => (
-                        <KitchenTicket key={order.id} order={order} onReady={handleMarkAsReady} canMarkReady={canMarkReady} />
+                        <KitchenTicketCard key={order.ticketKey} order={order} onReady={handleMarkAsReady} canMarkReady={canMarkReady} />
                     ))}
                 </div>
             )}

--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -24,11 +24,6 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                 </header>
 
                 <div className="p-4 space-y-4 flex-1 bg-white/80">
-                    <div className="flex items-center justify-between text-gray-900 font-semibold text-lg">
-                        <span>Total</span>
-                        <span>{order.total.toFixed(2)} €</span>
-                    </div>
-
                     {order.clientInfo && (
                         <div className="space-y-1 text-sm text-gray-700">
                             {order.clientInfo.nom && (
@@ -55,6 +50,11 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                                 </li>
                             ))}
                         </ul>
+                    </div>
+
+                    <div className="flex items-center justify-between text-gray-900 font-semibold text-lg pt-2 border-t border-gray-200">
+                        <span>Total</span>
+                        <span>{order.total.toFixed(2)} €</span>
                     </div>
                 </div>
 

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -585,6 +585,7 @@ body {
   color: var(--color-danger);
 }
 
+
 .status-card {
   position: relative;
   cursor: pointer;
@@ -593,11 +594,17 @@ body {
   flex-direction: column;
   gap: 1.25rem;
   min-height: 280px;
-  transition: transform 0.25s ease;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+  border-width: 2px;
+  border-style: solid;
+  border-color: transparent;
+  background-color: var(--color-surface);
+  box-shadow: 0 18px 36px rgba(15, 23, 42, 0.08);
 }
 
 .status-card:hover {
   transform: translateY(-4px);
+  box-shadow: 0 22px 44px rgba(15, 23, 42, 0.12);
 }
 
 .status-card__header {
@@ -665,52 +672,52 @@ body {
   grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
 }
 
+
 .status-card.status--free {
-  border-color: rgba(34, 197, 94, 0.45);
-  background: linear-gradient(160deg, rgba(34, 197, 94, 0.22) 0%, rgba(22, 163, 74, 0.08) 100%);
-  background-color: rgba(34, 197, 94, 0.22);
-  color: #166534;
-  box-shadow: 0 18px 36px rgba(22, 163, 74, 0.22);
+  border-color: #16a34a;
+  background-color: #ecfdf5;
+  color: #065f46;
 }
 
 .status-card.status--free .status-card__icon {
-  color: #22c55e;
+  color: #047857;
 }
 
 .status-card.status--free .status-card__state {
-  color: #15803d;
+  color: #047857;
 }
 
 .status-card.status--serving {
-  border-color: color-mix(in srgb, var(--color-warning) 45%, var(--color-border));
-  background: color-mix(in srgb, var(--color-warning) 18%, var(--color-surface));
-  background-color: color-mix(in srgb, var(--color-warning) 18%, var(--color-surface));
-  color: color-mix(in srgb, var(--color-warning) 60%, var(--color-heading));
+  border-color: #ea580c;
+  background-color: #fff7ed;
+  color: #7c2d12;
 }
 
 .status-card.status--serving .status-card__icon {
-  color: var(--color-warning);
+  color: #f97316;
+}
+
+.status-card.status--serving .status-card__state {
+  color: #c2410c;
 }
 
 .status-card.status--preparing {
-  border-color: rgba(250, 204, 21, 0.45);
-  background: linear-gradient(160deg, rgba(250, 204, 21, 0.24) 0%, rgba(253, 224, 71, 0.12) 100%);
-  background-color: rgba(250, 204, 21, 0.24);
-  color: #a16207;
+  border-color: #d97706;
+  background-color: #fef3c7;
+  color: #92400e;
 }
 
 .status-card.status--preparing .status-card__icon {
-  color: #facc15;
+  color: #f59e0b;
 }
 
 .status-card.status--preparing .status-card__state {
-  color: #ca8a04;
+  color: #b45309;
 }
 
 .status-card.status--ready {
-  border-color: rgba(37, 99, 235, 0.45);
-  background: linear-gradient(160deg, rgba(37, 99, 235, 0.22) 0%, rgba(59, 130, 246, 0.1) 100%);
-  background-color: rgba(37, 99, 235, 0.22);
+  border-color: #2563eb;
+  background-color: #dbeafe;
   color: #1d4ed8;
 }
 
@@ -723,18 +730,17 @@ body {
 }
 
 .status-card.status--payment {
-  border-color: rgba(139, 92, 246, 0.45);
-  background: linear-gradient(160deg, rgba(139, 92, 246, 0.22) 0%, rgba(167, 139, 250, 0.1) 100%);
-  background-color: rgba(139, 92, 246, 0.22);
-  color: #6d28d9;
+  border-color: #7c3aed;
+  background-color: #ede9fe;
+  color: #5b21b6;
 }
 
 .status-card.status--payment .status-card__icon {
-  color: #8b5cf6;
+  color: #6d28d9;
 }
 
 .status-card.status--payment .status-card__state {
-  color: #7c3aed;
+  color: #5b21b6;
 }
 
 .status-card.status--unknown {

--- a/types/index.ts
+++ b/types/index.ts
@@ -90,6 +90,10 @@ export interface Order {
   receipt_url?: string;
 }
 
+export interface KitchenTicket extends Order {
+  ticketKey: string;
+}
+
 export interface Purchase {
   id: string;
   ingredient_id: string;


### PR DESCRIPTION
## Summary
- move takeaway order totals beneath the article list to match the desired layout
- enhance timer styling and kitchen ticket display so each send generates its own card with timestamp details
- refresh table status colors for higher contrast and introduce a reusable kitchen ticket type

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d5b28c1950832aa851bdbbe923867c