### PR TITLE
Update table status mapping and cleanup styles

### DIFF
--- a/pages/Ventes.tsx
+++ b/pages/Ventes.tsx
@@ -10,18 +10,20 @@ const getTableStatus = (table: Table) => {
     return { text: 'Libre', statusClass: 'status--free', Icon: Armchair };
   }
 
-  if (table.statut === 'a_payer') {
-    if (table.estado_cocina === 'servido') {
-      return { text: 'À encaisser', statusClass: 'status--payment', Icon: DollarSign };
-    }
+  if (table.estado_cocina === 'servido') {
+    return { text: 'Para pagar', statusClass: 'status--payment', Icon: DollarSign };
+  }
+
+  if (table.estado_cocina === 'listo') {
     return { text: 'À servir', statusClass: 'status--ready', Icon: HandPlatter };
   }
 
-  if (table.statut === 'occupee') {
-    if (table.estado_cocina === 'recibido') {
-      return { text: 'En cuisine', statusClass: 'status--preparing', Icon: Utensils };
-    }
-    return { text: 'En service', statusClass: 'status--serving', Icon: Utensils };
+  if (table.estado_cocina === 'recibido' || table.estado_cocina === 'no_enviado' || table.statut === 'occupee') {
+    return { text: 'En cuisine', statusClass: 'status--preparing', Icon: Utensils };
+  }
+
+  if (table.statut === 'a_payer') {
+    return { text: 'Para pagar', statusClass: 'status--payment', Icon: DollarSign };
   }
 
   return { text: 'Inconnu', statusClass: 'status--unknown', Icon: Armchair };

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -687,20 +687,6 @@ body {
   color: #047857;
 }
 
-.status-card.status--serving {
-  border-color: #ea580c;
-  background-color: #fff7ed;
-  color: #7c2d12;
-}
-
-.status-card.status--serving .status-card__icon {
-  color: #f97316;
-}
-
-.status-card.status--serving .status-card__state {
-  color: #c2410c;
-}
-
 .status-card.status--preparing {
   border-color: #d97706;
   background-color: #fef3c7;
@@ -755,7 +741,6 @@ body {
 }
 
 .status-card.status--free .status-card__meta,
-.status-card.status--serving .status-card__meta,
 .status-card.status--preparing .status-card__meta,
 .status-card.status--ready .status-card__meta,
 .status-card.status--payment .status-card__meta {


### PR DESCRIPTION
## Summary
- align table status mapping with four supported labels and drop the serving state
- rename the payment label to "Para pagar" and keep the corresponding iconography consistent
- remove unused serving status styles from the global stylesheet

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d5bad22258832a850ecb8afcec3071