### PR TITLE
Fix takeaway completion status and daily report

### DIFF
--- a/pages/Ventes.tsx
+++ b/pages/Ventes.tsx
@@ -6,11 +6,13 @@ import { Table } from '../types';
 import OrderTimer from '../components/OrderTimer';
 
 const getTableStatus = (table: Table) => {
-  if (table.statut === 'libre') {
+  const hasActiveOrder = Boolean(table.commandeId);
+
+  if (table.statut === 'libre' || (!hasActiveOrder && table.statut !== 'a_payer')) {
     return { text: 'Libre', statusClass: 'status--free', Icon: Armchair };
   }
 
-  if (table.estado_cocina === 'servido') {
+  if (table.estado_cocina === 'servido' || table.estado_cocina === 'entregada' || table.statut === 'a_payer') {
     return { text: 'Para pagar', statusClass: 'status--payment', Icon: DollarSign };
   }
 
@@ -20,10 +22,6 @@ const getTableStatus = (table: Table) => {
 
   if (table.estado_cocina === 'recibido' || table.estado_cocina === 'no_enviado' || table.statut === 'occupee') {
     return { text: 'En cuisine', statusClass: 'status--preparing', Icon: Utensils };
-  }
-
-  if (table.statut === 'a_payer') {
-    return { text: 'Para pagar', statusClass: 'status--payment', Icon: DollarSign };
   }
 
   return { text: 'Inconnu', statusClass: 'status--unknown', Icon: Armchair };

--- a/types/index.ts
+++ b/types/index.ts
@@ -71,7 +71,7 @@ export interface Order {
   table_nom?: string;
   couverts: number;
   statut: 'en_cours' | 'finalisee' | 'pendiente_validacion';
-  estado_cocina: 'no_enviado' | 'recibido' | 'listo' | 'servido';
+  estado_cocina: 'no_enviado' | 'recibido' | 'listo' | 'servido' | 'entregada';
   date_creation: number; // timestamp
   date_envoi_cuisine?: number; // timestamp
   date_listo_cuisine?: number; // timestamp


### PR DESCRIPTION
## Summary
- treat the `entregada` takeaway status as a completed order in the customer tracker and order types
- improve table status detection so freed tables return to green and "entregada" maps to the payment state
- mark delivered takeaway orders as `entregada` in the API and make daily report generation resilient to date filters and login fetch errors

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d5c0bc5680832a9431fb2526e72d92