### PR TITLE
Align order urgency styles with timer palette

### DIFF
--- a/pages/Cuisine.tsx
+++ b/pages/Cuisine.tsx
@@ -4,12 +4,14 @@ import { api } from '../services/api';
 import { KitchenTicket as KitchenTicketOrder, OrderItem } from '../types';
 import { useAuth } from '../contexts/AuthContext';
 import OrderTimer from '../components/OrderTimer';
-import { getOrderUrgencyClass } from '../utils/orderUrgency';
+import { getOrderUrgencyStyles } from '../utils/orderUrgency';
 
 const KitchenTicketCard: React.FC<{ order: KitchenTicketOrder; onReady: (orderId: string) => void; canMarkReady: boolean }> = ({ order, onReady, canMarkReady }) => {
 
+    const urgencyStyles = getOrderUrgencyStyles(order.date_envoi_cuisine || Date.now());
+
     return (
-        <div className={`rounded-lg border shadow-md flex flex-col h-full ${getOrderUrgencyClass(order.date_envoi_cuisine || Date.now())}`}>
+        <div className={`rounded-lg border shadow-md flex flex-col h-full overflow-hidden transition-colors duration-300 ${urgencyStyles.container}`}>
             <header className="bg-brand-secondary text-white p-3 rounded-t-lg">
                 <div className="flex flex-col gap-2">
                     <h3 className="text-xl font-bold w-full">{order.table_nom || `À emporter #${order.id.slice(-4)}`}</h3>
@@ -21,7 +23,7 @@ const KitchenTicketCard: React.FC<{ order: KitchenTicketOrder; onReady: (orderId
                     </div>
                 </div>
             </header>
-            <div className="p-3 space-y-2 flex-1 overflow-y-auto">
+            <div className={`p-3 space-y-2 flex-1 overflow-y-auto transition-colors duration-300 ${urgencyStyles.content}`}>
                 {order.items.map((item: OrderItem) => (
                     <div key={item.id} className="p-2 bg-gray-50 rounded">
                         <p className="font-bold text-lg text-gray-900">{item.quantite}x {item.nom_produit}</p>
@@ -30,7 +32,7 @@ const KitchenTicketCard: React.FC<{ order: KitchenTicketOrder; onReady: (orderId
                 ))}
             </div>
             {canMarkReady && (
-                <footer className="p-3 border-t">
+                <footer className={`p-3 border-t transition-colors duration-300 ${urgencyStyles.content}`}>
                     <button onClick={() => onReady(order.id)} className="w-full bg-green-500 text-white font-bold py-3 rounded-lg text-lg flex items-center justify-center space-x-2 hover:bg-green-700 transition">
                         <ChefHat size={24}/>
                         <span>PRÊT</span>

--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -4,18 +4,18 @@ import { Order, OrderItem } from '../types';
 import { Eye, User, MapPin } from 'lucide-react';
 import Modal from '../components/Modal';
 import OrderTimer from '../components/OrderTimer';
-import { getOrderUrgencyClass } from '../utils/orderUrgency';
+import { getOrderUrgencyStyles } from '../utils/orderUrgency';
 
 const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => void, onDeliver?: (orderId: string) => void, isProcessing?: boolean }> = ({ order, onValidate, onDeliver, isProcessing }) => {
     const [isReceiptModalOpen, setIsReceiptModalOpen] = useState(false);
 
     const displayName = order.table_nom || `Commande #${order.id.slice(-6)}`;
     const timerStart = order.date_envoi_cuisine || order.date_creation;
-    const urgencyClass = getOrderUrgencyClass(timerStart);
+    const urgencyStyles = getOrderUrgencyStyles(timerStart);
 
     return (
         <>
-            <div className={`rounded-lg border shadow-md flex flex-col h-full overflow-hidden ${urgencyClass}`}>
+            <div className={`rounded-lg border shadow-md flex flex-col h-full overflow-hidden transition-colors duration-300 ${urgencyStyles.container}`}>
                 <header className="bg-brand-secondary text-white p-3 rounded-t-lg">
                     <div className="flex flex-col gap-3">
                         <h4 className="text-xl font-bold leading-tight">{displayName}</h4>
@@ -23,7 +23,7 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                     </div>
                 </header>
 
-                <div className="p-4 space-y-4 flex-1 bg-white/80">
+                <div className={`p-4 space-y-4 flex-1 transition-colors duration-300 ${urgencyStyles.content}`}>
                     {order.clientInfo && (
                         <div className="space-y-1 text-sm text-gray-700">
                             {order.clientInfo.nom && (
@@ -58,7 +58,7 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                     </div>
                 </div>
 
-                <footer className="p-4 border-t bg-white space-y-3">
+                <footer className={`p-4 border-t space-y-3 transition-colors duration-300 ${urgencyStyles.content}`}>
                     {order.statut === 'pendiente_validacion' && onValidate && (
                         <div className="space-y-2">
                             <button

--- a/utils/orderUrgency.ts
+++ b/utils/orderUrgency.ts
@@ -1,17 +1,68 @@
-export const getOrderUrgencyClass = (startTime?: number): string => {
+export type OrderUrgencyLevel = 'normal' | 'warning' | 'critical';
+
+export interface OrderUrgencyStyles {
+  level: OrderUrgencyLevel;
+  /**
+   * Classes applied on the ticket wrapper. They follow the same palette as the timer
+   * (brand primary for normal, yellow for warning, red for critical) while keeping
+   * enough contrast for borders and default text.
+   */
+  container: string;
+  /**
+   * Classes applied on inner content sections (body, footer…). These sections get
+   * a near-white background so text remains legible even when the wrapper switches
+   * to intense urgency colours.
+   */
+  content: string;
+}
+
+const URGENCY_STYLE_MAP: Record<OrderUrgencyLevel, Omit<OrderUrgencyStyles, 'level'>> = {
+  critical: {
+    container: 'bg-red-600 border-red-700 text-white',
+    content: 'bg-white/95 text-gray-900',
+  },
+  warning: {
+    container: 'bg-yellow-400 border-yellow-500 text-gray-900',
+    content: 'bg-white/95 text-gray-900',
+  },
+  normal: {
+    container: 'bg-brand-primary/20 border-brand-primary text-brand-secondary',
+    content: 'bg-white text-brand-text',
+  },
+};
+
+export const getOrderUrgencyLevel = (startTime?: number): OrderUrgencyLevel => {
   if (!startTime) {
-    return 'bg-white border-gray-300';
+    return 'normal';
   }
 
   const minutes = (Date.now() - startTime) / 60000;
 
-  if (minutes > 15) {
-    return 'bg-red-200 border-red-500';
+  if (minutes >= 20) {
+    return 'critical';
   }
 
-  if (minutes > 8) {
-    return 'bg-yellow-200 border-yellow-500';
+  if (minutes >= 10) {
+    return 'warning';
   }
 
-  return 'bg-white border-gray-300';
+  return 'normal';
 };
+
+export const getOrderUrgencyStyles = (startTime?: number): OrderUrgencyStyles => {
+  const level = getOrderUrgencyLevel(startTime);
+  const styles = URGENCY_STYLE_MAP[level];
+
+  return {
+    level,
+    container: styles.container,
+    content: styles.content,
+  };
+};
+
+/**
+ * @deprecated prefer using {@link getOrderUrgencyStyles} to access both the
+ * urgency level and the different sections' classes.
+ */
+export const getOrderUrgencyClass = (startTime?: number): string =>
+  getOrderUrgencyStyles(startTime).container;


### PR DESCRIPTION
## Summary
- align order urgency helper thresholds with the timer palette and expose structured style metadata
- update kitchen and takeaway cards to consume the new styles and keep their content backgrounds readable

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d5c5f5898c832a89de77d64c458dc6