### PR TITLE
Align takeaway cards with kitchen styling

### DIFF
--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -23,9 +23,9 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                     </div>
                 </header>
 
-                <div className="p-4 space-y-4 flex-1 bg-white/80">
+                <div className="p-3 space-y-3 flex-1 overflow-y-auto">
                     {order.clientInfo && (
-                        <div className="space-y-1 text-sm text-gray-700">
+                        <div className="space-y-1 text-sm text-gray-800 bg-white/90 rounded-md p-3 shadow-sm">
                             {order.clientInfo.nom && (
                                 <div className="flex items-center gap-2">
                                     <User size={14} />
@@ -33,7 +33,7 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                                 </div>
                             )}
                             {order.clientInfo.adresse && (
-                                <div className="flex items-start gap-2 text-sm text-gray-600">
+                                <div className="flex items-start gap-2 text-sm text-gray-700">
                                     <MapPin size={14} className="mt-0.5" />
                                     <span>{order.clientInfo.adresse}</span>
                                 </div>


### PR DESCRIPTION
## Summary
- harmonize the takeaway order card layout with the kitchen ticket card by aligning padding and scroll behavior
- ensure client information remains legible on urgency-colored backgrounds with a subtle white overlay

## Testing
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_b_68d5c74d53b0832a9134de724e0c4ba7