### PR TITLE
Improve staff login pin entry accessibility

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -513,9 +513,41 @@ body {
 }
 
 .pin-input {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
+  gap: 1.25rem;
+  padding: clamp(1.25rem, 3vw, 1.75rem);
+  border-radius: 1.25rem;
+  background: color-mix(in srgb, var(--color-surface) 85%, rgba(15, 23, 42, 0.08));
+  box-shadow: 0 18px 42px rgba(15, 23, 42, 0.12);
+  border: 1px solid color-mix(in srgb, var(--color-border-strong) 75%, transparent);
+}
+
+.pin-input:focus-within {
+  outline: 3px solid color-mix(in srgb, var(--color-accent) 75%, transparent);
+  outline-offset: 4px;
+  box-shadow: 0 22px 48px rgba(15, 23, 42, 0.18);
+}
+
+.pin-input__field {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.pin-input__live {
+  font-size: var(--font-size-xs);
+  color: var(--color-text-muted);
+  text-align: center;
+  min-height: 1.25rem;
 }
 
 .pin-pad {
@@ -554,7 +586,6 @@ body {
 .pin-indicator {
   display: flex;
   gap: clamp(0.5rem, 2vw, 0.75rem);
-  margin-bottom: 1.5rem;
 }
 
 .pin-indicator__slot {
@@ -575,6 +606,46 @@ body {
   display: flex;
   flex-direction: column;
   gap: clamp(1.25rem, 3vw, 1.75rem);
+}
+
+.modal-form__intro {
+  text-align: center;
+}
+
+.modal-form__help {
+  margin: 0;
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+}
+
+.modal-form__controls {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.5rem, 3vw, 2rem);
+}
+
+.modal-form__side {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  width: 100%;
+}
+
+.modal-form__actions {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+@media (min-width: 640px) {
+  .modal-form__controls {
+    flex-direction: row;
+    align-items: stretch;
+  }
+
+  .modal-form__side {
+    max-width: 14rem;
+  }
 }
 
 .modal-form__error {


### PR DESCRIPTION
## Summary
- add a real password input to the staff PIN keypad and wire up keyboard controls with aria-live feedback
- refresh the login modal layout with contextual help, grouped actions, and automatic focus when opened
- restyle the PIN panel for better contrast, spacing, and focus visibility

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d65f0e9fa0832aaec3c684580decd0