### PR TITLE
Fix Ventes table status classification

### DIFF
--- a/pages/Ventes.tsx
+++ b/pages/Ventes.tsx
@@ -6,12 +6,6 @@ import { Table } from '../types';
 import OrderTimer from '../components/OrderTimer';
 
 const getTableStatus = (table: Table) => {
-  const hasActiveOrder = Boolean(table.commandeId);
-
-  if (table.statut === 'libre' || (!hasActiveOrder && table.statut !== 'a_payer')) {
-    return { text: 'Libre', statusClass: 'status--free', Icon: Armchair };
-  }
-
   if (table.estado_cocina === 'servido' || table.estado_cocina === 'entregada' || table.statut === 'a_payer') {
     return { text: 'Para pagar', statusClass: 'status--payment', Icon: DollarSign };
   }
@@ -20,8 +14,12 @@ const getTableStatus = (table: Table) => {
     return { text: 'À servir', statusClass: 'status--ready', Icon: HandPlatter };
   }
 
-  if (table.estado_cocina === 'recibido' || table.estado_cocina === 'no_enviado' || table.statut === 'occupee') {
+  if (table.statut === 'occupee' || table.estado_cocina === 'no_enviado' || table.estado_cocina === 'recibido') {
     return { text: 'En cuisine', statusClass: 'status--preparing', Icon: Utensils };
+  }
+
+  if (table.statut === 'libre' && (!table.estado_cocina || table.estado_cocina === '')) {
+    return { text: 'Libre', statusClass: 'status--free', Icon: Armchair };
   }
 
   return { text: 'Inconnu', statusClass: 'status--unknown', Icon: Armchair };


### PR DESCRIPTION
## Summary
- update the sales view status resolver to consider only the table status and kitchen state for free tables
- keep occupied and kitchen states in the preparing bucket even if an order id is missing

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d66272814c832a8720d10fc12ca809