### PR TITLE
feat: secure role login access via proxy

### DIFF
--- a/components/ReportModal.tsx
+++ b/components/ReportModal.tsx
@@ -19,16 +19,22 @@ const ReportStat: React.FC<{ icon: React.ReactNode, label: string, value: string
 const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpen, onClose }) => {
     const [report, setReport] = useState<DailyReport | null>(null);
     const [loading, setLoading] = useState(true);
+    const [loginsError, setLoginsError] = useState<string | null>(null);
 
     useEffect(() => {
         if (isOpen) {
             const fetchReport = async () => {
                 setLoading(true);
+                setLoginsError(null);
                 try {
                     const data = await api.generateDailyReport();
                     setReport(data);
                 } catch (error) {
-                    console.error("Failed to generate report:", error);
+                    console.error('Échec de la récupération des connexions pour le rapport quotidien', error);
+                    setReport(null);
+                    setLoginsError(
+                        "Impossible de récupérer les connexions depuis le proxy sécurisé. Veuillez réessayer plus tard.",
+                    );
                 } finally {
                     setLoading(false);
                 }
@@ -110,7 +116,14 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
             <>
                 <div className="p-6 max-h-[70vh] overflow-y-auto">
                      {loading && <p>Génération du rapport...</p>}
-                     {!loading && !report && <p className="text-red-500">Impossible de générer le rapport.</p>}
+                     {!loading && loginsError && (
+                        <div className="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+                            {loginsError}
+                        </div>
+                     )}
+                     {!loading && !report && !loginsError && (
+                        <p className="text-red-500">Impossible de générer le rapport.</p>
+                     )}
                      {!loading && report && (
                          <div className="space-y-6">
                             <div className="text-center border-b pb-4">

--- a/netlify/functions/role-logins.ts
+++ b/netlify/functions/role-logins.ts
@@ -1,0 +1,124 @@
+import type { Handler } from '@netlify/functions';
+import { createClient } from '@supabase/supabase-js';
+
+type EnvConfig = {
+  url: string;
+  serviceKey: string;
+};
+
+const getEnvConfig = (): EnvConfig => {
+  const url = process.env.SUPABASE_URL ?? process.env.VITE_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!url) {
+    throw new Error('Missing SUPABASE_URL environment variable for role login proxy.');
+  }
+
+  if (!serviceKey) {
+    throw new Error('Missing SUPABASE_SERVICE_ROLE_KEY environment variable for role login proxy.');
+  }
+
+  return { url, serviceKey };
+};
+
+const { url, serviceKey } = getEnvConfig();
+
+const supabase = createClient(url, serviceKey, {
+  auth: {
+    persistSession: false,
+  },
+});
+
+type RoleLoginRow = {
+  id: string;
+  role_id: string;
+  login_at: string;
+  roles: {
+    id: string;
+    name: string;
+  } | null;
+};
+
+type RoleLoginPayload = {
+  roleId?: string;
+  loginAt?: string;
+};
+
+const jsonResponse = (statusCode: number, body: unknown) => ({
+  statusCode,
+  headers: {
+    'Content-Type': 'application/json',
+    'Access-Control-Allow-Origin': '*',
+  },
+  body: JSON.stringify(body),
+});
+
+const handler: Handler = async event => {
+  if (event.httpMethod === 'OPTIONS') {
+    return {
+      statusCode: 204,
+      headers: {
+        'Access-Control-Allow-Origin': '*',
+        'Access-Control-Allow-Methods': 'GET,POST,OPTIONS',
+        'Access-Control-Allow-Headers': 'Content-Type',
+      },
+    };
+  }
+
+  try {
+    if (event.httpMethod === 'POST') {
+      const payload = (event.body ? JSON.parse(event.body) : {}) as RoleLoginPayload;
+      const { roleId, loginAt } = payload;
+
+      if (!roleId) {
+        return jsonResponse(400, { message: 'roleId is required' });
+      }
+
+      const timestamp = loginAt ?? new Date().toISOString();
+      const { error } = await supabase.from('role_logins').insert({ role_id: roleId, login_at: timestamp });
+
+      if (error) {
+        console.error('Failed to insert role login', error);
+        return jsonResponse(500, { message: 'Failed to insert role login', details: error.message });
+      }
+
+      return jsonResponse(200, { roleId, loginAt: timestamp });
+    }
+
+    if (event.httpMethod === 'GET') {
+      const startIso = event.queryStringParameters?.startIso;
+
+      if (!startIso) {
+        return jsonResponse(400, { message: 'startIso query parameter is required' });
+      }
+
+      const { data, error } = await supabase
+        .from('role_logins')
+        .select('id, role_id, login_at, roles ( id, name )')
+        .gte('login_at', startIso)
+        .order('login_at', { ascending: true });
+
+      if (error) {
+        console.error('Failed to fetch role logins', error);
+        return jsonResponse(500, { message: 'Failed to fetch role logins', details: error.message });
+      }
+
+      const rows = (data ?? []) as RoleLoginRow[];
+      const logins = rows.map(row => ({
+        roleId: row.role_id,
+        roleName: row.roles?.name ?? 'Rôle inconnu',
+        loginAt: row.login_at,
+      }));
+
+      return jsonResponse(200, { data: logins });
+    }
+
+    return jsonResponse(405, { message: 'Method not allowed' });
+  } catch (error) {
+    console.error('Unhandled error in role login proxy', error);
+    const message = error instanceof Error ? error.message : 'Unknown error';
+    return jsonResponse(500, { message: 'Unexpected error', details: message });
+  }
+};
+
+export { handler };

--- a/services/roleLoginsProxy.ts
+++ b/services/roleLoginsProxy.ts
@@ -1,0 +1,55 @@
+import type { RoleLogin } from '../types';
+
+const PROXY_ENDPOINT = '/.netlify/functions/role-logins';
+
+type FetchResponse = {
+  data: RoleLogin[];
+};
+
+type InsertResponse = {
+  roleId: string;
+  loginAt: string;
+};
+
+const parseError = async (response: Response): Promise<never> => {
+  let details: string | undefined;
+
+  try {
+    const payload = await response.json();
+    if (payload && typeof payload === 'object') {
+      details = typeof payload.details === 'string' ? payload.details : payload.message;
+    }
+  } catch (error) {
+    // Ignore JSON parsing errors and fallback to status text
+  }
+
+  const reason = details ?? response.statusText;
+  throw new Error(`Role login proxy request failed (${response.status}): ${reason}`);
+};
+
+export const logRoleLogin = async (roleId: string, loginAt?: string): Promise<InsertResponse> => {
+  const response = await fetch(PROXY_ENDPOINT, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ roleId, loginAt }),
+  });
+
+  if (!response.ok) {
+    await parseError(response);
+  }
+
+  const payload = (await response.json()) as InsertResponse;
+  return payload;
+};
+
+export const fetchRoleLoginsSince = async (startIso: string): Promise<RoleLogin[]> => {
+  const response = await fetch(`${PROXY_ENDPOINT}?startIso=${encodeURIComponent(startIso)}`);
+  if (!response.ok) {
+    await parseError(response);
+  }
+
+  const payload = (await response.json()) as FetchResponse;
+  return payload.data ?? [];
+};


### PR DESCRIPTION
## Summary
- add a Netlify function that proxies role login inserts and reads with the Supabase service key
- call the proxy from the client to log PIN logins and retrieve role login history for reports
- surface a user-facing error state in the daily report modal when login retrieval fails

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d66387f098832a87fe5eefe099582a