### PR TITLE
Refine kitchen ticket styling with urgency accents

### DIFF
--- a/pages/Cuisine.tsx
+++ b/pages/Cuisine.tsx
@@ -9,32 +9,62 @@ import { getOrderUrgencyStyles } from '../utils/orderUrgency';
 const KitchenTicketCard: React.FC<{ order: KitchenTicketOrder; onReady: (orderId: string) => void; canMarkReady: boolean }> = ({ order, onReady, canMarkReady }) => {
 
     const urgencyStyles = getOrderUrgencyStyles(order.date_envoi_cuisine || Date.now());
+    const urgencyLabelMap: Record<typeof urgencyStyles.level, string> = {
+        normal: 'Normal',
+        warning: 'À surveiller',
+        critical: 'Urgent',
+    };
 
     return (
-        <div className={`rounded-lg border shadow-md flex flex-col h-full overflow-hidden transition-colors duration-300 ${urgencyStyles.container}`}>
-            <header className="bg-brand-secondary text-white p-3 rounded-t-lg">
-                <div className="flex flex-col gap-2">
-                    <h3 className="text-xl font-bold w-full">{order.table_nom || `À emporter #${order.id.slice(-4)}`}</h3>
-                    <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-1">
-                        <OrderTimer startTime={order.date_envoi_cuisine || Date.now()} className="w-full justify-center sm:w-auto" />
-                        <p className="text-xs text-white/80 text-center sm:text-right">
+        <div className={`relative flex h-full flex-col overflow-hidden rounded-xl border bg-brand-surface shadow-lg transition-shadow duration-300 hover:shadow-xl ${urgencyStyles.border}`}>
+            <span aria-hidden className={`absolute inset-y-0 left-0 w-1.5 ${urgencyStyles.accent}`} />
+            <header className="border-b border-brand-border/60 px-5 pt-5 pb-4">
+                <div className="flex flex-col gap-4">
+                    <div className="flex items-start justify-between gap-3">
+                        <div className="space-y-1">
+                            <p className="text-[11px] font-semibold uppercase tracking-[0.35em] text-brand-text-muted">Commande</p>
+                            <h3 className="text-2xl font-semibold text-brand-heading">
+                                {order.table_nom || `À emporter #${order.id.slice(-4)}`}
+                            </h3>
+                        </div>
+                        <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${urgencyStyles.badge}`}>
+                            <span className={`h-2 w-2 rounded-full ${urgencyStyles.accent}`} />
+                            <span>{urgencyLabelMap[urgencyStyles.level]}</span>
+                        </span>
+                    </div>
+                    <div className="flex flex-wrap items-end justify-between gap-3">
+                        <OrderTimer startTime={order.date_envoi_cuisine || Date.now()} className="text-base" />
+                        <p className="text-xs font-medium text-brand-text-muted sm:text-right">
                             Envoyé {new Date(order.date_envoi_cuisine || Date.now()).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}
                         </p>
                     </div>
                 </div>
             </header>
-            <div className={`p-3 space-y-2 flex-1 overflow-y-auto transition-colors duration-300 ${urgencyStyles.content}`}>
-                {order.items.map((item: OrderItem) => (
-                    <div key={item.id} className="p-2 bg-gray-50 rounded">
-                        <p className="font-bold text-lg text-gray-900">{item.quantite}x {item.nom_produit}</p>
-                        {item.commentaire && <p className="text-sm text-gray-600 italic pl-2">- {item.commentaire}</p>}
-                    </div>
-                ))}
+            <div className="flex-1 overflow-y-auto px-5 py-4">
+                <ul className="space-y-3">
+                    {order.items.map((item: OrderItem) => (
+                        <li key={item.id} className="rounded-lg border border-brand-border/70 bg-brand-surface-elevated px-4 py-3 shadow-sm">
+                            <div className="flex items-baseline justify-between gap-3">
+                                <p className="text-lg font-semibold text-brand-heading">{item.nom_produit}</p>
+                                <span className="text-2xl font-bold text-brand-heading">{item.quantite}×</span>
+                            </div>
+                            {item.commentaire && (
+                                <div className="mt-3 rounded-md border border-dashed border-brand-border/80 bg-brand-accent-soft/50 px-3 py-2">
+                                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-brand-text-muted">Commentaire</p>
+                                    <p className="mt-1 text-sm text-brand-heading">{item.commentaire}</p>
+                                </div>
+                            )}
+                        </li>
+                    ))}
+                </ul>
             </div>
             {canMarkReady && (
-                <footer className={`p-3 border-t transition-colors duration-300 ${urgencyStyles.content}`}>
-                    <button onClick={() => onReady(order.id)} className="w-full bg-green-500 text-white font-bold py-3 rounded-lg text-lg flex items-center justify-center space-x-2 hover:bg-green-700 transition">
-                        <ChefHat size={24}/>
+                <footer className="border-t border-brand-border/60 px-5 pb-5 pt-4">
+                    <button
+                        onClick={() => onReady(order.id)}
+                        className="group inline-flex w-full items-center justify-center gap-3 rounded-lg border-2 border-transparent bg-status-success px-4 py-3 text-lg font-semibold uppercase tracking-[0.2em] text-white shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-status-success/70 focus-visible:ring-offset-2 hover:bg-status-success-hover"
+                    >
+                        <ChefHat size={22} className="shrink-0" />
                         <span>PRÊT</span>
                     </button>
                 </footer>

--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -6,62 +6,80 @@ import Modal from '../components/Modal';
 import OrderTimer from '../components/OrderTimer';
 import { getOrderUrgencyStyles } from '../utils/orderUrgency';
 
+
 const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => void, onDeliver?: (orderId: string) => void, isProcessing?: boolean }> = ({ order, onValidate, onDeliver, isProcessing }) => {
     const [isReceiptModalOpen, setIsReceiptModalOpen] = useState(false);
 
     const displayName = order.table_nom || `Commande #${order.id.slice(-6)}`;
     const timerStart = order.date_envoi_cuisine || order.date_creation;
     const urgencyStyles = getOrderUrgencyStyles(timerStart);
+    const urgencyLabelMap: Record<typeof urgencyStyles.level, string> = {
+        normal: 'Normal',
+        warning: 'À surveiller',
+        critical: 'Urgent',
+    };
 
     return (
         <>
-            <div className={`rounded-lg border shadow-md flex flex-col h-full overflow-hidden transition-colors duration-300 ${urgencyStyles.container}`}>
-                <header className="bg-brand-secondary text-white p-3 rounded-t-lg">
+            <div className={`relative flex h-full flex-col overflow-hidden rounded-xl border bg-brand-surface shadow-md transition-shadow duration-300 hover:shadow-lg ${urgencyStyles.border}`}>
+                <span aria-hidden className={`absolute inset-y-0 left-0 w-1 ${urgencyStyles.accent}`} />
+                <header className="border-b border-brand-border/60 px-5 pt-5 pb-4">
                     <div className="flex flex-col gap-3">
-                        <h4 className="text-xl font-bold leading-tight">{displayName}</h4>
-                        <OrderTimer startTime={timerStart} className="w-full justify-center" />
+                        <div className="flex items-start justify-between gap-3">
+                            <div className="space-y-1">
+                                <h4 className="text-xl font-semibold leading-tight text-brand-heading">{displayName}</h4>
+                                <p className="text-xs text-brand-text-muted">
+                                    Commande envoyée {new Date(timerStart).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}
+                                </p>
+                            </div>
+                            <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${urgencyStyles.badge}`}>
+                                <span className={`h-2 w-2 rounded-full ${urgencyStyles.accent}`} />
+                                <span>{urgencyLabelMap[urgencyStyles.level]}</span>
+                            </span>
+                        </div>
+                        <OrderTimer startTime={timerStart} className="text-base" />
                     </div>
                 </header>
 
-
-              <div className="p-3 space-y-3 flex-1 overflow-y-auto">
-
-                
+                <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
                     {order.clientInfo && (
-                        <div className="space-y-1 text-sm text-gray-800 bg-white/90 rounded-md p-3 shadow-sm">
+                        <div className="space-y-2 rounded-lg border border-brand-border/60 bg-brand-surface-elevated p-4 shadow-sm">
                             {order.clientInfo.nom && (
-                                <div className="flex items-center gap-2">
-                                    <User size={14} />
+                                <div className="flex items-center gap-2 text-sm text-brand-heading">
+                                    <User size={16} className={urgencyStyles.icon} />
                                     <span className="font-medium">{order.clientInfo.nom}</span>
                                 </div>
                             )}
                             {order.clientInfo.adresse && (
-                                <div className="flex items-start gap-2 text-sm text-gray-700">
-                                    <MapPin size={14} className="mt-0.5" />
+                                <div className="flex items-start gap-2 text-sm text-brand-text">
+                                    <MapPin size={16} className={`mt-0.5 ${urgencyStyles.icon}`} />
                                     <span>{order.clientInfo.adresse}</span>
                                 </div>
                             )}
                         </div>
                     )}
 
-                    <div className="space-y-2">
-                        <h5 className="text-sm font-semibold text-gray-800 uppercase tracking-wide">Articles</h5>
-                        <ul className="space-y-1">
+                    <div className="space-y-3">
+                        <h5 className="text-xs font-semibold uppercase tracking-[0.2em] text-brand-text-muted">Articles</h5>
+                        <ul className="space-y-2">
                             {order.items.map((item: OrderItem) => (
-                                <li key={item.id} className="text-sm text-gray-700 bg-gray-50 rounded-md px-3 py-2">
-                                    <span className="font-semibold text-gray-900">{item.quantite}x</span> {item.nom_produit}
+                                <li key={item.id} className="rounded-lg border border-brand-border/60 bg-brand-surface-elevated px-4 py-3 text-sm text-brand-heading shadow-sm">
+                                    <div className="flex items-baseline justify-between gap-3">
+                                        <span className="font-semibold">{item.nom_produit}</span>
+                                        <span className="text-lg font-bold">{item.quantite}×</span>
+                                    </div>
                                 </li>
                             ))}
                         </ul>
                     </div>
 
-                    <div className="flex items-center justify-between text-gray-900 font-semibold text-lg pt-2 border-t border-gray-200">
+                    <div className="flex items-center justify-between rounded-lg border border-brand-border/60 bg-brand-surface-elevated px-4 py-3 font-semibold text-brand-heading shadow-sm">
                         <span>Total</span>
                         <span>{order.total.toFixed(2)} €</span>
                     </div>
                 </div>
 
-                <footer className={`p-4 border-t space-y-3 transition-colors duration-300 ${urgencyStyles.content}`}>
+                <footer className="border-t border-brand-border/60 px-5 pb-5 pt-4">
                     {order.statut === 'pendiente_validacion' && onValidate && (
                         <div className="space-y-2">
                             <button
@@ -69,7 +87,7 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                                 className="w-full ui-btn ui-btn-secondary"
                                 type="button"
                             >
-                                <Eye size={16} /> {order.receipt_url ? 'Voir le justificatif' : 'Justificatif indisponible'}
+                                <Eye size={16} className={urgencyStyles.icon} /> {order.receipt_url ? 'Voir le justificatif' : 'Justificatif indisponible'}
                             </button>
                             <button
                                 onClick={() => onValidate(order.id)}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1467,3 +1467,56 @@ p {
   color: #f8fafc;
   line-height: var(--line-height-snug);
 }
+@layer utilities {
+  .urgency-border-normal {
+    border-color: #c7d2fe;
+  }
+
+  .urgency-border-warning {
+    border-color: #facc15;
+  }
+
+  .urgency-border-critical {
+    border-color: #fca5a5;
+  }
+
+  .urgency-accent-normal {
+    background-color: #2563eb;
+  }
+
+  .urgency-accent-warning {
+    background-color: #f59e0b;
+  }
+
+  .urgency-accent-critical {
+    background-color: #dc2626;
+  }
+
+  .urgency-badge-normal {
+    background-color: #eff4ff;
+    color: #1d4ed8;
+  }
+
+  .urgency-badge-warning {
+    background-color: #fef3c7;
+    color: #92400e;
+  }
+
+  .urgency-badge-critical {
+    background-color: #fee2e2;
+    color: #b91c1c;
+  }
+
+  .urgency-icon-normal {
+    color: #2563eb;
+  }
+
+  .urgency-icon-warning {
+    color: #b45309;
+  }
+
+  .urgency-icon-critical {
+    color: #b91c1c;
+  }
+}
+

--- a/utils/orderUrgency.ts
+++ b/utils/orderUrgency.ts
@@ -2,32 +2,34 @@ export type OrderUrgencyLevel = 'normal' | 'warning' | 'critical';
 
 export interface OrderUrgencyStyles {
   level: OrderUrgencyLevel;
-  /**
-   * Classes applied on the ticket wrapper. They follow the same palette as the timer
-   * (brand primary for normal, yellow for warning, red for critical) while keeping
-   * enough contrast for borders and default text.
-   */
-  container: string;
-  /**
-   * Classes applied on inner content sections (body, footer…). These sections get
-   * a near-white background so text remains legible even when the wrapper switches
-   * to intense urgency colours.
-   */
-  content: string;
+  /** Classes applied on the ticket wrapper border. */
+  border: string;
+  /** Accent colour used for badges or sidebands. */
+  accent: string;
+  /** Background and text colour for urgency badges. */
+  badge: string;
+  /** Icon/text colour accent for subtle highlights. */
+  icon: string;
 }
 
 const URGENCY_STYLE_MAP: Record<OrderUrgencyLevel, Omit<OrderUrgencyStyles, 'level'>> = {
   critical: {
-    container: 'bg-red-600 border-red-700 text-white',
-    content: 'bg-white/95 text-gray-900',
+    border: 'urgency-border-critical',
+    accent: 'urgency-accent-critical',
+    badge: 'urgency-badge-critical',
+    icon: 'urgency-icon-critical',
   },
   warning: {
-    container: 'bg-yellow-400 border-yellow-500 text-gray-900',
-    content: 'bg-white/95 text-gray-900',
+    border: 'urgency-border-warning',
+    accent: 'urgency-accent-warning',
+    badge: 'urgency-badge-warning',
+    icon: 'urgency-icon-warning',
   },
   normal: {
-    container: 'bg-brand-primary/20 border-brand-primary text-brand-secondary',
-    content: 'bg-white text-brand-text',
+    border: 'urgency-border-normal',
+    accent: 'urgency-accent-normal',
+    badge: 'urgency-badge-normal',
+    icon: 'urgency-icon-normal',
   },
 };
 
@@ -55,8 +57,10 @@ export const getOrderUrgencyStyles = (startTime?: number): OrderUrgencyStyles =>
 
   return {
     level,
-    container: styles.container,
-    content: styles.content,
+    border: styles.border,
+    accent: styles.accent,
+    badge: styles.badge,
+    icon: styles.icon,
   };
 };
 
@@ -65,4 +69,4 @@ export const getOrderUrgencyStyles = (startTime?: number): OrderUrgencyStyles =>
  * urgency level and the different sections' classes.
  */
 export const getOrderUrgencyClass = (startTime?: number): string =>
-  getOrderUrgencyStyles(startTime).container;
+  getOrderUrgencyStyles(startTime).border;


### PR DESCRIPTION
## Summary
- redesign the kitchen ticket card with a neutral surface, urgency badge, and clearer typography
- expose urgency border, accent, badge, and icon classes from `getOrderUrgencyStyles` and reuse them in takeaway tickets
- add Tailwind utility classes to style the new urgency borders, badges, and icon colours

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d665d8b2e4832a9f553cb015aa776f