### PR TITLE
Align kitchen and takeaway styling with urgency palette

### DIFF
--- a/pages/Cuisine.tsx
+++ b/pages/Cuisine.tsx
@@ -12,18 +12,18 @@ const KitchenTicketCard: React.FC<{ order: KitchenTicketOrder; onReady: (orderId
     const urgencyLabelMap: Record<typeof urgencyStyles.level, string> = {
         normal: 'Normal',
         warning: 'À surveiller',
-        critical: 'Urgent',
+        critical: 'Critique',
     };
 
     return (
-        <div className={`relative flex h-full flex-col overflow-hidden rounded-xl border bg-brand-surface shadow-lg transition-shadow duration-300 hover:shadow-xl ${urgencyStyles.border}`}>
+        <div className={`relative flex h-full flex-col overflow-hidden rounded-xl border bg-white text-gray-900 shadow-lg transition-shadow duration-300 hover:shadow-xl ${urgencyStyles.border}`}>
             <span aria-hidden className={`absolute inset-y-0 left-0 w-1.5 ${urgencyStyles.accent}`} />
-            <header className="border-b border-brand-border/60 px-5 pt-5 pb-4">
+            <header className="border-b border-gray-200 px-5 pt-5 pb-4">
                 <div className="flex flex-col gap-4">
                     <div className="flex items-start justify-between gap-3">
                         <div className="space-y-1">
-                            <p className="text-[11px] font-semibold uppercase tracking-[0.35em] text-brand-text-muted">Commande</p>
-                            <h3 className="text-2xl font-semibold text-brand-heading">
+                            <p className="text-[11px] font-semibold uppercase tracking-[0.35em] text-gray-500">Commande</p>
+                            <h3 className="text-2xl font-semibold text-gray-900">
                                 {order.table_nom || `À emporter #${order.id.slice(-4)}`}
                             </h3>
                         </div>
@@ -34,7 +34,7 @@ const KitchenTicketCard: React.FC<{ order: KitchenTicketOrder; onReady: (orderId
                     </div>
                     <div className="flex flex-wrap items-end justify-between gap-3">
                         <OrderTimer startTime={order.date_envoi_cuisine || Date.now()} className="text-base" />
-                        <p className="text-xs font-medium text-brand-text-muted sm:text-right">
+                        <p className="text-xs font-medium text-gray-500 sm:text-right">
                             Envoyé {new Date(order.date_envoi_cuisine || Date.now()).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}
                         </p>
                     </div>
@@ -43,15 +43,15 @@ const KitchenTicketCard: React.FC<{ order: KitchenTicketOrder; onReady: (orderId
             <div className="flex-1 overflow-y-auto px-5 py-4">
                 <ul className="space-y-3">
                     {order.items.map((item: OrderItem) => (
-                        <li key={item.id} className="rounded-lg border border-brand-border/70 bg-brand-surface-elevated px-4 py-3 shadow-sm">
+                        <li key={item.id} className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 shadow-sm">
                             <div className="flex items-baseline justify-between gap-3">
-                                <p className="text-lg font-semibold text-brand-heading">{item.nom_produit}</p>
-                                <span className="text-2xl font-bold text-brand-heading">{item.quantite}×</span>
+                                <p className="text-lg font-semibold text-gray-900">{item.nom_produit}</p>
+                                <span className="text-2xl font-bold text-gray-900">{item.quantite}×</span>
                             </div>
                             {item.commentaire && (
-                                <div className="mt-3 rounded-md border border-dashed border-brand-border/80 bg-brand-accent-soft/50 px-3 py-2">
-                                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-brand-text-muted">Commentaire</p>
-                                    <p className="mt-1 text-sm text-brand-heading">{item.commentaire}</p>
+                                <div className="mt-3 rounded-md border border-dashed border-blue-200 bg-blue-50 px-3 py-2">
+                                    <p className="text-[11px] font-semibold uppercase tracking-[0.18em] text-blue-700">Commentaire</p>
+                                    <p className="mt-1 text-sm text-gray-900">{item.commentaire}</p>
                                 </div>
                             )}
                         </li>
@@ -59,7 +59,7 @@ const KitchenTicketCard: React.FC<{ order: KitchenTicketOrder; onReady: (orderId
                 </ul>
             </div>
             {canMarkReady && (
-                <footer className="border-t border-brand-border/60 px-5 pb-5 pt-4">
+                <footer className="border-t border-gray-200 px-5 pb-5 pt-4">
                     <button
                         onClick={() => onReady(order.id)}
                         className="group inline-flex w-full items-center justify-center gap-3 rounded-lg border-2 border-transparent bg-status-success px-4 py-3 text-lg font-semibold uppercase tracking-[0.2em] text-white shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-status-success/70 focus-visible:ring-offset-2 hover:bg-status-success-hover"
@@ -122,13 +122,13 @@ const Cuisine: React.FC = () => {
     };
 
     // FIX: Use the 'loading' state variable that is defined within the component.
-    if (loading) return <div className="text-gray-800">Chargement des commandes pour la cuisine...</div>;
+    if (loading) return <div className="text-gray-700">Chargement des commandes pour la cuisine...</div>;
 
     return (
         <div className="h-full flex flex-col">
-            <h1 className="text-3xl font-bold mb-6 text-white">Vue Cuisine</h1>
+            <h1 className="mb-6 text-3xl font-bold text-gray-900">Vue Cuisine</h1>
             {orders.length === 0 ? (
-                <div className="flex-1 flex items-center justify-center text-2xl text-gray-700">Aucune commande en préparation.</div>
+                <div className="flex flex-1 items-center justify-center text-2xl text-gray-500">Aucune commande en préparation.</div>
             ) : (
                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 flex-1">
                     {orders.map(order => (

--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -16,19 +16,19 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
     const urgencyLabelMap: Record<typeof urgencyStyles.level, string> = {
         normal: 'Normal',
         warning: 'À surveiller',
-        critical: 'Urgent',
+        critical: 'Critique',
     };
 
     return (
         <>
-            <div className={`relative flex h-full flex-col overflow-hidden rounded-xl border bg-brand-surface shadow-md transition-shadow duration-300 hover:shadow-lg ${urgencyStyles.border}`}>
+            <div className={`relative flex h-full flex-col overflow-hidden rounded-xl border bg-white text-gray-900 shadow-md transition-shadow duration-300 hover:shadow-lg ${urgencyStyles.border}`}>
                 <span aria-hidden className={`absolute inset-y-0 left-0 w-1 ${urgencyStyles.accent}`} />
-                <header className="border-b border-brand-border/60 px-5 pt-5 pb-4">
+                <header className="border-b border-gray-200 px-5 pt-5 pb-4">
                     <div className="flex flex-col gap-3">
                         <div className="flex items-start justify-between gap-3">
                             <div className="space-y-1">
-                                <h4 className="text-xl font-semibold leading-tight text-brand-heading">{displayName}</h4>
-                                <p className="text-xs text-brand-text-muted">
+                                <h4 className="text-xl font-semibold leading-tight text-gray-900">{displayName}</h4>
+                                <p className="text-xs text-gray-500">
                                     Commande envoyée {new Date(timerStart).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}
                                 </p>
                             </div>
@@ -43,43 +43,43 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
 
                 <div className="flex-1 space-y-4 overflow-y-auto px-5 py-4">
                     {order.clientInfo && (
-                        <div className="space-y-2 rounded-lg border border-brand-border/60 bg-brand-surface-elevated p-4 shadow-sm">
+                        <div className="space-y-2 rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
                             {order.clientInfo.nom && (
-                                <div className="flex items-center gap-2 text-sm text-brand-heading">
+                                <div className="flex items-center gap-2 text-sm text-gray-900">
                                     <User size={16} className={urgencyStyles.icon} />
                                     <span className="font-medium">{order.clientInfo.nom}</span>
                                 </div>
                             )}
                             {order.clientInfo.adresse && (
-                                <div className="flex items-start gap-2 text-sm text-brand-text">
-                                    <MapPin size={16} className={`mt-0.5 ${urgencyStyles.icon}`} />
-                                    <span>{order.clientInfo.adresse}</span>
+                                <div className="flex items-start gap-2 text-sm text-gray-700">
+                                    <MapPin size={16} className={`mt-0.5 text-gray-500 ${urgencyStyles.icon}`} />
+                                    <span className="text-gray-700">{order.clientInfo.adresse}</span>
                                 </div>
                             )}
                         </div>
                     )}
 
                     <div className="space-y-3">
-                        <h5 className="text-xs font-semibold uppercase tracking-[0.2em] text-brand-text-muted">Articles</h5>
+                        <h5 className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Articles</h5>
                         <ul className="space-y-2">
                             {order.items.map((item: OrderItem) => (
-                                <li key={item.id} className="rounded-lg border border-brand-border/60 bg-brand-surface-elevated px-4 py-3 text-sm text-brand-heading shadow-sm">
-                                    <div className="flex items-baseline justify-between gap-3">
-                                        <span className="font-semibold">{item.nom_produit}</span>
-                                        <span className="text-lg font-bold">{item.quantite}×</span>
+                                <li key={item.id} className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-900 shadow-sm">
+                                    <div className="flex items-baseline justify-between gap-3 text-gray-900">
+                                        <span className="font-semibold text-gray-900">{item.nom_produit}</span>
+                                        <span className="text-lg font-bold text-gray-900">{item.quantite}×</span>
                                     </div>
                                 </li>
                             ))}
                         </ul>
                     </div>
 
-                    <div className="flex items-center justify-between rounded-lg border border-brand-border/60 bg-brand-surface-elevated px-4 py-3 font-semibold text-brand-heading shadow-sm">
+                    <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 font-semibold text-gray-900 shadow-sm">
                         <span>Total</span>
-                        <span>{order.total.toFixed(2)} €</span>
+                        <span className="text-gray-900">{order.total.toFixed(2)} €</span>
                     </div>
                 </div>
 
-                <footer className="border-t border-brand-border/60 px-5 pb-5 pt-4">
+                <footer className="border-t border-gray-200 px-5 pb-5 pt-4">
                     {order.statut === 'pendiente_validacion' && onValidate && (
                         <div className="space-y-2">
                             <button
@@ -181,11 +181,11 @@ const ParaLlevar: React.FC = () => {
         }
     };
 
-    if (loading) return <div className="text-gray-800">Chargement des commandes à emporter...</div>;
+    if (loading) return <div className="text-gray-700">Chargement des commandes à emporter...</div>;
 
     return (
         <div>
-            <h1 className="text-heading mb-6">Commandes à Emporter</h1>
+            <h1 className="mb-6 text-3xl font-bold text-gray-900">Commandes à Emporter</h1>
             <div className="grid grid-cols-1 gap-8 sm:grid-cols-2">
                 {/* Column for validation */}
                 <div className="bg-gray-100 p-4 rounded-xl">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1469,7 +1469,7 @@ p {
 }
 @layer utilities {
   .urgency-border-normal {
-    border-color: #c7d2fe;
+    border-color: #2563eb;
   }
 
   .urgency-border-warning {
@@ -1477,7 +1477,7 @@ p {
   }
 
   .urgency-border-critical {
-    border-color: #fca5a5;
+    border-color: #ef4444;
   }
 
   .urgency-accent-normal {
@@ -1485,15 +1485,15 @@ p {
   }
 
   .urgency-accent-warning {
-    background-color: #f59e0b;
+    background-color: #facc15;
   }
 
   .urgency-accent-critical {
-    background-color: #dc2626;
+    background-color: #ef4444;
   }
 
   .urgency-badge-normal {
-    background-color: #eff4ff;
+    background-color: #dbeafe;
     color: #1d4ed8;
   }
 
@@ -1512,11 +1512,11 @@ p {
   }
 
   .urgency-icon-warning {
-    color: #b45309;
+    color: #ca8a04;
   }
 
   .urgency-icon-critical {
-    color: #b91c1c;
+    color: #ef4444;
   }
 }
 

--- a/utils/orderUrgency.ts
+++ b/utils/orderUrgency.ts
@@ -14,22 +14,22 @@ export interface OrderUrgencyStyles {
 
 const URGENCY_STYLE_MAP: Record<OrderUrgencyLevel, Omit<OrderUrgencyStyles, 'level'>> = {
   critical: {
-    border: 'urgency-border-critical',
-    accent: 'urgency-accent-critical',
-    badge: 'urgency-badge-critical',
-    icon: 'urgency-icon-critical',
+    border: 'border-red-500 urgency-border-critical',
+    accent: 'bg-red-500 urgency-accent-critical',
+    badge: 'bg-red-100 text-red-700 ring-1 ring-inset ring-red-300 urgency-badge-critical',
+    icon: 'text-red-500 urgency-icon-critical',
   },
   warning: {
-    border: 'urgency-border-warning',
-    accent: 'urgency-accent-warning',
-    badge: 'urgency-badge-warning',
-    icon: 'urgency-icon-warning',
+    border: 'border-yellow-400 urgency-border-warning',
+    accent: 'bg-yellow-400 urgency-accent-warning',
+    badge: 'bg-yellow-100 text-yellow-800 ring-1 ring-inset ring-yellow-300 urgency-badge-warning',
+    icon: 'text-yellow-500 urgency-icon-warning',
   },
   normal: {
-    border: 'urgency-border-normal',
-    accent: 'urgency-accent-normal',
-    badge: 'urgency-badge-normal',
-    icon: 'urgency-icon-normal',
+    border: 'border-brand-accent urgency-border-normal',
+    accent: 'bg-brand-accent urgency-accent-normal',
+    badge: 'bg-blue-100 text-blue-700 ring-1 ring-inset ring-blue-200 urgency-badge-normal',
+    icon: 'text-brand-accent urgency-icon-normal',
   },
 };
 


### PR DESCRIPTION
## Summary
- restyle kitchen and takeaway cards to use white surfaces with dark text while keeping urgency badges and totals legible
- rename the critical urgency label to “Critique” in both ticket UIs
- sync urgency utility classes and CSS with timer colors and expose Tailwind border accents

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d670dafaa4832a9aa8e4b0dbcb785b