### PR TITLE
Handle role login proxy failures in daily report

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -15,3 +15,6 @@ VITE_CLOUDINARY_PRODUCTS_FOLDER="products"
 VITE_CLOUDINARY_RECEIPTS_FOLDER="receipts"
 # Public placeholder hosted in your Cloudinary account (displayed when a product has no image)
 VITE_CLOUDINARY_DEFAULT_PRODUCT_IMAGE="https://res.cloudinary.com/your-cloud-name/image/upload/v1234567890/placeholders/product.png"
+
+# Server-side secrets (used by Netlify Functions)
+SUPABASE_SERVICE_ROLE_KEY="your-service-role-key"

--- a/README.md
+++ b/README.md
@@ -98,6 +98,9 @@ Dans l'interface Netlify (`Site settings > Environment variables`), ajoutez les 
 - `VITE_CLOUDINARY_CLOUD_NAME`
 - `VITE_CLOUDINARY_UPLOAD_PRESET` (et, si nécessaire, `VITE_CLOUDINARY_UPLOAD_PRESET_PRODUCTS` / `VITE_CLOUDINARY_UPLOAD_PRESET_RECEIPTS`)
 - `VITE_CLOUDINARY_PRODUCTS_FOLDER`, `VITE_CLOUDINARY_RECEIPTS_FOLDER`, `VITE_CLOUDINARY_DEFAULT_PRODUCT_IMAGE`
+- `SUPABASE_SERVICE_ROLE_KEY` (nécessaire aux fonctions Netlify pour récupérer les connexions de rôles)
+
+Pour les fonctions serverless (`netlify/functions/role-logins.ts`), assurez-vous d'ajouter une clé service Supabase dédiée à l'environnement Netlify. Cette clé ne doit pas être exposée côté client.
 
 Netlify redémarrera automatiquement après mise à jour. Vérifiez également que la configuration Supabase autorise le domaine Netlify (`Settings > API > Allowed Redirect URLs`) si vous activez l'authentification Supabase ultérieurement.
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -157,6 +157,7 @@ export interface DailyReport {
     soldProducts: SoldProductsByCategory[];
     lowStockIngredients: Ingredient[];
     roleLogins: RoleLogin[];
+    roleLoginsUnavailable?: boolean;
 }
 
 export interface Sale {


### PR DESCRIPTION
## Summary
- guard the daily report role login fetch behind error handling and return an availability flag
- extend the DailyReport contract and modal UI to warn when role logins cannot be retrieved while keeping other data visible
- document the required SUPABASE_SERVICE_ROLE_KEY environment variable for the Netlify role login proxy

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d673037724832abdb9da951ebebe3d