### PR TITLE
feat: add period filtering to dashboard stats

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -108,22 +108,28 @@ export interface SalesDataPoint {
     value: number;
 }
 
-export interface WeeklySalesChartPoint {
+export type DashboardPeriod = 'week' | 'month';
+
+export interface PeriodSalesChartPoint {
     name: string;
     ventes: number;
-    ventesSemainePrecedente: number;
+    ventesPeriodePrecedente: number;
 }
 
 export interface DashboardStats {
-    ventesAujourdhui: number;
-    beneficeAujourdhui: number;
-    clientsAujourdhui: number;
+    period: DashboardPeriod;
+    periodLabel: string;
+    periodStart: string;
+    periodEnd: string;
+    ventesPeriode: number;
+    beneficePeriode: number;
+    clientsPeriode: number;
     panierMoyen: number;
     tablesOccupees: number;
     clientsActuels: number;
     commandesEnCuisine: number;
     ingredientsStockBas: Ingredient[];
-    ventes7Jours: WeeklySalesChartPoint[];
+    ventesPeriodeSeries: PeriodSalesChartPoint[];
     ventesParCategorie: SalesDataPoint[];
 }
 


### PR DESCRIPTION
## Summary
- add a period selector to the dashboard and refresh stats when the user switches between week and month views
- aggregate dashboard metrics per selected period on the API and return labeled time-series data for the charts
- extend the dashboard types to describe the new period metadata and series structure

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d6749de220832a8202b86faf3c2f4d