### PR TITLE
Prevent redundant server snapshot reapplication

### DIFF
--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -47,6 +47,12 @@ const Commande: React.FC = () => {
         const pendingOrder = pendingServerOrderRef.current;
         if (!pendingOrder) return;
 
+        const currentOrder = orderRef.current;
+        if (currentOrder && JSON.stringify(currentOrder) === JSON.stringify(pendingOrder)) {
+            pendingServerOrderRef.current = null;
+            return;
+        }
+
         pendingServerOrderRef.current = null;
         orderRef.current = pendingOrder;
         setOrder(pendingOrder);
@@ -74,7 +80,12 @@ const Commande: React.FC = () => {
                     originalOrderRef.current = originalSnapshot;
                     setOriginalOrder(originalSnapshot);
                 } else {
-                    pendingServerOrderRef.current = orderData;
+                    const confirmedOrder = originalOrderRef.current;
+                    if (confirmedOrder && JSON.stringify(confirmedOrder) === JSON.stringify(orderData)) {
+                        pendingServerOrderRef.current = null;
+                    } else {
+                        pendingServerOrderRef.current = orderData;
+                    }
                 }
                 return;
             }


### PR DESCRIPTION
## Summary
- avoid storing refresh snapshots that match the last confirmed order
- skip applying pending snapshots when they match the current order
- ensure ignored snapshots are cleared from the pending reference

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d67d12b0fc832ab510591be99b099a