### PR TITLE
Improve table refresh concurrency and order snapshot syncing

### DIFF
--- a/pages/Ventes.tsx
+++ b/pages/Ventes.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect, useState, useCallback } from 'react';
+import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { Armchair, DollarSign, Utensils, HandPlatter } from 'lucide-react';
 import { api } from '../services/api';
@@ -100,15 +100,21 @@ const TableCard: React.FC<{ table: Table; onServe: (orderId: string) => void }> 
 const Ventes: React.FC = () => {
     const [tables, setTables] = useState<Table[]>([]);
     const [loading, setLoading] = useState(true);
+    const fetchIdRef = useRef(0);
 
     const fetchTables = useCallback(async () => {
+        const fetchId = ++fetchIdRef.current;
         try {
             const data = await api.getTables();
-            setTables(data);
+            if (fetchId === fetchIdRef.current) {
+                setTables(data);
+            }
         } catch (error) {
             console.error("Failed to fetch tables", error);
         } finally {
-            setLoading(false);
+            if (fetchId === fetchIdRef.current) {
+                setLoading(false);
+            }
         }
     }, []);
     


### PR DESCRIPTION
## Summary
- guard the sales tables view against stale fetches and drive updates from realtime table events
- track reliable server snapshots in the order page to avoid redundant reads and keep optimistic updates aligned
- streamline table metadata queries to only request kitchen status fields from Supabase

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d6870f5174832a9bbb2e2013b689e6