### PR TITLE
Refonte des états du plan de salle

### DIFF
--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -249,7 +249,7 @@ const Commande: React.FC = () => {
         await syncQueueRef.current;
     }, [applyPendingServerSnapshot, fetchOrderData]);
 
-    const scheduleItemsSync = useCallback((delay = 150) => {
+    const scheduleItemsSync = useCallback((delay = 0) => {
         if (itemsSyncTimeoutRef.current !== null) {
             window.clearTimeout(itemsSyncTimeoutRef.current);
         }

--- a/types/index.ts
+++ b/types/index.ts
@@ -45,7 +45,7 @@ export interface Table {
   id: string;
   nom: string;
   capacite: number;
-  statut: 'libre' | 'occupee' | 'a_payer';
+  statut: 'libre' | 'en_cuisine' | 'para_entregar' | 'para_pagar';
   commandeId?: string;
   couverts?: number;
   estado_cocina?: Order['estado_cocina'];


### PR DESCRIPTION
## Summary
- unify restaurant table statuses autour de quatre états (libre, en cuisine, para entregar, para pagar)
- ajuster l’API et l’interface du plan de salle pour refléter ces nouveaux états et la transition service/paiement
- accélérer la synchronisation des articles afin que les ajouts produits soient envoyés immédiatement et gèrent les commandes successives

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d68e5bfcc8832a946ab0fa1591a7c2