### PR TITLE
Fix table status resolution for dining room orders

### DIFF
--- a/services/api.ts
+++ b/services/api.ts
@@ -450,6 +450,10 @@ const resolveTableStatut = (
 
   const estadoCocina = meta?.estado_cocina;
 
+  if (!estadoCocina || estadoCocina === 'no_enviado') {
+    return 'libre';
+  }
+
   if (estadoCocina === 'listo') {
     return 'para_entregar';
   }
@@ -462,7 +466,7 @@ const resolveTableStatut = (
     return row.statut;
   }
 
-  return 'En cuisine';
+  return 'en_cuisine';
 };
 
 const mapTableRow = (


### PR DESCRIPTION
## Summary
- ensure tables without orders or with unsent orders resolve to the default `libre` status
- fix the fallback status string so tables marked as sent to the kitchen map to the expected `en_cuisine`

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d69aea26d8832aa1eb755e6516f228