### PR TITLE
Adjust order notifications for item-only updates

### DIFF
--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -253,10 +253,14 @@ const Commande: React.FC = () => {
                     .filter(item => isPersistedItemId(item.id) && !optimisticItems.some(finalItem => finalItem.id === item.id))
                     .map(item => item.id);
 
-                const updatedOrder = await api.updateOrder(currentOrder.id, {
-                    items: finalItems,
-                    removedItemIds,
-                });
+                const updatedOrder = await api.updateOrder(
+                    currentOrder.id,
+                    {
+                        items: finalItems,
+                        removedItemIds,
+                    },
+                    { includeNotifications: false },
+                );
                 const ingredientsData = await api.getIngredients();
 
                 setOrder(updatedOrder);

--- a/services/api.ts
+++ b/services/api.ts
@@ -721,8 +721,14 @@ const notificationsService = {
   },
 };
 
-const publishOrderChange = () => {
-  notificationsService.publish('notifications_updated');
+type PublishOrderChangeOptions = {
+  includeNotifications?: boolean;
+};
+
+const publishOrderChange = (options?: PublishOrderChangeOptions) => {
+  if (options?.includeNotifications !== false) {
+    notificationsService.publish('notifications_updated');
+  }
   notificationsService.publish('orders_updated');
 };
 
@@ -1180,7 +1186,11 @@ export const api = {
     publishOrderChange();
   },
 
-  updateOrder: async (orderId: string, updates: Partial<Order> & { removedItemIds?: string[] }): Promise<Order> => {
+  updateOrder: async (
+    orderId: string,
+    updates: Partial<Order> & { removedItemIds?: string[] },
+    options?: PublishOrderChangeOptions,
+  ): Promise<Order> => {
     const existingOrder = await fetchOrderById(orderId);
     if (!existingOrder) {
       throw new Error('Order not found');
@@ -1254,7 +1264,7 @@ export const api = {
       await supabase.from('orders').update(payload).eq('id', orderId);
     }
 
-    publishOrderChange();
+    publishOrderChange({ includeNotifications: options?.includeNotifications ?? true });
     const updatedOrder = await fetchOrderById(orderId);
     if (!updatedOrder) {
       throw new Error('Order not found after update');


### PR DESCRIPTION
## Summary
- add optional includeNotifications flag when publishing order updates
- propagate the flag through api.updateOrder and disable notifications for item-only changes in Commande

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d6c211ec8c832ab40e6fd7fd5c558c