### PR TITLE
Use removal snapshot for remote optimistic item updates

### DIFF
--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -218,7 +218,10 @@ const Commande: React.FC = () => {
             ? (updater as (prevItems: OrderItem[]) => OrderItem[])(items)
             : updater;
 
-        const optimisticSourceItems = currentOrder.items.map(item => ({ ...item }));
+        const optimisticSourceItemsBase = options?.isLocalUpdate
+            ? currentOrder.items
+            : options?.removalSourceItems ?? currentOrder.items;
+        const optimisticSourceItems = optimisticSourceItemsBase.map(item => ({ ...item }));
         const optimisticItems = computeItems(optimisticSourceItems);
         const optimisticOrder: Order = {
             ...currentOrder,


### PR DESCRIPTION
## Summary
- build remote optimistic previews from the provided removal snapshot when available so local removals are reflected accurately

## Testing
- Manual verification attempted but blocked by existing build error in `pages/Produits.tsx` when launching the dev server

------
https://chatgpt.com/codex/tasks/task_b_68d6db5cd7dc832aaacde968fb6cc475