### PR TITLE
Adjust order sync to refresh ingredients asynchronously

### DIFF
--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -268,15 +268,18 @@ const Commande: React.FC = () => {
                     },
                     { includeNotifications: false },
                 );
-                const ingredientsData = await api.getIngredients();
-
                 setOrder(updatedOrder);
                 orderRef.current = updatedOrder;
                 const updatedOriginalSnapshot = cloneOrder(updatedOrder);
                 setOriginalOrder(updatedOriginalSnapshot);
                 originalOrderRef.current = updatedOriginalSnapshot;
                 serverOrderRef.current = cloneOrder(updatedOrder);
-                setIngredients(ingredientsData);
+
+                void api.getIngredients()
+                    .then(setIngredients)
+                    .catch(error => {
+                        console.error("Failed to refresh ingredients", error);
+                    });
                 applyPendingServerSnapshot();
             } catch (error) {
                 console.error("Failed to update order:", error);


### PR DESCRIPTION
## Summary
- ensure order state and snapshots update immediately after api.updateOrder resolves
- refresh ingredient data asynchronously with retained error logging

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d6eaa496b0832aa2aee7e125dd8771