### PR TITLE
Adjust kitchen ticket borders for urgency levels

### DIFF
--- a/pages/Cuisine.tsx
+++ b/pages/Cuisine.tsx
@@ -54,8 +54,7 @@ const KitchenTicketCard: React.FC<{ order: KitchenTicketOrder; onReady: (orderId
     }, [order.items]);
 
     return (
-        <div className={`relative flex h-full flex-col overflow-hidden rounded-xl border bg-white text-gray-900 shadow-lg transition-shadow duration-300 hover:shadow-xl ${urgencyStyles.border}`}>
-            <span aria-hidden className={`absolute inset-y-0 left-0 w-1.5 ${urgencyStyles.accent}`} />
+        <div className={`flex h-full flex-col overflow-hidden rounded-xl bg-white text-gray-900 shadow-lg transition-shadow duration-300 hover:shadow-xl ${urgencyStyles.border}`}>
             <header className="border-b border-gray-200 px-5 pt-5 pb-4">
                 <div className="flex w-full flex-col gap-4">
                     <div className="space-y-1">

--- a/utils/orderUrgency.ts
+++ b/utils/orderUrgency.ts
@@ -14,19 +14,19 @@ export interface OrderUrgencyStyles {
 
 const URGENCY_STYLE_MAP: Record<OrderUrgencyLevel, Omit<OrderUrgencyStyles, 'level'>> = {
   critical: {
-    border: 'border-red-500 urgency-border-critical',
+    border: 'border-4 border-solid border-red-500',
     accent: 'bg-red-500 urgency-accent-critical',
     badge: 'bg-red-100 text-red-700 ring-1 ring-inset ring-red-300 urgency-badge-critical',
     icon: 'text-red-500 urgency-icon-critical',
   },
   warning: {
-    border: 'border-yellow-400 urgency-border-warning',
+    border: 'border-[3px] border-solid border-yellow-400',
     accent: 'bg-yellow-400 urgency-accent-warning',
     badge: 'bg-yellow-100 text-yellow-800 ring-1 ring-inset ring-yellow-300 urgency-badge-warning',
     icon: 'text-yellow-500 urgency-icon-warning',
   },
   normal: {
-    border: 'border-brand-accent urgency-border-normal',
+    border: 'border-2 border-solid border-brand-accent',
     accent: 'bg-brand-accent urgency-accent-normal',
     badge: 'bg-blue-100 text-blue-700 ring-1 ring-inset ring-blue-200 urgency-badge-normal',
     icon: 'text-brand-accent urgency-icon-normal',


### PR DESCRIPTION
## Summary
- update urgency style map to use Tailwind border width and color classes for each state
- simplify kitchen ticket card border styling to rely on the urgency border class and remove the decorative sidebar

## Testing
- npm run lint *(fails: Missing script "lint")*

------
https://chatgpt.com/codex/tasks/task_b_68d7aff03120832a90dd94d1c855f1ac