### PR TITLE
Adjust status card title styling

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -703,8 +703,10 @@ body {
 }
 
 .status-card__title {
-  font-size: clamp(1.35rem, 2.5vw, 1.65rem);
+  font-size: clamp(2rem, 3vw, 2.35rem);
   margin: 0;
+  color: #ffffff;
+  text-shadow: 0 2px 6px rgba(15, 23, 42, 0.4);
 }
 
 .status-card__icon {


### PR DESCRIPTION
## Summary
- increase the status card title size to improve readability
- force white text with a subtle shadow to maintain contrast on colored backgrounds

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_b_68d7bad2ebc0832aa3f099f4bdb19f0c