### PR TITLE
Add white border to order timer

### DIFF
--- a/components/OrderTimer.tsx
+++ b/components/OrderTimer.tsx
@@ -27,7 +27,9 @@ const OrderTimer: React.FC<OrderTimerProps> = ({ startTime, className = '' }) =>
   };
 
   return (
-    <div className={`flex items-center space-x-2 px-2 py-1 rounded-full text-lg font-bold ${getTimerColor()} ${className}`}>
+    <div
+      className={`flex items-center space-x-2 px-2 py-1 rounded-full text-lg font-bold border-2 border-white ${getTimerColor()} ${className}`}
+    >
       <Clock size={20} />
       <span>{timerString}</span>
     </div>


### PR DESCRIPTION
## Summary
- add a consistent white border to the order timer so its outline remains visible across color states

## Testing
- npx vite --host 0.0.0.0 --port 4173 *(fails: existing duplicate declaration "HelpCircle" in pages/Produits.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68d7bb48ed78832ab18fe6b509befd18