### PR TITLE
Supprimer les balises h1 en doublon sur les pages opérationnelles

### DIFF
--- a/pages/Cuisine.tsx
+++ b/pages/Cuisine.tsx
@@ -155,8 +155,8 @@ const Cuisine: React.FC = () => {
     if (loading) return <div className="text-gray-700">Chargement des commandes pour la cuisine...</div>;
 
     return (
-        <div className="h-full flex flex-col">
-            <h1 className="mb-4 text-3xl font-bold text-white sm:mb-6">Vue Cuisine</h1>
+        <div className="flex h-full flex-col">
+            <div className="mb-4 text-3xl font-bold text-white sm:mb-6">Vue Cuisine</div>
             {orders.length === 0 ? (
                 <div className="flex flex-1 items-center justify-center text-2xl text-gray-500">Aucune commande en préparation.</div>
             ) : (

--- a/pages/Ingredients.tsx
+++ b/pages/Ingredients.tsx
@@ -59,7 +59,7 @@ const Ingredients: React.FC = () => {
 
     return (
         <div className="space-y-6">
-            <h1 className="text-heading">Gestion des Ingrédients</h1>
+            <div className="text-heading">Gestion des Ingrédients</div>
 
             <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
                 <div className="relative w-full sm:w-auto">

--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -184,8 +184,8 @@ const ParaLlevar: React.FC = () => {
     if (loading) return <div className="text-gray-700">Chargement des commandes à emporter...</div>;
 
     return (
-        <div>
-            <h1 className="mb-6 text-3xl font-bold text-gray-900">Commandes à Emporter</h1>
+        <div className="space-y-6">
+            <div className="text-3xl font-bold text-gray-900">Commandes à Emporter</div>
             <div className="grid grid-cols-1 gap-8 sm:grid-cols-2">
                 {/* Column for validation */}
                 <div className="bg-gray-100 p-4 rounded-xl">

--- a/pages/Produits.tsx
+++ b/pages/Produits.tsx
@@ -99,8 +99,8 @@ const Produits: React.FC = () => {
 
     return (
         <div className="space-y-6">
-            <h1 className="text-heading">Gestion des Produits</h1>
-            
+            <div className="text-heading">Gestion des Produits</div>
+
             <div className="ui-card p-4 flex flex-col sm:flex-row justify-between items-center gap-4">
                 <div className="flex flex-col sm:flex-row gap-4 w-full">
                     <div className="relative flex-grow">

--- a/pages/ResumeVentes.tsx
+++ b/pages/ResumeVentes.tsx
@@ -87,7 +87,7 @@ const ResumeVentes: React.FC = () => {
 
     return (
         <div className="space-y-6">
-            <h1 className="text-3xl font-bold text-white">Résumé des Ventes par Commande</h1>
+            <div className="text-3xl font-bold text-white">Résumé des Ventes par Commande</div>
             <div className="bg-white p-4 rounded-xl shadow-md space-y-4">
                  <div className="flex flex-wrap items-end gap-4">
                      <div className="flex-grow">

--- a/pages/Ventes.tsx
+++ b/pages/Ventes.tsx
@@ -148,7 +148,7 @@ const Ventes: React.FC = () => {
 
     return (
         <div>
-            <h1 className="section-title">Plan de salle</h1>
+            <div className="section-title">Plan de salle</div>
             <div className="status-grid">
                 {tables.map(table => (
                     <TableCard key={table.id} table={table} onServe={handleServeOrder} />


### PR DESCRIPTION
## Summary
- remplace les balises h1 en tête de pages back-office par des conteneurs neutres tout en conservant le style visuel
- ajuste les classes utilitaires pour préserver des espacements cohérents après la suppression des balises h1

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d7bc31bc68832a8bbdb545052bc821