### PR TITLE
Normalize currency formatting across the app

### DIFF
--- a/components/CustomerOrderTracker.tsx
+++ b/components/CustomerOrderTracker.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { api } from '../services/api';
 import { Order } from '../types';
 import { CheckCircle, ChefHat, FileText, PackageCheck, User, MapPin, Receipt, Phone } from 'lucide-react';
+import { formatIntegerAmount } from '../utils/formatIntegerAmount';
 import {
     clearActiveCustomerOrder,
     getActiveCustomerOrder,
@@ -178,13 +179,13 @@ const CustomerOrderTracker: React.FC<CustomerOrderTrackerProps> = ({ orderId, on
                         {order.items.map(item => (
                             <div key={item.id} className={`flex justify-between ${variant === 'hero' ? 'text-gray-200' : 'text-gray-600'}`}>
                                 <span>{item.quantite}x {item.nom_produit}</span>
-                                <span>{(item.prix_unitaire * item.quantite).toFixed(2)}€</span>
+                                <span>{formatIntegerAmount(item.prix_unitaire * item.quantite)}€</span>
                             </div>
                         ))}
                     </div>
                     <div className={`flex justify-between font-bold text-lg border-t pt-2 ${variant === 'hero' ? 'text-white border-gray-500' : 'text-gray-800'}`}>
                         <span>Total</span>
-                        <span>{order.total.toFixed(2)}€</span>
+                        <span>{formatIntegerAmount(order.total)}€</span>
                     </div>
 
                     <div className={`border-t pt-4 space-y-2 ${variant === 'hero' ? 'border-gray-500' : ''}`}>

--- a/components/PaymentModal.tsx
+++ b/components/PaymentModal.tsx
@@ -2,6 +2,7 @@ import React, { useState } from 'react';
 import { Order } from '../types';
 import Modal from './Modal';
 import { Upload } from 'lucide-react';
+import { formatIntegerAmount } from '../utils/formatIntegerAmount';
 
 interface PaymentModalProps {
   isOpen: boolean;
@@ -29,7 +30,7 @@ const PaymentModal: React.FC<PaymentModalProps> = ({ isOpen, onClose, order, onF
       <form onSubmit={handleSubmit} className="space-y-6">
         <div className="text-center">
           <p className="text-gray-600">Total à payer</p>
-          <p className="text-4xl font-extrabold text-gray-900">{order.total.toFixed(2)} €</p>
+          <p className="text-4xl font-extrabold text-gray-900">{formatIntegerAmount(order.total)} €</p>
         </div>
 
         <div>

--- a/components/ReportModal.tsx
+++ b/components/ReportModal.tsx
@@ -3,6 +3,7 @@ import Modal from './Modal';
 import { api } from '../services/api';
 import { DailyReport, RoleLogin } from '../types';
 import { Users, ShoppingCart, DollarSign, Package, AlertTriangle, MessageSquare, LogIn } from 'lucide-react';
+import { formatIntegerAmount } from '../utils/formatIntegerAmount';
 
 const ReportStat: React.FC<{ icon: React.ReactNode, label: string, value: string | number }> = ({ icon, label, value }) => (
     <div className="bg-gray-100 p-4 rounded-lg flex items-center">
@@ -60,9 +61,9 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
         parts.push('---');
     
         parts.push(`*Statistiques du Jour*`);
-        parts.push(`- Ventes: *${reportData.ventesDuJour.toFixed(2)} €*`);
+        parts.push(`- Ventes: *${formatIntegerAmount(reportData.ventesDuJour)} €*`);
         parts.push(`- Clients: *${reportData.clientsDuJour}*`);
-        parts.push(`- Panier Moyen: *${reportData.panierMoyen.toFixed(2)} €*`);
+        parts.push(`- Panier Moyen: *${formatIntegerAmount(reportData.panierMoyen)} €*`);
         parts.push('---');
     
         parts.push(`*Produits Vendus*`);
@@ -72,7 +73,7 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
           reportData.soldProducts.forEach(category => {
             parts.push(`\n_${category.categoryName}_`);
             category.products.forEach(product => {
-              parts.push(`  - ${product.quantity}x ${product.name} (${product.totalSales.toFixed(2)} €)`);
+              parts.push(`  - ${product.quantity}x ${product.name} (${formatIntegerAmount(product.totalSales)} €)`);
             });
           });
         }
@@ -147,9 +148,9 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
                             </div>
                             
                             <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-                                <ReportStat icon={<DollarSign/>} label="Ventes du Jour" value={`${report.ventesDuJour.toFixed(2)} €`} />
+                                <ReportStat icon={<DollarSign/>} label="Ventes du Jour" value={`${formatIntegerAmount(report.ventesDuJour)} €`} />
                                 <ReportStat icon={<Users/>} label="Clients du Jour" value={report.clientsDuJour} />
-                                <ReportStat icon={<ShoppingCart/>} label="Panier Moyen" value={`${report.panierMoyen.toFixed(2)} €`} />
+                                <ReportStat icon={<ShoppingCart/>} label="Panier Moyen" value={`${formatIntegerAmount(report.panierMoyen)} €`} />
                             </div>
 
                             <div>
@@ -161,7 +162,7 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
                                             <ul className="list-disc list-inside pl-2 text-gray-700">
                                                 {category.products.map(product => (
                                                     <li key={product.id}>
-                                                        {product.quantity}x {product.name} - <span className="font-semibold">{product.totalSales.toFixed(2)} €</span>
+                                                        {product.quantity}x {product.name} - <span className="font-semibold">{formatIntegerAmount(product.totalSales)} €</span>
                                                     </li>
                                                 ))}
                                             </ul>

--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -4,6 +4,7 @@ import { api } from '../services/api';
 import { uploadPaymentReceipt } from '../services/cloudinary';
 import { Order, Product, Category, OrderItem, Ingredient } from '../types';
 import { PlusCircle, MinusCircle, Send, DollarSign, AlertTriangle, Check, ArrowLeft, MessageSquare } from 'lucide-react';
+import { formatIntegerAmount } from '../utils/formatIntegerAmount';
 import OrderTimer from '../components/OrderTimer';
 import PaymentModal from '../components/PaymentModal';
 import Modal from '../components/Modal';
@@ -585,7 +586,7 @@ const Commande: React.FC = () => {
                                 <img src={product.image} alt={product.nom_produit} className="w-24 h-24 object-cover rounded-md mb-2" />
                                 <p className="font-semibold text-sm text-gray-800">{product.nom_produit}</p>
                                 <p className="text-xs text-gray-600 px-1 h-10 overflow-hidden flex-grow">{product.description}</p>
-                                <p className="font-bold text-brand-primary mt-1">{product.prix_vente.toFixed(2)} €</p>
+                                <p className="font-bold text-brand-primary mt-1">{formatIntegerAmount(product.prix_vente)} €</p>
                             </button>
                         )
                     })}
@@ -614,10 +615,10 @@ const Commande: React.FC = () => {
                                         <div key={item.id} className="p-3 rounded-lg bg-yellow-100">
                                             <div className="flex justify-between items-start">
                                                 <p className="font-bold text-gray-900 flex-1">{item.quantite}x {item.nom_produit}</p>
-                                                <p className="font-bold text-gray-900">{(item.quantite * item.prix_unitaire).toFixed(2)}€</p>
+                                                <p className="font-bold text-gray-900">{formatIntegerAmount(item.quantite * item.prix_unitaire)}€</p>
                                             </div>
                                             <div className="flex justify-between items-center mt-2">
-                                                <p className="text-sm text-gray-700">{item.prix_unitaire.toFixed(2)} € /u</p>
+                                                <p className="text-sm text-gray-700">{formatIntegerAmount(item.prix_unitaire)} € /u</p>
                                                 <div className="flex items-center space-x-2 text-gray-800">
                                                     <button onClick={() => handleQuantityChange(index, -1)} className="p-1"><MinusCircle size={20} /></button>
                                                     <span className="font-bold w-6 text-center">{item.quantite}</span>
@@ -654,9 +655,9 @@ const Commande: React.FC = () => {
                                         <div key={item.id} className="p-3 rounded-lg bg-green-100">
                                             <div className="flex justify-between items-start">
                                                 <p className="font-bold text-gray-900 flex-1">{item.quantite}x {item.nom_produit}</p>
-                                                <p className="font-bold text-gray-900">{(item.quantite * item.prix_unitaire).toFixed(2)}€</p>
+                                                <p className="font-bold text-gray-900">{formatIntegerAmount(item.quantite * item.prix_unitaire)}€</p>
                                             </div>
-                                            <p className="text-sm text-gray-700 mt-2">{item.prix_unitaire.toFixed(2)} € /u</p>
+                                            <p className="text-sm text-gray-700 mt-2">{formatIntegerAmount(item.prix_unitaire)} € /u</p>
                                             {item.commentaire && (
                                                 <p className="mt-2 text-sm italic text-gray-600 pl-2">"{item.commentaire}"</p>
                                             )}
@@ -670,7 +671,7 @@ const Commande: React.FC = () => {
                 <div className="p-4 border-t space-y-4">
                     <div className="flex justify-between text-2xl font-semibold text-brand-secondary">
                         <span>Total</span>
-                        <span>{order.total.toFixed(2)} €</span>
+                        <span>{formatIntegerAmount(order.total)} €</span>
                     </div>
 
                     {order.estado_cocina === 'listo' && (

--- a/pages/CommandeClient.tsx
+++ b/pages/CommandeClient.tsx
@@ -7,6 +7,7 @@ import Modal from '../components/Modal';
 import { ArrowLeft, ShoppingCart, Plus, Minus, X, Upload, MessageCircle, CheckCircle, History } from 'lucide-react';
 import CustomerOrderTracker from '../components/CustomerOrderTracker';
 import { clearActiveCustomerOrder, getActiveCustomerOrder, storeActiveCustomerOrder } from '../services/customerOrderStorage';
+import { formatIntegerAmount } from '../utils/formatIntegerAmount';
 
 // ==================================================================================
 // 2. Item Customization Modal
@@ -61,7 +62,7 @@ const ItemCustomizationModal: React.FC<ItemCustomizationModalProps> = ({ isOpen,
                         <button onClick={() => setQuantity(q => q + 1)} className="p-2 rounded-full bg-gray-200 text-gray-800"><Plus size={18}/></button>
                     </div>
                     <button onClick={handleSave} className="bg-brand-primary text-brand-secondary font-bold py-2 px-6 rounded-lg hover:bg-yellow-400 transition">
-                        Ajouter ({ (product.prix_vente * quantity).toFixed(2) } €)
+                        Ajouter ({formatIntegerAmount(product.prix_vente * quantity)} €)
                     </button>
                 </div>
             </div>
@@ -260,7 +261,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
     const generateWhatsAppMessage = (order: Order) => {
         const header = `*Nouvelle Commande OUIOUITACOS #${order.id.slice(-6)}*`;
         const itemLines = (order.items ?? []).map(item => {
-            const baseLine = `- ${item.quantite}x ${item.nom_produit} (${item.prix_unitaire.toFixed(2)}€) → ${(item.prix_unitaire * item.quantite).toFixed(2)}€`;
+            const baseLine = `- ${item.quantite}x ${item.nom_produit} (${formatIntegerAmount(item.prix_unitaire)}€) → ${formatIntegerAmount(item.prix_unitaire * item.quantite)}€`;
             const details: string[] = [];
             if (item.commentaire) {
                 details.push(`Commentaire: ${item.commentaire}`);
@@ -272,7 +273,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
         });
         const items = itemLines.length > 0 ? itemLines.join('\n') : 'Aucun article';
         const totalValue = order.total ?? order.items.reduce((sum, item) => sum + item.prix_unitaire * item.quantite, 0);
-        const totalMsg = `*Total: ${totalValue.toFixed(2)}€*`;
+        const totalMsg = `*Total: ${formatIntegerAmount(totalValue)}€*`;
         const paymentMethod = order.payment_method ? `Paiement: ${order.payment_method}` : undefined;
         const client = `Client: ${order.clientInfo?.nom} (${order.clientInfo?.telephone})\nAdresse: ${order.clientInfo?.adresse}`;
         const footer = "Justificatif de paiement ci-joint.";
@@ -296,7 +297,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                                     <div key={order.id} className="flex justify-between items-center bg-gray-50 p-3 rounded-lg">
                                         <div>
                                             <p className="font-semibold text-gray-700">Commande du {new Date(order.date_creation).toLocaleDateString()}</p>
-                                            <p className="text-sm text-gray-500">{order.items.length} article(s) - {order.total.toFixed(2)}€</p>
+                                            <p className="text-sm text-gray-500">{order.items.length} article(s) - {formatIntegerAmount(order.total)}€</p>
                                         </div>
                                         <button onClick={() => handleReorder(order)} className="bg-brand-primary text-brand-secondary font-bold py-1 px-3 rounded-lg text-sm hover:bg-yellow-400">
                                             Commander à nouveau
@@ -326,7 +327,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                                     <img src={product.image} alt={product.nom_produit} className="w-28 h-28 object-cover rounded-md mb-2" />
                                     <p className="font-semibold text-sm flex-grow text-gray-700">{product.nom_produit}</p>
                                     <p className="text-xs text-gray-500 mt-1 px-1 h-10 overflow-hidden">{product.description}</p>
-                                    <p className="font-bold text-gray-700 mt-1">{product.prix_vente.toFixed(2)} €</p>
+                                    <p className="font-bold text-gray-700 mt-1">{formatIntegerAmount(product.prix_vente)} €</p>
                                     {product.estado !== 'disponible' && <span className="text-xs text-red-500 font-bold mt-1">Épuisé</span>}
                                 </div>
                             ))}
@@ -345,7 +346,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                                         <div>
                                             <p className="font-semibold text-gray-700">{item.nom_produit}</p>
                                             {item.commentaire && <p className="text-xs text-gray-500 italic">"{item.commentaire}"</p>}
-                                            <p className="text-sm text-gray-600 font-semibold">{(item.prix_unitaire * item.quantite).toFixed(2)} €</p>
+                                            <p className="text-sm text-gray-600 font-semibold">{formatIntegerAmount(item.prix_unitaire * item.quantite)} €</p>
                                         </div>
                                         <div className="flex items-center gap-2">
                                             <button onClick={() => handleQuantityChange(item.id, -1)} className="p-1 rounded-full bg-gray-200"><Minus size={14}/></button>
@@ -359,7 +360,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                         <div className="border-t my-4"></div>
                         <div className="flex justify-between text-xl font-bold text-gray-700">
                             <span>Total</span>
-                            <span>{total.toFixed(2)} €</span>
+                            <span>{formatIntegerAmount(total)} €</span>
                         </div>
 
                         {cart.length > 0 && (
@@ -392,7 +393,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                                     <input id="payment-proof-upload" type="file" required accept="image/*,.pdf" onChange={e => setPaymentProof(e.target.files ? e.target.files[0] : null)} className="hidden" />
                                 </div>
                                 <button type="submit" disabled={!clientInfo.nom || !clientInfo.telephone || !clientInfo.adresse || !paymentProof || submitting} className="w-full bg-brand-accent text-white font-bold py-3 rounded-lg text-lg hover:bg-red-700 transition disabled:bg-gray-400">
-                                    {submitting ? 'Envoi...' : `Soumettre la Commande (${total.toFixed(2)} €)`}
+                                    {submitting ? 'Envoi...' : `Soumettre la Commande (${formatIntegerAmount(total)} €)`}
                                 </button>
                             </form>
                         )}

--- a/pages/Dashboard.tsx
+++ b/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import { api, getBusinessDayStart } from '../services/api';
 import { DashboardStats, SalesDataPoint, DashboardPeriod } from '../types';
 import Modal from '../components/Modal';
 import RoleManager from '../components/RoleManager';
+import { formatIntegerAmount } from '../utils/formatIntegerAmount';
 
 const MainStatCard: React.FC<{ title: string; value: string; icon: React.ReactNode }> = ({ title, value, icon }) => (
     <div className="ui-card p-6 flex items-center space-x-4">
@@ -112,10 +113,10 @@ const Dashboard: React.FC = () => {
 
             {/* Block 1: Key Indicators */}
             <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-                <MainStatCard title={`Ventes (${stats.periodLabel})`} value={`${stats.ventesPeriode.toFixed(2)} €`} icon={<DollarSign size={28}/>} />
-                <MainStatCard title={`Bénéfice (${stats.periodLabel})`} value={`${stats.beneficePeriode.toFixed(2)} €`} icon={<DollarSign size={28}/>} />
+                <MainStatCard title={`Ventes (${stats.periodLabel})`} value={`${formatIntegerAmount(stats.ventesPeriode)} €`} icon={<DollarSign size={28}/>} />
+                <MainStatCard title={`Bénéfice (${stats.periodLabel})`} value={`${formatIntegerAmount(stats.beneficePeriode)} €`} icon={<DollarSign size={28}/>} />
                 <MainStatCard title={`Clients (${stats.periodLabel})`} value={stats.clientsPeriode.toString()} icon={<Users size={28}/>} />
-                <MainStatCard title="Panier Moyen" value={`${stats.panierMoyen.toFixed(2)} €`} icon={<BarChart2 size={28}/>} />
+                <MainStatCard title="Panier Moyen" value={`${formatIntegerAmount(stats.panierMoyen)} €`} icon={<BarChart2 size={28}/>} />
             </div>
 
             {/* Block 2: Operational Status */}
@@ -162,7 +163,7 @@ const Dashboard: React.FC = () => {
                             <Pie data={pieData} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={100} fill="#8884d8" label>
                                 {pieData.map((entry, index) => <Cell key={`cell-${index}`} fill={PIE_COLORS[index % PIE_COLORS.length]} />)}
                             </Pie>
-                            <Tooltip formatter={(value: number) => `${value.toFixed(2)} €`} />
+                            <Tooltip formatter={(value: number) => `${formatIntegerAmount(value)} €`} />
                             <Legend/>
                         </PieChart>
                     </ResponsiveContainer>

--- a/pages/Ingredients.tsx
+++ b/pages/Ingredients.tsx
@@ -4,6 +4,7 @@ import { api } from '../services/api';
 import { Ingredient } from '../types';
 import Modal from '../components/Modal';
 import { PlusCircle, Edit, Trash2, PackagePlus, Search } from 'lucide-react';
+import { formatIntegerAmount } from '../utils/formatIntegerAmount';
 
 const Ingredients: React.FC = () => {
     const { role } = useAuth();
@@ -105,7 +106,7 @@ const Ingredients: React.FC = () => {
                                         {ing.stock_minimum} {ing.unite}
                                     </td>
                                      <td className={`p-3 ${isLowStock ? 'text-red-800' : 'text-gray-700'}`}>
-                                        {ing.prix_unitaire.toFixed(2)} €
+                                        {formatIntegerAmount(ing.prix_unitaire)} €
                                     </td>
                                     {canEdit && (
                                         <td className="p-3 text-right">

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -7,6 +7,7 @@ import { Product, Order } from '../types';
 import { Mail, MapPin, Phone, Menu, X } from 'lucide-react';
 import CustomerOrderTracker from '../components/CustomerOrderTracker';
 import { clearActiveCustomerOrder, getActiveCustomerOrder } from '../services/customerOrderStorage';
+import { formatIntegerAmount } from '../utils/formatIntegerAmount';
 
 type PinInputProps = {
   pin: string;
@@ -268,7 +269,7 @@ const Login: React.FC = () => {
                         <div key={order.id} className="hero-history__item">
                           <div className="hero-history__meta">
                             <p className="hero-history__date">Commande du {new Date(order.date_creation).toLocaleDateString()}</p>
-                            <p className="hero-history__details">{order.items.length} article(s) • {order.total.toFixed(2)}€</p>
+                            <p className="hero-history__details">{order.items.length} article(s) • {formatIntegerAmount(order.total)}€</p>
                           </div>
                           <button
                             type="button"
@@ -310,7 +311,7 @@ const Login: React.FC = () => {
                     <div className="menu-card__body">
                       <h3 className="menu-card__title">{product.nom_produit}</h3>
                       <p className="menu-card__description">{product.description}</p>
-                      <p className="menu-card__price">{product.prix_vente.toFixed(2)} €</p>
+                      <p className="menu-card__price">{formatIntegerAmount(product.prix_vente)} €</p>
                     </div>
                   </article>
                 ))}

--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -5,6 +5,7 @@ import { Eye, User, MapPin } from 'lucide-react';
 import Modal from '../components/Modal';
 import OrderTimer from '../components/OrderTimer';
 import { getOrderUrgencyStyles } from '../utils/orderUrgency';
+import { formatIntegerAmount } from '../utils/formatIntegerAmount';
 
 
 const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => void, onDeliver?: (orderId: string) => void, isProcessing?: boolean }> = ({ order, onValidate, onDeliver, isProcessing }) => {
@@ -75,7 +76,7 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
 
                     <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 font-semibold text-gray-900 shadow-sm">
                         <span>Total</span>
-                        <span className="text-gray-900">{order.total.toFixed(2)} €</span>
+                        <span className="text-gray-900">{formatIntegerAmount(order.total)} €</span>
                     </div>
                 </div>
 

--- a/pages/Produits.tsx
+++ b/pages/Produits.tsx
@@ -7,6 +7,7 @@ import { uploadProductImage, resolveProductImageUrl } from '../services/cloudina
 import { Product, Category, Ingredient, RecipeItem } from '../types';
 import Modal from '../components/Modal';
 import { PlusCircle, Edit, Trash2, Search, Settings, GripVertical, CheckCircle, Clock, XCircle, MoreVertical, Upload, HelpCircle } from 'lucide-react';
+import { formatIntegerAmount } from '../utils/formatIntegerAmount';
 
 const getStatusInfo = (status: Product['estado']) => {
     switch (status) {
@@ -199,7 +200,7 @@ const ProductCard: React.FC<{ product: Product; category?: Category; onEdit: () 
                         <p className="text-xs text-gray-500">{category?.nom || 'Sans catégorie'}</p>
                         <h3 className="font-bold text-lg text-gray-900">{product.nom_produit}</h3>
                     </div>
-                <p className="text-xl font-extrabold text-brand-primary">{product.prix_vente.toFixed(2)}€</p>
+                <p className="text-xl font-extrabold text-brand-primary">{formatIntegerAmount(product.prix_vente)}€</p>
                 </div>
                  <p className="text-xs text-gray-600 mt-1 flex-grow">{product.description}</p>
                 
@@ -345,15 +346,15 @@ const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSu
                     <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 bg-gray-50 border border-gray-200 rounded-lg p-4 text-sm text-gray-700">
                         <div>
                             <p className="text-xs uppercase tracking-wide text-gray-500">Coût de revient</p>
-                            <p className="text-lg font-semibold text-gray-900">{recipeCost.toFixed(2)} €</p>
+                            <p className="text-lg font-semibold text-gray-900">{formatIntegerAmount(recipeCost)} €</p>
                         </div>
                         <div>
                             <p className="text-xs uppercase tracking-wide text-gray-500">Marge</p>
-                            <p className={`text-lg font-semibold ${marginValue >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>{marginValue.toFixed(2)} €</p>
+                            <p className={`text-lg font-semibold ${marginValue >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>{formatIntegerAmount(marginValue)} €</p>
                         </div>
                         <div>
                             <p className="text-xs uppercase tracking-wide text-gray-500">Marge %</p>
-                            <p className={`text-lg font-semibold ${marginPercentage >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>{Number.isFinite(marginPercentage) ? marginPercentage.toFixed(1) : '0.0'}%</p>
+                            <p className={`text-lg font-semibold ${marginPercentage >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>{Number.isFinite(marginPercentage) ? formatIntegerAmount(marginPercentage) : '0'}%</p>
                         </div>
                     </div>
 

--- a/pages/ResumeVentes.tsx
+++ b/pages/ResumeVentes.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { api } from '../services/api';
 import { Order } from '../types';
 import { Download, ChevronDown, ChevronRight, User, ShoppingBag } from 'lucide-react';
+import { formatIntegerAmount } from '../utils/formatIntegerAmount';
 
 const ResumeVentes: React.FC = () => {
     const [orders, setOrders] = useState<Order[]>([]);
@@ -57,8 +58,8 @@ const ResumeVentes: React.FC = () => {
                 order.type === 'sur_place' ? 'Sur Place' : 'À Emporter',
                 `"${order.type === 'sur_place' ? (order.table_nom || 'N/A') : (order.clientInfo?.nom || 'N/A')}"`,
                 order.couverts,
-                order.total.toFixed(2),
-                (order.profit || 0).toFixed(2),
+                formatIntegerAmount(order.total),
+                formatIntegerAmount(order.profit || 0),
                 order.payment_method || 'N/A'
             ].join(','))
         ];
@@ -143,8 +144,8 @@ const ResumeVentes: React.FC = () => {
                                             )}
                                         </td>
                                         <td className="p-3 font-semibold text-gray-900">{order.type === 'sur_place' ? (order.table_nom || 'N/A') : (order.clientInfo?.nom || 'N/A')}</td>
-                                        <td className="p-3 text-gray-800 font-bold text-right">{order.total.toFixed(2)} €</td>
-                                        <td className="p-3 font-semibold text-green-600 text-right">{(order.profit || 0).toFixed(2)} €</td>
+                                        <td className="p-3 text-gray-800 font-bold text-right">{formatIntegerAmount(order.total)} €</td>
+                                        <td className="p-3 font-semibold text-green-600 text-right">{formatIntegerAmount(order.profit || 0)} €</td>
                                         <td className="p-3 text-gray-700 capitalize">{order.payment_method || 'N/A'}</td>
                                     </tr>
                                     {expandedOrderId === order.id && (
@@ -154,7 +155,7 @@ const ResumeVentes: React.FC = () => {
                                                     <h4 className="font-semibold mb-2 text-gray-800">Détail des articles :</h4>
                                                     <ul className="list-disc list-inside pl-2 text-gray-700">
                                                     {order.items.map(item => (
-                                                        <li key={item.id}>{item.quantite}x {item.nom_produit} - <span className="font-semibold">{(item.prix_unitaire * item.quantite).toFixed(2)}€</span></li>
+                                                        <li key={item.id}>{item.quantite}x {item.nom_produit} - <span className="font-semibold">{formatIntegerAmount(item.prix_unitaire * item.quantite)}€</span></li>
                                                     ))}
                                                     </ul>
                                                 </div>
@@ -167,8 +168,8 @@ const ResumeVentes: React.FC = () => {
                          <tfoot className="border-t-2 border-gray-300">
                             <tr className="font-bold text-gray-900">
                                 <td colSpan={4} className="p-3 text-right">TOTAUX</td>
-                                <td className="p-3 text-right">{totals.totalSales.toFixed(2)} €</td>
-                                <td className="p-3 text-right text-green-700">{totals.totalProfit.toFixed(2)} €</td>
+                                <td className="p-3 text-right">{formatIntegerAmount(totals.totalSales)} €</td>
+                                <td className="p-3 text-right text-green-700">{formatIntegerAmount(totals.totalProfit)} €</td>
                                 <td></td>
                             </tr>
                         </tfoot>

--- a/utils/formatIntegerAmount.ts
+++ b/utils/formatIntegerAmount.ts
@@ -1,0 +1,11 @@
+const integerAmountFormatter = new Intl.NumberFormat('fr-FR', {
+  maximumFractionDigits: 0,
+});
+
+export function formatIntegerAmount(value: number): string {
+  if (!Number.isFinite(value)) {
+    return '0';
+  }
+
+  return integerAmountFormatter.format(Math.round(value));
+}


### PR DESCRIPTION
## Summary
- add a shared `formatIntegerAmount` helper that rounds amounts and formats them with the fr-FR locale
- replace direct numeric formatting with the helper across dashboards, orders, reports, CSV exports, and WhatsApp messages
- ensure derived metrics such as margins and percentages use integer rounding before display

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d7bd83d2f0832a9bb21bdde677ddc4