### PR TITLE
Supprime les en-têtes décoratifs des pages back-office

### DIFF
--- a/pages/Cuisine.tsx
+++ b/pages/Cuisine.tsx
@@ -156,11 +156,10 @@ const Cuisine: React.FC = () => {
 
     return (
         <div className="flex h-full flex-col">
-            <div className="mb-4 text-3xl font-bold text-white sm:mb-6">Vue Cuisine</div>
             {orders.length === 0 ? (
-                <div className="flex flex-1 items-center justify-center text-2xl text-gray-500">Aucune commande en préparation.</div>
+                <div className="mt-6 flex flex-1 items-center justify-center text-2xl text-gray-500">Aucune commande en préparation.</div>
             ) : (
-                <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 flex-1">
+                <div className="mt-6 grid flex-1 grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                     {orders.map(order => (
                         <KitchenTicketCard key={order.ticketKey} order={order} onReady={handleMarkAsReady} canMarkReady={canMarkReady} />
                     ))}

--- a/pages/Ingredients.tsx
+++ b/pages/Ingredients.tsx
@@ -60,9 +60,7 @@ const Ingredients: React.FC = () => {
 
     return (
         <div className="space-y-6">
-            <div className="text-heading">Gestion des Ingrédients</div>
-
-            <div className="flex flex-col sm:flex-row justify-between items-center gap-4">
+            <div className="mt-6 flex flex-col sm:flex-row justify-between items-center gap-4">
                 <div className="relative w-full sm:w-auto">
                     <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={20} />
                     <input

--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -186,8 +186,7 @@ const ParaLlevar: React.FC = () => {
 
     return (
         <div className="space-y-6">
-            <div className="text-3xl font-bold text-gray-900">Commandes à Emporter</div>
-            <div className="grid grid-cols-1 gap-8 sm:grid-cols-2">
+            <div className="mt-6 grid grid-cols-1 gap-8 sm:grid-cols-2">
                 {/* Column for validation */}
                 <div className="bg-gray-100 p-4 rounded-xl">
                     <h2 className="text-xl font-bold mb-4 text-center text-blue-700">En Attente de Validation ({pendingOrders.length})</h2>

--- a/pages/Produits.tsx
+++ b/pages/Produits.tsx
@@ -100,9 +100,7 @@ const Produits: React.FC = () => {
 
     return (
         <div className="space-y-6">
-            <div className="text-heading">Gestion des Produits</div>
-
-            <div className="ui-card p-4 flex flex-col sm:flex-row justify-between items-center gap-4">
+            <div className="mt-6 ui-card p-4 flex flex-col sm:flex-row justify-between items-center gap-4">
                 <div className="flex flex-col sm:flex-row gap-4 w-full">
                     <div className="relative flex-grow">
                         <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={20} />

--- a/pages/ResumeVentes.tsx
+++ b/pages/ResumeVentes.tsx
@@ -88,8 +88,7 @@ const ResumeVentes: React.FC = () => {
 
     return (
         <div className="space-y-6">
-            <div className="text-3xl font-bold text-white">Résumé des Ventes par Commande</div>
-            <div className="bg-white p-4 rounded-xl shadow-md space-y-4">
+            <div className="mt-6 space-y-4 rounded-xl bg-white p-4 shadow-md">
                  <div className="flex flex-wrap items-end gap-4">
                      <div className="flex-grow">
                         <label className="text-sm font-medium text-gray-700">Date de début</label>

--- a/pages/Ventes.tsx
+++ b/pages/Ventes.tsx
@@ -148,8 +148,7 @@ const Ventes: React.FC = () => {
 
     return (
         <div>
-            <div className="section-title">Plan de salle</div>
-            <div className="status-grid">
+            <div className="mt-6 status-grid">
                 {tables.map(table => (
                     <TableCard key={table.id} table={table} onServe={handleServeOrder} />
                 ))}


### PR DESCRIPTION
## Summary
- retire les conteneurs de titres redondants des vues ParaLlevar, Résumé des ventes, Cuisine, Ingrédients, Produits et Ventes
- applique des marges supérieures cohérentes sur les blocs principaux pour conserver l’espacement vertical

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d7c39186d0832a965040d0abac492a