### PR TITLE
Center status card header content

### DIFF
--- a/styles/globals.css
+++ b/styles/globals.css
@@ -681,8 +681,9 @@ body {
 .status-card__header {
   display: flex;
   flex-direction: column;
-  align-items: flex-start;
+  align-items: center;
   gap: 0.75rem;
+  text-align: center;
 }
 
 .status-card__timer {


### PR DESCRIPTION
## Summary
- center align status card headers to keep table names centered
- ensure header text alignment works with existing timer layout

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68d7c4c5e720832aa8433d37ceeba01d