### PR TITLE
Improve responsive layouts and typography

### DIFF
--- a/components/ReportModal.tsx
+++ b/components/ReportModal.tsx
@@ -12,7 +12,7 @@ const ReportStat: React.FC<{ icon: React.ReactNode, label: string, value: string
         </div>
         <div className="space-y-1">
             <p className="text-xs sm:text-sm text-gray-500 font-semibold">{label}</p>
-            <p className="text-lg sm:text-xl font-bold text-gray-800">{value}</p>
+            <p className="font-bold text-gray-800 text-[clamp(1.1rem,2.5vw,1.5rem)]">{value}</p>
         </div>
     </div>
 );
@@ -138,7 +138,7 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
                                 </div>
                             )}
                             <div className="text-center border-b pb-4">
-                                 <h2 className="text-3xl font-bold text-brand-secondary">Rapport OUIOUITACOS</h2>
+                                 <h2 className="font-bold text-brand-secondary text-[clamp(1.75rem,4vw,2.75rem)]">Rapport OUIOUITACOS</h2>
                                  <p className="text-gray-500">
                                      Généré le {new Date(report.generatedAt).toLocaleString('fr-FR')}
                                  </p>

--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -529,7 +529,7 @@ const Commande: React.FC = () => {
 
     return (
         <>
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 h-[calc(100vh-10rem)]">
+        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 min-h-[calc(100vh-12rem)] lg:h-[calc(100vh-10rem)]">
             {/* Menu Section */}
             <div className="lg:col-span-2 ui-card flex flex-col">
             <div className="p-4 border-b">

--- a/pages/Dashboard.tsx
+++ b/pages/Dashboard.tsx
@@ -14,7 +14,7 @@ const MainStatCard: React.FC<{ title: string; value: string; icon: React.ReactNo
         </div>
         <div>
             <p className="text-sm font-semibold text-gray-500">{title}</p>
-            <p className="text-3xl font-bold text-gray-800">{value}</p>
+            <p className="text-2xl md:text-3xl xl:text-4xl font-bold text-gray-800">{value}</p>
         </div>
     </div>
 );
@@ -26,7 +26,7 @@ const OpStatCard: React.FC<{ title: string; value: string | number; icon: React.
         </div>
         <div>
             <p className="text-xs text-gray-500">{title}</p>
-            <p className="text-xl font-bold text-gray-800">{value}</p>
+            <p className="text-lg sm:text-xl xl:text-2xl font-bold text-gray-800">{value}</p>
         </div>
     </div>
 );
@@ -112,7 +112,7 @@ const Dashboard: React.FC = () => {
             </div>
 
             {/* Block 1: Key Indicators */}
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
+            <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
                 <MainStatCard title={`Ventes (${stats.periodLabel})`} value={`${formatIntegerAmount(stats.ventesPeriode)} €`} icon={<DollarSign size={28}/>} />
                 <MainStatCard title={`Bénéfice (${stats.periodLabel})`} value={`${formatIntegerAmount(stats.beneficePeriode)} €`} icon={<DollarSign size={28}/>} />
                 <MainStatCard title={`Clients (${stats.periodLabel})`} value={stats.clientsPeriode.toString()} icon={<Users size={28}/>} />
@@ -120,11 +120,11 @@ const Dashboard: React.FC = () => {
             </div>
 
             {/* Block 2: Operational Status */}
-             <div className="grid grid-cols-2 md:grid-cols-4 gap-6">
+             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
                 <OpStatCard title="Tables Occupées" value={stats.tablesOccupees} icon={<Armchair size={24}/>} />
                 <OpStatCard title="Clients Actuels" value={stats.clientsActuels} icon={<Users size={24}/>} />
                 <OpStatCard title="En Cuisine" value={stats.commandesEnCuisine} icon={<Soup size={24}/>} />
-                <OpStatCard 
+                <OpStatCard
                     title="Ingrédients Bas" 
                     value={stats.ingredientsStockBas.length} 
                     icon={<AlertTriangle size={24} className={stats.ingredientsStockBas.length > 0 ? 'text-red-500' : 'text-gray-600'} />}

--- a/pages/Ingredients.tsx
+++ b/pages/Ingredients.tsx
@@ -60,8 +60,8 @@ const Ingredients: React.FC = () => {
 
     return (
         <div className="space-y-6">
-            <div className="mt-6 flex flex-col sm:flex-row justify-between items-center gap-4">
-                <div className="relative w-full sm:w-auto">
+            <div className="mt-6 flex flex-col md:flex-row md:justify-between md:items-center gap-4">
+                <div className="relative w-full md:w-80">
                     <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={20} />
                     <input
                         type="text"
@@ -72,7 +72,7 @@ const Ingredients: React.FC = () => {
                     />
                 </div>
                 {canEdit && (
-                    <button onClick={() => handleOpenModal('add')} className="w-full sm:w-auto ui-btn-primary">
+                    <button onClick={() => handleOpenModal('add')} className="w-full md:w-auto ui-btn-primary">
                         <PlusCircle size={20} />
                         Ajouter un ingrédient
                     </button>

--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -28,7 +28,7 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                     <div className="flex flex-col gap-3">
                         <div className="flex items-start justify-between gap-3">
                             <div className="space-y-1">
-                                <h4 className="text-xl font-semibold leading-tight text-gray-900">{displayName}</h4>
+                                <h4 className="text-lg sm:text-xl md:text-2xl font-semibold leading-tight text-gray-900">{displayName}</h4>
                                 <p className="text-xs text-gray-500">
                                     Commande envoyée {new Date(timerStart).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}
                                 </p>
@@ -38,7 +38,7 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                                 <span>{urgencyLabelMap[urgencyStyles.level]}</span>
                             </span>
                         </div>
-                        <OrderTimer startTime={timerStart} className="text-base" />
+                        <OrderTimer startTime={timerStart} className="text-sm sm:text-base" />
                     </div>
                 </header>
 
@@ -67,7 +67,7 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                                 <li key={item.id} className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-900 shadow-sm">
                                     <div className="flex items-baseline justify-between gap-3 text-gray-900">
                                         <span className="font-semibold text-gray-900">{item.nom_produit}</span>
-                                        <span className="text-lg font-bold text-gray-900">{item.quantite}×</span>
+                                        <span className="text-base sm:text-lg font-bold text-gray-900">{item.quantite}×</span>
                                     </div>
                                 </li>
                             ))}
@@ -76,7 +76,7 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
 
                     <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 font-semibold text-gray-900 shadow-sm">
                         <span>Total</span>
-                        <span className="text-gray-900">{formatIntegerAmount(order.total)} €</span>
+                        <span className="text-lg sm:text-xl text-gray-900">{formatIntegerAmount(order.total)} €</span>
                     </div>
                 </div>
 
@@ -186,10 +186,10 @@ const ParaLlevar: React.FC = () => {
 
     return (
         <div className="space-y-6">
-            <div className="mt-6 grid grid-cols-1 gap-8 sm:grid-cols-2">
+            <div className="mt-6 grid grid-cols-1 gap-8 md:grid-cols-2">
                 {/* Column for validation */}
                 <div className="bg-gray-100 p-4 rounded-xl">
-                    <h2 className="text-xl font-bold mb-4 text-center text-blue-700">En Attente de Validation ({pendingOrders.length})</h2>
+                    <h2 className="text-lg sm:text-xl font-bold mb-4 text-center text-blue-700">En Attente de Validation ({pendingOrders.length})</h2>
                     <div className="space-y-4">
                         {pendingOrders.length > 0 ? pendingOrders.map(order => (
                             <TakeawayCard key={order.id} order={order} onValidate={handleValidate} isProcessing={processingOrderId === order.id} />
@@ -199,7 +199,7 @@ const ParaLlevar: React.FC = () => {
 
                 {/* Column for ready orders */}
                 <div className="bg-gray-100 p-4 rounded-xl">
-                    <h2 className="text-xl font-bold mb-4 text-center text-green-700">Commandes Prêtes ({readyOrders.length})</h2>
+                    <h2 className="text-lg sm:text-xl font-bold mb-4 text-center text-green-700">Commandes Prêtes ({readyOrders.length})</h2>
                     <div className="space-y-4">
                         {readyOrders.length > 0 ? readyOrders.map(order => (
                             <TakeawayCard key={order.id} order={order} onDeliver={handleDeliver} isProcessing={processingOrderId === order.id} />

--- a/pages/Produits.tsx
+++ b/pages/Produits.tsx
@@ -100,9 +100,9 @@ const Produits: React.FC = () => {
 
     return (
         <div className="space-y-6">
-            <div className="mt-6 ui-card p-4 flex flex-col sm:flex-row justify-between items-center gap-4">
-                <div className="flex flex-col sm:flex-row gap-4 w-full">
-                    <div className="relative flex-grow">
+            <div className="mt-6 ui-card p-4 flex flex-col lg:flex-row justify-between items-center gap-4">
+                <div className="flex flex-col md:flex-row gap-4 w-full">
+                    <div className="relative flex-grow md:max-w-md">
                         <Search className="absolute left-3 top-1/2 -translate-y-1/2 text-gray-400" size={20} />
                         <input
                             type="text"
@@ -115,18 +115,18 @@ const Produits: React.FC = () => {
                     <select
                         value={categoryFilter}
                         onChange={e => setCategoryFilter(e.target.value)}
-                        className="ui-select sm:w-56"
+                        className="ui-select md:w-56"
                     >
                         <option value="all">Toutes les catégories</option>
                         {categories.map(cat => <option key={cat.id} value={cat.id}>{cat.nom}</option>)}
                     </select>
                 </div>
                 {canEdit && (
-                    <div className="flex gap-2 w-full sm:w-auto">
-                        <button onClick={() => setCategoryModalOpen(true)} className="flex-1 sm:flex-initial ui-btn-secondary">
+                    <div className="flex gap-2 w-full lg:w-auto">
+                        <button onClick={() => setCategoryModalOpen(true)} className="flex-1 lg:flex-initial ui-btn-secondary">
                             <Settings size={20} />
                         </button>
-                        <button onClick={() => handleOpenModal('product', 'add')} className="flex-1 sm:flex-initial ui-btn-primary">
+                        <button onClick={() => handleOpenModal('product', 'add')} className="flex-1 lg:flex-initial ui-btn-primary">
                             <PlusCircle size={20} />
                             Ajouter Produit
                         </button>

--- a/pages/ResumeVentes.tsx
+++ b/pages/ResumeVentes.tsx
@@ -89,16 +89,16 @@ const ResumeVentes: React.FC = () => {
     return (
         <div className="space-y-6">
             <div className="mt-6 space-y-4 rounded-xl bg-white p-4 shadow-md">
-                 <div className="flex flex-wrap items-end gap-4">
-                     <div className="flex-grow">
+                 <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
+                     <div className="flex flex-col">
                         <label className="text-sm font-medium text-gray-700">Date de début</label>
                         <input type="date" name="startDate" value={filters.startDate} onChange={handleFilterChange} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-900"/>
                     </div>
-                    <div className="flex-grow">
+                    <div className="flex flex-col">
                         <label className="text-sm font-medium text-gray-700">Date de fin</label>
                         <input type="date" name="endDate" value={filters.endDate} onChange={handleFilterChange} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-900"/>
                     </div>
-                    <div className="flex-grow">
+                    <div className="flex flex-col">
                         <label className="text-sm font-medium text-gray-700">Méthode de paiement</label>
                         <select name="paymentMethod" value={filters.paymentMethod} onChange={handleFilterChange} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-900">
                             <option value="all">Toutes</option>
@@ -107,7 +107,7 @@ const ResumeVentes: React.FC = () => {
                             <option value="tarjeta">Tarjeta</option>
                         </select>
                     </div>
-                    <button onClick={exportToCSV} className="bg-green-600 text-white font-bold py-2 px-4 rounded-lg flex items-center gap-2 hover:bg-green-700 transition h-10">
+                    <button onClick={exportToCSV} className="bg-green-600 text-white font-bold py-2 px-4 rounded-lg flex items-center justify-center gap-2 hover:bg-green-700 transition h-12 sm:h-full sm:self-end">
                         <Download size={18} /> Export CSV
                     </button>
                 </div>


### PR DESCRIPTION
## Summary
- replace fixed heights in the order screen with responsive min-height/desktop height handling to avoid clipping on smaller viewports
- update dashboard statistics and report modal headings with adaptive typography for better readability
- tweak grid and flex layouts across data-heavy screens to add responsive breakpoints and spacing improvements

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68d7c70a92d8832a92c25962a5cf5783