### PR TITLE
Add table management workflow on sales floor

### DIFF
--- a/components/TableModal.tsx
+++ b/components/TableModal.tsx
@@ -1,0 +1,234 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import Modal from './Modal';
+
+export type TableFormValues = {
+  nom: string;
+  capacite: number;
+  couverts?: number;
+};
+
+interface TableModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+  mode: 'create' | 'edit';
+  initialValues?: Partial<TableFormValues>;
+  onSubmit: (values: TableFormValues) => Promise<void>;
+  showCouvertsField?: boolean;
+}
+
+type FieldErrors = Partial<Record<'nom' | 'capacite' | 'couverts', string>>;
+
+const defaultFormState = { nom: '', capacite: '', couverts: '' } as const;
+
+const TableModal: React.FC<TableModalProps> = ({
+  isOpen,
+  onClose,
+  mode,
+  initialValues,
+  onSubmit,
+  showCouvertsField = false,
+}) => {
+  const [formState, setFormState] = useState<typeof defaultFormState>(defaultFormState);
+  const [fieldErrors, setFieldErrors] = useState<FieldErrors>({});
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const modalTitle = useMemo(
+    () => (mode === 'create' ? 'Ajouter une table' : 'Modifier la table'),
+    [mode],
+  );
+
+  useEffect(() => {
+    if (!isOpen) {
+      setFormState(defaultFormState);
+      setFieldErrors({});
+      setSubmitError(null);
+      setIsSubmitting(false);
+      return;
+    }
+
+    const nextState = {
+      nom: initialValues?.nom ?? '',
+      capacite: initialValues?.capacite ? String(initialValues.capacite) : '',
+      couverts:
+        showCouvertsField && initialValues?.couverts !== undefined
+          ? String(initialValues.couverts)
+          : '',
+    } as typeof defaultFormState;
+
+    setFormState(nextState);
+    setFieldErrors({});
+    setSubmitError(null);
+  }, [initialValues?.capacite, initialValues?.couverts, initialValues?.nom, isOpen, showCouvertsField]);
+
+  const handleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = event.target;
+    setFormState(prev => ({
+      ...prev,
+      [name]: value,
+    }));
+  };
+
+  const validate = (): FieldErrors => {
+    const errors: FieldErrors = {};
+    const trimmedName = formState.nom.trim();
+    const trimmedCapacity = formState.capacite.trim();
+
+    if (!trimmedName) {
+      errors.nom = 'Le nom est requis.';
+    }
+
+    let capacityValue: number | null = null;
+    if (!trimmedCapacity) {
+      errors.capacite = 'La capacité est requise.';
+    } else {
+      const parsed = Number(trimmedCapacity);
+      if (!Number.isInteger(parsed) || parsed <= 0) {
+        errors.capacite = 'La capacité doit être un entier positif.';
+      } else {
+        capacityValue = parsed;
+      }
+    }
+
+    if (showCouvertsField) {
+      const trimmedCouverts = formState.couverts.trim();
+      if (!trimmedCouverts) {
+        errors.couverts = 'Le nombre de couverts est requis.';
+      } else {
+        const parsed = Number(trimmedCouverts);
+        if (!Number.isInteger(parsed) || parsed <= 0) {
+          errors.couverts = 'Les couverts doivent être un entier positif.';
+        } else if (capacityValue !== null && parsed > capacityValue) {
+          errors.couverts = 'Les couverts ne peuvent pas dépasser la capacité.';
+        }
+      }
+    }
+
+    return errors;
+  };
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setFieldErrors({});
+    setSubmitError(null);
+
+    const errors = validate();
+    if (Object.keys(errors).length > 0) {
+      setFieldErrors(errors);
+      return;
+    }
+
+    const payload: TableFormValues = {
+      nom: formState.nom.trim(),
+      capacite: Number(formState.capacite.trim()),
+    };
+
+    if (showCouvertsField) {
+      const trimmed = formState.couverts.trim();
+      if (trimmed) {
+        payload.couverts = Number(trimmed);
+      }
+    }
+
+    setIsSubmitting(true);
+    try {
+      await onSubmit(payload);
+    } catch (error) {
+      const message =
+        error instanceof Error && error.message
+          ? error.message
+          : 'Une erreur est survenue. Veuillez réessayer.';
+      setSubmitError(message);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  return (
+    <Modal isOpen={isOpen} onClose={onClose} title={modalTitle} size="md">
+      <form onSubmit={handleSubmit} className="space-y-5">
+        {submitError && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
+            {submitError}
+          </div>
+        )}
+
+        <div>
+          <label htmlFor="table-name" className="block text-sm font-medium text-gray-700">
+            Nom de la table
+          </label>
+          <input
+            id="table-name"
+            name="nom"
+            type="text"
+            className="ui-input mt-1"
+            value={formState.nom}
+            onChange={handleChange}
+            disabled={isSubmitting}
+            placeholder="Ex. Terrasse 1"
+            autoFocus
+          />
+          {fieldErrors.nom && <p className="mt-1 text-sm text-red-600">{fieldErrors.nom}</p>}
+        </div>
+
+        <div>
+          <label htmlFor="table-capacity" className="block text-sm font-medium text-gray-700">
+            Capacité (nombre de places)
+          </label>
+          <input
+            id="table-capacity"
+            name="capacite"
+            type="number"
+            min={1}
+            className="ui-input mt-1"
+            value={formState.capacite}
+            onChange={handleChange}
+            disabled={isSubmitting}
+            placeholder="Ex. 4"
+          />
+          {fieldErrors.capacite && <p className="mt-1 text-sm text-red-600">{fieldErrors.capacite}</p>}
+        </div>
+
+        {showCouvertsField && (
+          <div>
+            <label htmlFor="table-couverts" className="block text-sm font-medium text-gray-700">
+              Couverts (actuels)
+            </label>
+            <input
+              id="table-couverts"
+              name="couverts"
+              type="number"
+              min={1}
+              className="ui-input mt-1"
+              value={formState.couverts}
+              onChange={handleChange}
+              disabled={isSubmitting}
+              placeholder="Ex. 2"
+            />
+            {fieldErrors.couverts && <p className="mt-1 text-sm text-red-600">{fieldErrors.couverts}</p>}
+          </div>
+        )}
+
+        <div className="flex flex-col gap-3 pt-2 sm:flex-row">
+          <button
+            type="button"
+            onClick={onClose}
+            className="w-full ui-btn-secondary py-3"
+            disabled={isSubmitting}
+          >
+            Annuler
+          </button>
+          <button
+            type="submit"
+            className="w-full ui-btn-primary py-3 disabled:opacity-60"
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Enregistrement...' : 'Enregistrer'}
+          </button>
+        </div>
+      </form>
+    </Modal>
+  );
+};
+
+export default TableModal;

--- a/pages/Ventes.tsx
+++ b/pages/Ventes.tsx
@@ -1,9 +1,20 @@
 import React, { useEffect, useState, useCallback, useRef } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Armchair, DollarSign, Utensils, HandPlatter } from 'lucide-react';
+import {
+  Armchair,
+  DollarSign,
+  Utensils,
+  HandPlatter,
+  MoreVertical,
+  Pencil,
+  Trash2,
+  Plus,
+} from 'lucide-react';
 import { api } from '../services/api';
 import { Table } from '../types';
 import OrderTimer from '../components/OrderTimer';
+import TableModal, { TableFormValues } from '../components/TableModal';
+import { useAuth } from '../contexts/AuthContext';
 
 type StatusDescriptor = { text: string; statusClass: string; Icon: React.ComponentType<{ size?: number }> };
 
@@ -41,10 +52,18 @@ const getTableStatus = (table: Table): StatusDescriptor => {
   }
 };
 
-
-const TableCard: React.FC<{ table: Table; onServe: (orderId: string) => void }> = ({ table, onServe }) => {
+const TableCard: React.FC<{
+  table: Table;
+  onServe: (orderId: string) => void;
+  canEdit: boolean;
+  onEdit?: (table: Table) => void;
+  onDelete?: (table: Table) => Promise<void> | void;
+  isDeleting?: boolean;
+}> = ({ table, onServe, canEdit, onEdit, onDelete, isDeleting }) => {
   const navigate = useNavigate();
   const { text, statusClass, Icon } = getTableStatus(table);
+  const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const menuRef = useRef<HTMLDivElement | null>(null);
 
   const handleCardClick = () => {
     navigate(`/commande/${table.id}`);
@@ -64,14 +83,93 @@ const TableCard: React.FC<{ table: Table; onServe: (orderId: string) => void }> 
     }
   };
 
+  const handleMenuToggle = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    setIsMenuOpen(prev => !prev);
+  };
+
+  useEffect(() => {
+    if (!isMenuOpen) {
+      return;
+    }
+
+    const handleClickOutside = (event: MouseEvent) => {
+      if (menuRef.current && !menuRef.current.contains(event.target as Node)) {
+        setIsMenuOpen(false);
+      }
+    };
+
+    document.addEventListener('mousedown', handleClickOutside);
+    return () => {
+      document.removeEventListener('mousedown', handleClickOutside);
+    };
+  }, [isMenuOpen]);
+
+  const handleEditClick = (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    setIsMenuOpen(false);
+    onEdit?.(table);
+  };
+
+  const handleDeleteClick = async (event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    setIsMenuOpen(false);
+    if (!onDelete) {
+      return;
+    }
+
+    try {
+      await onDelete(table);
+    } catch (error) {
+      console.error('Failed to delete table from card:', error);
+    }
+  };
+
   return (
     <div
       onClick={handleCardClick}
       onKeyDown={handleCardKeyDown}
-      className={`ui-card status-card ${statusClass}`}
+      className={`ui-card status-card ${statusClass} relative`}
       role="button"
       tabIndex={0}
     >
+      {canEdit && (
+        <div className="absolute right-3 top-3" ref={menuRef}>
+          <button
+            type="button"
+            onClick={handleMenuToggle}
+            className="flex h-9 w-9 items-center justify-center rounded-full text-gray-500 transition hover:bg-gray-100 hover:text-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-primary-500 disabled:cursor-not-allowed disabled:opacity-60"
+            aria-haspopup="menu"
+            aria-expanded={isMenuOpen}
+            aria-label="Options de la table"
+            disabled={isDeleting}
+          >
+            <MoreVertical size={18} />
+          </button>
+          {isMenuOpen && (
+            <div className="absolute right-0 mt-2 w-44 rounded-md border border-gray-200 bg-white py-1 text-sm shadow-lg">
+              <button
+                type="button"
+                onClick={handleEditClick}
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-gray-700 transition hover:bg-gray-100"
+              >
+                <Pencil size={16} />
+                Modifier
+              </button>
+              <button
+                type="button"
+                onClick={handleDeleteClick}
+                className="flex w-full items-center gap-2 px-3 py-2 text-left text-red-600 transition hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                disabled={isDeleting}
+              >
+                <Trash2 size={16} />
+                {isDeleting ? 'Suppression…' : 'Supprimer'}
+              </button>
+            </div>
+          )}
+        </div>
+      )}
+
       <div className="status-card__header">
         <h3 className="status-card__title">{table.nom}</h3>
         {table.date_envoi_cuisine && table.statut !== 'libre' && (
@@ -104,57 +202,211 @@ const TableCard: React.FC<{ table: Table; onServe: (orderId: string) => void }> 
 };
 
 const Ventes: React.FC = () => {
-    const [tables, setTables] = useState<Table[]>([]);
-    const [loading, setLoading] = useState(true);
-    const fetchIdRef = useRef(0);
+  const { role } = useAuth();
+  const canEditTables = role?.permissions?.['/ventes'] === 'editor';
 
-    const fetchTables = useCallback(async () => {
-        const fetchId = ++fetchIdRef.current;
-        try {
-            const data = await api.getTables();
-            if (fetchId === fetchIdRef.current) {
-                setTables(data);
-            }
-        } catch (error) {
-            console.error("Failed to fetch tables", error);
-        } finally {
-            if (fetchId === fetchIdRef.current) {
-                setLoading(false);
-            }
-        }
-    }, []);
-    
-    useEffect(() => {
-        setLoading(true);
-        fetchTables();
-        const interval = setInterval(fetchTables, 10000); // Refresh every 10 seconds
-        const unsubscribe = api.notifications.subscribe('orders_updated', fetchTables);
-        return () => {
-            clearInterval(interval);
-            unsubscribe();
-        };
-    }, [fetchTables]);
+  const [tables, setTables] = useState<Table[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [fetchError, setFetchError] = useState<string | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [actionSuccess, setActionSuccess] = useState<string | null>(null);
+  const [isModalOpen, setIsModalOpen] = useState(false);
+  const [modalMode, setModalMode] = useState<'create' | 'edit'>('create');
+  const [selectedTable, setSelectedTable] = useState<Table | null>(null);
+  const [deletingTableId, setDeletingTableId] = useState<string | null>(null);
+  const fetchIdRef = useRef(0);
 
-    const handleServeOrder = async (orderId: string) => {
-        try {
-            await api.markOrderAsServed(orderId);
-            fetchTables(); // Refresh table view immediately
-        } catch (error) {
-            console.error("Failed to mark order as served:", error);
-        }
+  const fetchTables = useCallback(async () => {
+    const fetchId = ++fetchIdRef.current;
+    try {
+      const data = await api.getTables();
+      if (fetchId === fetchIdRef.current) {
+        setTables(data);
+        setFetchError(null);
+      }
+    } catch (error) {
+      console.error('Failed to fetch tables', error);
+      if (fetchId === fetchIdRef.current) {
+        setFetchError('Impossible de charger le plan de salle. Veuillez réessayer.');
+      }
+    } finally {
+      if (fetchId === fetchIdRef.current) {
+        setLoading(false);
+      }
+    }
+  }, []);
+
+  useEffect(() => {
+    setLoading(true);
+    fetchTables();
+    const interval = setInterval(fetchTables, 10000);
+    const unsubscribe = api.notifications.subscribe('orders_updated', fetchTables);
+    return () => {
+      clearInterval(interval);
+      unsubscribe();
     };
+  }, [fetchTables]);
 
-    if (loading) return <p className="section-text section-text--muted">Chargement du plan de salle...</p>;
+  const handleModalClose = useCallback(() => {
+    setIsModalOpen(false);
+    setSelectedTable(null);
+  }, []);
 
-    return (
-        <div>
-            <div className="mt-6 status-grid">
-                {tables.map(table => (
-                    <TableCard key={table.id} table={table} onServe={handleServeOrder} />
-                ))}
-            </div>
-        </div>
-    );
+  const openCreateModal = useCallback(() => {
+    setModalMode('create');
+    setSelectedTable(null);
+    setActionError(null);
+    setActionSuccess(null);
+    setIsModalOpen(true);
+  }, []);
+
+  const handleEditTable = useCallback((table: Table) => {
+    setModalMode('edit');
+    setSelectedTable(table);
+    setActionError(null);
+    setActionSuccess(null);
+    setIsModalOpen(true);
+  }, []);
+
+  const handleModalSubmit = useCallback(
+    async (values: TableFormValues) => {
+      setActionError(null);
+      setActionSuccess(null);
+
+      try {
+        let successMessage = '';
+        if (modalMode === 'create') {
+          await api.createTable(values);
+          successMessage = 'Table créée avec succès.';
+        } else {
+          if (!selectedTable) {
+            const message = 'Aucune table sélectionnée pour la mise à jour.';
+            setActionError(message);
+            throw new Error(message);
+          }
+          await api.updateTable(selectedTable.id, values);
+          successMessage = 'Table mise à jour avec succès.';
+        }
+
+        await fetchTables();
+        handleModalClose();
+        setActionSuccess(successMessage);
+      } catch (error) {
+        console.error('Failed to save table:', error);
+        const message =
+          modalMode === 'create'
+            ? 'Impossible de créer la table. Veuillez réessayer.'
+            : 'Impossible de mettre à jour la table. Veuillez réessayer.';
+        setActionError(message);
+        throw new Error(message);
+      }
+    },
+    [fetchTables, handleModalClose, modalMode, selectedTable],
+  );
+
+  const handleDeleteTable = useCallback(
+    async (table: Table) => {
+      if (!confirm('Supprimer cette table ? Cette action est irréversible.')) {
+        return;
+      }
+
+      setActionError(null);
+      setActionSuccess(null);
+      setDeletingTableId(table.id);
+
+      try {
+        await api.deleteTable(table.id);
+        await fetchTables();
+        setActionSuccess('Table supprimée avec succès.');
+      } catch (error) {
+        console.error('Failed to delete table:', error);
+        setActionError('Impossible de supprimer la table. Veuillez réessayer.');
+      } finally {
+        setDeletingTableId(null);
+      }
+    },
+    [fetchTables],
+  );
+
+  const handleServeOrder = useCallback(
+    async (orderId: string) => {
+      setActionError(null);
+      setActionSuccess(null);
+      try {
+        await api.markOrderAsServed(orderId);
+        await fetchTables();
+      } catch (error) {
+        console.error('Failed to mark order as served:', error);
+        setActionError('Impossible de marquer la commande comme servie. Veuillez réessayer.');
+      }
+    },
+    [fetchTables],
+  );
+
+  if (loading) {
+    return <p className="section-text section-text--muted">Chargement du plan de salle...</p>;
+  }
+
+  const modalInitialValues =
+    modalMode === 'edit' && selectedTable
+      ? {
+          nom: selectedTable.nom,
+          capacite: selectedTable.capacite,
+          couverts: selectedTable.couverts,
+        }
+      : undefined;
+
+  const showCouvertsField = modalMode === 'edit' && Boolean(selectedTable?.commandeId);
+
+  return (
+    <div>
+      <div className="flex flex-col gap-4">
+        {canEditTables && (
+          <div className="flex justify-end">
+            <button type="button" onClick={openCreateModal} className="ui-btn ui-btn-primary flex items-center gap-2">
+              <Plus size={18} />
+              Ajouter une table
+            </button>
+          </div>
+        )}
+
+        {fetchError && (
+          <div className="rounded-md border border-amber-200 bg-amber-50 p-4 text-sm text-amber-700">{fetchError}</div>
+        )}
+
+        {actionError && (
+          <div className="rounded-md border border-red-200 bg-red-50 p-4 text-sm text-red-700">{actionError}</div>
+        )}
+
+        {actionSuccess && (
+          <div className="rounded-md border border-emerald-200 bg-emerald-50 p-4 text-sm text-emerald-700">{actionSuccess}</div>
+        )}
+      </div>
+
+      <div className="mt-6 status-grid">
+        {tables.map(table => (
+          <TableCard
+            key={table.id}
+            table={table}
+            onServe={handleServeOrder}
+            canEdit={Boolean(canEditTables)}
+            onEdit={handleEditTable}
+            onDelete={handleDeleteTable}
+            isDeleting={deletingTableId === table.id}
+          />
+        ))}
+      </div>
+
+      <TableModal
+        isOpen={isModalOpen}
+        onClose={handleModalClose}
+        mode={modalMode}
+        initialValues={modalInitialValues}
+        onSubmit={handleModalSubmit}
+        showCouvertsField={showCouvertsField}
+      />
+    </div>
+  );
 };
 
 export default Ventes;


### PR DESCRIPTION
## Summary
- add Supabase helpers to create, update, and delete restaurant tables while publishing refresh events
- introduce a validated TableModal form component for table creation and editing
- enhance the Ventes page with editor-only actions, modal integration, and card menus for editing or removing tables

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d7ca475a68832a86f611a9ed250d58