### PR TITLE
Empêcher la suppression des ingrédients utilisés

### DIFF
--- a/pages/Ingredients.tsx
+++ b/pages/Ingredients.tsx
@@ -252,15 +252,18 @@ const ResupplyModal: React.FC<{ isOpen: boolean; onClose: () => void; onSuccess:
 
 const DeleteModal: React.FC<{ isOpen: boolean; onClose: () => void; onSuccess: () => void; ingredient: Ingredient }> = ({ isOpen, onClose, onSuccess, ingredient }) => {
     const [isSubmitting, setSubmitting] = useState(false);
+    const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
     const handleDelete = async () => {
         setSubmitting(true);
+        setErrorMessage(null);
         try {
             await api.deleteIngredient(ingredient.id);
             onSuccess();
             onClose();
         } catch (error) {
             console.error("Failed to delete ingredient", error);
+            setErrorMessage("Impossible de supprimer cet ingrédient car il est utilisé dans au moins une recette.");
         } finally {
             setSubmitting(false);
         }
@@ -269,6 +272,7 @@ const DeleteModal: React.FC<{ isOpen: boolean; onClose: () => void; onSuccess: (
     return (
         <Modal isOpen={isOpen} onClose={onClose} title="Confirmer la Suppression">
             <p className="text-gray-700">Êtes-vous sûr de vouloir supprimer l'ingrédient <strong className="text-gray-900">{ingredient.nom}</strong> ? Cette action est irréversible.</p>
+            {errorMessage && <p className="mt-4 text-sm text-red-600">{errorMessage}</p>}
             <div className="flex flex-col sm:flex-row gap-3 pt-6">
                 <button type="button" onClick={onClose} className="w-full ui-btn-secondary py-3">Annuler</button>
                 <button onClick={handleDelete} disabled={isSubmitting} className="w-full ui-btn-danger py-3 disabled:opacity-60">{isSubmitting ? 'Suppression...' : 'Supprimer'}</button>

--- a/services/api.ts
+++ b/services/api.ts
@@ -1760,6 +1760,20 @@ export const api = {
   },
 
   deleteIngredient: async (ingredientId: string): Promise<{ success: boolean }> => {
+    const relatedRecipesResponse = await supabase
+      .from('product_recipes')
+      .select('ingredient_id, product_id, qte_utilisee')
+      .eq('ingredient_id', ingredientId)
+      .limit(1);
+
+    const relatedRecipes = unwrap<SupabaseRecipeRow[]>(
+      relatedRecipesResponse as SupabaseResponse<SupabaseRecipeRow[]>,
+    );
+
+    if (relatedRecipes.length > 0) {
+      throw new Error("Impossible de supprimer l'ingrédient car il est utilisé dans une recette.");
+    }
+
     await supabase.from('ingredients').delete().eq('id', ingredientId);
     notificationsService.publish('notifications_updated');
     return { success: true };


### PR DESCRIPTION
## Summary
- empêcher la suppression d'un ingrédient lorsqu'il est lié à une recette de produit
- informer l'utilisateur dans la modale de suppression lorsqu'un ingrédient ne peut pas être supprimé

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d815dd8870832ab2f8f74de2e0a8d9