### PR TITLE
Add site content management hook and customization page

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -13,7 +13,8 @@ import Produits from './pages/Produits';
 import CommandeClient from './pages/CommandeClient';
 import NotFound from './pages/NotFound';
 import ResumeVentes from './pages/ResumeVentes';
-import { NAV_LINKS } from './constants';
+import SiteCustomization from './pages/SiteCustomization';
+import { NAV_LINKS, SITE_CUSTOMIZER_PERMISSION_KEY } from './constants';
 
 const isPermissionGranted = (permission?: string) =>
   permission === 'editor' || permission === 'readonly';
@@ -64,6 +65,14 @@ const AppRoutes: React.FC = () => {
                 <Route path="resume-ventes" element={<PrivateRoute permissionKey="/resume-ventes"><ResumeVentes /></PrivateRoute>} />
                 <Route path="ingredients" element={<PrivateRoute permissionKey="/ingredients"><Ingredients /></PrivateRoute>} />
                 <Route path="produits" element={<PrivateRoute permissionKey="/produits"><Produits /></PrivateRoute>} />
+                <Route
+                  path={SITE_CUSTOMIZER_PERMISSION_KEY.slice(1)}
+                  element={
+                    <PrivateRoute permissionKey={SITE_CUSTOMIZER_PERMISSION_KEY}>
+                      <SiteCustomization />
+                    </PrivateRoute>
+                  }
+                />
             </Route>
             
             <Route path="*" element={<NotFound />} />

--- a/components/RoleManager.tsx
+++ b/components/RoleManager.tsx
@@ -2,7 +2,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { Plus, Save, Trash2 } from 'lucide-react';
 import Modal from './Modal';
 import { api } from '../services/api';
-import { NAV_LINKS, ROLE_HOME_PAGE_META_KEY } from '../constants';
+import { NAV_LINKS, ROLE_HOME_PAGE_META_KEY, ROLES, SITE_CUSTOMIZER_PERMISSION_KEY } from '../constants';
 import { Role } from '../types';
 import { useAuth } from '../contexts/AuthContext';
 
@@ -24,12 +24,25 @@ interface RoleFormState {
 const DEFAULT_HOME_PAGE = NAV_LINKS[0]?.permissionKey ?? '/dashboard';
 const isPermissionGranted = (permission?: PermissionLevel) => permission === 'editor' || permission === 'readonly';
 
-const ensureNavPermissions = (permissions?: Role['permissions']): Role['permissions'] => {
+const isAdminRoleName = (name?: string | null): boolean => {
+  if (!name) {
+    return false;
+  }
+
+  const normalized = name.trim().toLowerCase();
+  return normalized === ROLES.ADMIN || normalized === 'administrateur';
+};
+
+const ensureNavPermissions = (permissions?: Role['permissions'], roleName?: string | null): Role['permissions'] => {
   const base: Record<string, PermissionLevel> = { ...(permissions || {}) };
   delete base[ROLE_HOME_PAGE_META_KEY];
   NAV_LINKS.forEach(link => {
     if (!(link.permissionKey in base)) {
-      base[link.permissionKey] = 'none';
+      if (link.permissionKey === SITE_CUSTOMIZER_PERMISSION_KEY && isAdminRoleName(roleName)) {
+        base[link.permissionKey] = 'editor';
+      } else {
+        base[link.permissionKey] = 'none';
+      }
     }
   });
   return base;
@@ -163,7 +176,7 @@ const RoleManager: React.FC<RoleManagerProps> = ({ isOpen, onClose }) => {
   };
 
   const handleSelectRole = (role: Role) => {
-    const permissions = ensureNavPermissions(role.permissions);
+    const permissions = ensureNavPermissions(role.permissions, role.name);
     setMode('edit');
     setFormState({
       id: role.id,
@@ -216,7 +229,7 @@ const RoleManager: React.FC<RoleManagerProps> = ({ isOpen, onClose }) => {
     setIsSubmitting(true);
 
     try {
-      const permissions = ensureNavPermissions(formState.permissions);
+      const permissions = ensureNavPermissions(formState.permissions, formState.name);
       const resolvedHomePage = isPermissionGranted(permissions[formState.homePage])
         ? formState.homePage
         : getDefaultHomePage(permissions);
@@ -240,7 +253,7 @@ const RoleManager: React.FC<RoleManagerProps> = ({ isOpen, onClose }) => {
           homePage: resolvedHomePage,
         });
         setStatusMessage('Rôle mis à jour avec succès.');
-        const nextPermissions = ensureNavPermissions(updatedRole.permissions);
+        const nextPermissions = ensureNavPermissions(updatedRole.permissions, updatedRole.name);
         setFormState({
           id: updatedRole.id,
           name: updatedRole.name,

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -1,4 +1,6 @@
-import { LayoutDashboard, Package, Armchair, Soup, UtensilsCrossed, ShoppingBag, AreaChart } from 'lucide-react';
+import { LayoutDashboard, Package, Armchair, Soup, UtensilsCrossed, ShoppingBag, AreaChart, Brush } from 'lucide-react';
+
+export const SITE_CUSTOMIZER_PERMISSION_KEY = '/site-customizer';
 
 export const NAV_LINKS = [
   { name: 'Dashboard', href: '/dashboard', icon: LayoutDashboard, permissionKey: '/dashboard' },
@@ -6,6 +8,12 @@ export const NAV_LINKS = [
   { name: 'Plan de Salle', href: '/ventes', icon: Armchair, permissionKey: '/ventes' },
   { name: 'Cuisine', href: '/cocina', icon: Soup, permissionKey: '/cocina' },
   { name: 'Résumé Ventes', href: '/resume-ventes', icon: AreaChart, permissionKey: '/resume-ventes' },
+  {
+    name: 'Personnalisation',
+    href: SITE_CUSTOMIZER_PERMISSION_KEY,
+    icon: Brush,
+    permissionKey: SITE_CUSTOMIZER_PERMISSION_KEY,
+  },
   { name: 'Produits', href: '/produits', icon: UtensilsCrossed, permissionKey: '/produits' },
   { name: 'Ingrédients', href: '/ingredients', icon: Package, permissionKey: '/ingredients' },
 ];

--- a/hooks/useSiteContent.ts
+++ b/hooks/useSiteContent.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useState } from 'react';
+import { SiteContent } from '../types';
+import { api } from '../services/api';
+import { DEFAULT_SITE_CONTENT, resolveSiteContent } from '../utils/siteContent';
+
+interface UseSiteContentResult {
+  content: SiteContent;
+  loading: boolean;
+  error: string | null;
+  refresh: () => Promise<void>;
+  updateContent: (next: SiteContent) => Promise<SiteContent>;
+}
+
+const useSiteContent = (): UseSiteContentResult => {
+  const [content, setContent] = useState<SiteContent>(DEFAULT_SITE_CONTENT);
+  const [loading, setLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    try {
+      const remote = await api.getSiteContent();
+      setContent(resolveSiteContent(remote ?? undefined));
+      setError(null);
+    } catch (err) {
+      console.error('Failed to fetch site content', err);
+      setContent(DEFAULT_SITE_CONTENT);
+      setError(err instanceof Error ? err.message : 'Impossible de charger le contenu du site.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  const updateContent = useCallback(async (next: SiteContent) => {
+    const updated = await api.updateSiteContent(next);
+    const resolved = resolveSiteContent(updated);
+    setContent(resolved);
+    return resolved;
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  return {
+    content,
+    loading,
+    error,
+    refresh,
+    updateContent,
+  };
+};
+
+export default useSiteContent;
+export { DEFAULT_SITE_CONTENT };

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -8,6 +8,7 @@ import { Mail, MapPin, Phone, Menu, X } from 'lucide-react';
 import CustomerOrderTracker from '../components/CustomerOrderTracker';
 import { clearActiveCustomerOrder, getActiveCustomerOrder } from '../services/customerOrderStorage';
 import { formatIntegerAmount } from '../utils/formatIntegerAmount';
+import useSiteContent from '../hooks/useSiteContent';
 
 type PinInputProps = {
   pin: string;
@@ -117,7 +118,10 @@ const Login: React.FC = () => {
   const pinInputRef = useRef<HTMLInputElement>(null);
   const { login } = useAuth();
   const navigate = useNavigate();
-  
+  const { content: siteContent } = useSiteContent();
+  const { navigation, hero, about, menu: menuContent, contact, footer } = siteContent;
+  const heroBackgroundStyle = hero.backgroundImage ? { backgroundImage: `url('${hero.backgroundImage}')` } : undefined;
+
   const [products, setProducts] = useState<Product[]>([]);
   const [orderHistory, setOrderHistory] = useState<Order[]>([]);
   const [menuLoading, setMenuLoading] = useState(true);
@@ -203,14 +207,14 @@ const Login: React.FC = () => {
     <div className="login-page">
       <header className="login-header">
         <div className="layout-container login-header__inner">
-          <a href="#accueil" className="login-brand">OUIOUITACOS</a>
+          <a href="#accueil" className="login-brand">{navigation.brand}</a>
           <nav className="login-nav" aria-label="Navigation principale">
-            <a href="#accueil" className="login-nav__link">Accueil</a>
-            <a href="#apropos" className="login-nav__link">À propos</a>
-            <a href="#menu" className="login-nav__link">Menu</a>
-            <a href="#contact" className="login-nav__link">Contact</a>
+            <a href="#accueil" className="login-nav__link">{navigation.links.home}</a>
+            <a href="#apropos" className="login-nav__link">{navigation.links.about}</a>
+            <a href="#menu" className="login-nav__link">{navigation.links.menu}</a>
+            <a href="#contact" className="login-nav__link">{navigation.links.contact}</a>
             <button type="button" onClick={() => setIsModalOpen(true)} className="ui-btn ui-btn-accent login-nav__cta">
-              Staff Login
+              {navigation.links.loginCta}
             </button>
           </nav>
           <button type="button" onClick={() => setMobileMenuOpen(true)} className="login-header__menu" aria-label="Ouvrir le menu">
@@ -225,10 +229,18 @@ const Login: React.FC = () => {
             <X size={28} />
           </button>
           <nav className="login-menu-overlay__nav" aria-label="Navigation mobile">
-            <a href="#accueil" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">Accueil</a>
-            <a href="#apropos" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">À propos</a>
-            <a href="#menu" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">Menu</a>
-            <a href="#contact" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">Contact</a>
+            <a href="#accueil" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">
+              {navigation.links.home}
+            </a>
+            <a href="#apropos" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">
+              {navigation.links.about}
+            </a>
+            <a href="#menu" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">
+              {navigation.links.menu}
+            </a>
+            <a href="#contact" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">
+              {navigation.links.contact}
+            </a>
             <button
               type="button"
               onClick={() => {
@@ -237,33 +249,27 @@ const Login: React.FC = () => {
               }}
               className="ui-btn ui-btn-accent hero-cta"
             >
-              Staff Login
+              {navigation.links.loginCta}
             </button>
           </nav>
         </div>
       )}
 
       <main>
-        <section
-          id="accueil"
-          className="section section-hero"
-          style={{ backgroundImage: "url('https://picsum.photos/seed/tacosbg/1920/1080')" }}
-        >
+        <section id="accueil" className="section section-hero" style={heroBackgroundStyle}>
           <div className="section-hero__inner">
             {activeOrderId ? (
               <CustomerOrderTracker orderId={activeOrderId} onNewOrderClick={handleNewOrder} variant="hero" />
             ) : (
-              <div className="hero-content">
-                <h2 className="hero-title">Le Goût Authentique du Mexique</h2>
-                <p className="hero-subtitle">
-                  Des tacos préparés avec passion, des ingrédients frais et une touche de tradition pour un voyage gustatif inoubliable.
-                </p>
-                <button onClick={() => navigate('/commande-client')} className="ui-btn ui-btn-accent hero-cta">
-                  Commander en ligne
-                </button>
-                {orderHistory.length > 0 && (
-                  <div className="hero-history">
-                    <p className="hero-history__title">Vos dernières commandes</p>
+                <div className="hero-content">
+                  <h2 className="hero-title">{hero.title}</h2>
+                  <p className="hero-subtitle">{hero.subtitle}</p>
+                  <button onClick={() => navigate('/commande-client')} className="ui-btn ui-btn-accent hero-cta">
+                    {hero.ctaLabel}
+                  </button>
+                  {orderHistory.length > 0 && (
+                    <div className="hero-history">
+                      <p className="hero-history__title">{hero.historyTitle}</p>
                     <div className="hero-history__list">
                       {orderHistory.slice(0, 3).map(order => (
                         <div key={order.id} className="hero-history__item">
@@ -276,7 +282,7 @@ const Login: React.FC = () => {
                             onClick={() => handleQuickReorder(order.id)}
                             className="hero-history__cta"
                           >
-                            Commander à nouveau
+                            {hero.reorderCtaLabel}
                           </button>
                         </div>
                       ))}
@@ -290,19 +296,30 @@ const Login: React.FC = () => {
 
         <section id="apropos" className="section section-surface">
           <div className="section-inner section-inner--center">
-            <h2 className="section-title">Notre Histoire</h2>
-            <p className="section-text section-text--muted">
-              Fondé par des passionnés de la cuisine mexicaine, OUIOUITACOS est né d'un désir simple : partager le goût authentique des tacos faits maison.
-              Chaque recette est un héritage familial, chaque ingrédient est choisi avec soin, et chaque plat est préparé avec le cœur. Venez découvrir une explosion de saveurs qui vous transportera directement dans les rues de Mexico.
-            </p>
+            <h2 className="section-title">{about.title}</h2>
+            <p className="section-text section-text--muted">{about.description}</p>
+            {about.image && (
+              <img
+                src={about.image}
+                alt={about.title}
+                className="mt-6 h-64 w-full rounded-xl object-cover shadow-lg"
+              />
+            )}
           </div>
         </section>
 
         <section id="menu" className="section section-muted">
           <div className="section-inner section-inner--wide section-inner--center">
-            <h2 className="section-title">Nos Best-sellers</h2>
+            <h2 className="section-title">{menuContent.title}</h2>
+            {menuContent.image && (
+              <img
+                src={menuContent.image}
+                alt={menuContent.title}
+                className="mb-8 h-64 w-full rounded-xl object-cover shadow-lg"
+              />
+            )}
             {menuLoading ? (
-              <p className="section-text section-text--muted">Chargement du menu...</p>
+              <p className="section-text section-text--muted">{menuContent.loadingLabel}</p>
             ) : (
               <div className="menu-grid">
                 {products.map(product => (
@@ -319,7 +336,7 @@ const Login: React.FC = () => {
             )}
             <div className="section-actions">
               <button onClick={() => navigate('/commande-client')} className="ui-btn ui-btn-primary hero-cta">
-                Voir le menu complet & Commander
+                {menuContent.ctaLabel}
               </button>
             </div>
           </div>
@@ -327,22 +344,29 @@ const Login: React.FC = () => {
 
         <section id="contact" className="section section-surface">
           <div className="section-inner section-inner--wide section-inner--center">
-            <h2 className="section-title">Contactez-nous</h2>
+            <h2 className="section-title">{contact.title}</h2>
+            {contact.image && (
+              <img
+                src={contact.image}
+                alt={contact.title}
+                className="mb-8 h-64 w-full rounded-xl object-cover shadow-lg"
+              />
+            )}
             <div className="contact-grid">
               <div className="contact-card">
                 <MapPin className="contact-card__icon" />
-                <h3 className="contact-card__title">Adresse</h3>
-                <p className="contact-card__text">123 Rue du Taco, 75000 Paris</p>
+                <h3 className="contact-card__title">{contact.addressLabel}</h3>
+                <p className="contact-card__text">{contact.address}</p>
               </div>
               <div className="contact-card">
                 <Phone className="contact-card__icon" />
-                <h3 className="contact-card__title">Téléphone</h3>
-                <p className="contact-card__text">01 23 45 67 89</p>
+                <h3 className="contact-card__title">{contact.phoneLabel}</h3>
+                <p className="contact-card__text">{contact.phone}</p>
               </div>
               <div className="contact-card">
                 <Mail className="contact-card__icon" />
-                <h3 className="contact-card__title">Email</h3>
-                <p className="contact-card__text">contact@ouiouitacos.fr</p>
+                <h3 className="contact-card__title">{contact.emailLabel}</h3>
+                <p className="contact-card__text">{contact.email}</p>
               </div>
             </div>
           </div>
@@ -351,7 +375,9 @@ const Login: React.FC = () => {
 
       <footer className="site-footer">
         <div className="layout-container site-footer__inner">
-          <p>&copy; {new Date().getFullYear()} OUIOUITACOS. Tous droits réservés.</p>
+          <p>
+            &copy; {new Date().getFullYear()} {navigation.brand}. {footer.text}
+          </p>
         </div>
       </footer>
 

--- a/pages/SiteCustomization.tsx
+++ b/pages/SiteCustomization.tsx
@@ -1,0 +1,864 @@
+import React, { useEffect, useMemo, useState } from 'react';
+import { Mail, MapPin, Phone } from 'lucide-react';
+import useSiteContent from '../hooks/useSiteContent';
+import { SiteContent } from '../types';
+import { normalizeCloudinaryImageUrl, uploadProductImage } from '../services/cloudinary';
+import { resolveSiteContent } from '../utils/siteContent';
+
+const cardClass = 'rounded-2xl border border-gray-200 bg-white p-6 shadow-sm';
+
+const imageWarning = "L'URL doit provenir de Cloudinary (https://*.cloudinary.com).";
+
+type ImageFieldKey = 'hero.backgroundImage' | 'about.image' | 'menu.image' | 'contact.image';
+
+const IMAGE_FIELD_LABELS: Record<ImageFieldKey, string> = {
+  'hero.backgroundImage': 'Visuel de fond (hero)',
+  'about.image': 'Image de la section À propos',
+  'menu.image': 'Image de la section Menu',
+  'contact.image': 'Image de la section Contact',
+};
+
+const INITIAL_IMAGE_ERRORS: Record<ImageFieldKey, string | null> = {
+  'hero.backgroundImage': null,
+  'about.image': null,
+  'menu.image': null,
+  'contact.image': null,
+};
+
+const SiteCustomization: React.FC = () => {
+  const { content, loading, error, updateContent } = useSiteContent();
+  const [draft, setDraft] = useState<SiteContent>(content);
+  const [isDirty, setIsDirty] = useState(false);
+  const [saving, setSaving] = useState(false);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+  const [formError, setFormError] = useState<string | null>(null);
+  const [imageErrors, setImageErrors] = useState<Record<ImageFieldKey, string | null>>({
+    ...INITIAL_IMAGE_ERRORS,
+  });
+  const [uploadingField, setUploadingField] = useState<ImageFieldKey | null>(null);
+
+  useEffect(() => {
+    setDraft(content);
+    setIsDirty(false);
+    setStatusMessage(null);
+    setFormError(null);
+    setImageErrors({ ...INITIAL_IMAGE_ERRORS });
+  }, [content]);
+
+  const previewContent = useMemo(() => resolveSiteContent(draft), [draft]);
+  const previewHeroStyle = previewContent.hero.backgroundImage
+    ? { backgroundImage: `url('${previewContent.hero.backgroundImage}')` }
+    : undefined;
+
+  const mutateDraft = (updater: (prev: SiteContent) => SiteContent) => {
+    setDraft(prev => updater(prev));
+    setIsDirty(true);
+    setStatusMessage(null);
+    setFormError(null);
+  };
+
+  const handleNavigationChange = (key: keyof SiteContent['navigation']['links']) =>
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      mutateDraft(prev => ({
+        ...prev,
+        navigation: {
+          ...prev.navigation,
+          links: {
+            ...prev.navigation.links,
+            [key]: value,
+          },
+        },
+      }));
+    };
+
+  const handleBrandChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    mutateDraft(prev => ({
+      ...prev,
+      navigation: {
+        ...prev.navigation,
+        brand: value,
+      },
+    }));
+  };
+
+  const handleHeroFieldChange = (key: Exclude<keyof SiteContent['hero'], 'backgroundImage'>) =>
+    (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
+      const value = event.target.value;
+      mutateDraft(prev => ({
+        ...prev,
+        hero: {
+          ...prev.hero,
+          [key]: value,
+        },
+      }));
+    };
+
+  const handleAboutChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
+    const value = event.target.value;
+    mutateDraft(prev => ({
+      ...prev,
+      about: {
+        ...prev.about,
+        description: value,
+      },
+    }));
+  };
+
+  const handleAboutTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    mutateDraft(prev => ({
+      ...prev,
+      about: {
+        ...prev.about,
+        title: value,
+      },
+    }));
+  };
+
+  const handleMenuFieldChange = (key: Exclude<keyof SiteContent['menu'], 'image'>) =>
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      mutateDraft(prev => ({
+        ...prev,
+        menu: {
+          ...prev.menu,
+          [key]: value,
+        },
+      }));
+    };
+
+  const handleContactFieldChange = (key: Exclude<keyof SiteContent['contact'], 'image'>) =>
+    (event: React.ChangeEvent<HTMLInputElement>) => {
+      const value = event.target.value;
+      mutateDraft(prev => ({
+        ...prev,
+        contact: {
+          ...prev.contact,
+          [key]: value,
+        },
+      }));
+    };
+
+  const handleFooterTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const value = event.target.value;
+    mutateDraft(prev => ({
+      ...prev,
+      footer: {
+        ...prev.footer,
+        text: value,
+      },
+    }));
+  };
+
+  const setImageField = (field: ImageFieldKey, value: string | null) => {
+    mutateDraft(prev => {
+      if (field === 'hero.backgroundImage') {
+        return {
+          ...prev,
+          hero: {
+            ...prev.hero,
+            backgroundImage: value,
+          },
+        };
+      }
+      if (field === 'about.image') {
+        return {
+          ...prev,
+          about: {
+            ...prev.about,
+            image: value,
+          },
+        };
+      }
+      if (field === 'menu.image') {
+        return {
+          ...prev,
+          menu: {
+            ...prev.menu,
+            image: value,
+          },
+        };
+      }
+      return {
+        ...prev,
+        contact: {
+          ...prev.contact,
+          image: value,
+        },
+      };
+    });
+  };
+
+  const handleImageInputChange = (field: ImageFieldKey) => (event: React.ChangeEvent<HTMLInputElement>) => {
+    const raw = event.target.value;
+    const trimmed = raw.trim();
+    const nextValue = trimmed.length > 0 ? trimmed : null;
+    setImageField(field, nextValue);
+    const isValid = !trimmed || normalizeCloudinaryImageUrl(trimmed);
+    setImageErrors(prev => ({
+      ...prev,
+      [field]: isValid ? null : imageWarning,
+    }));
+  };
+
+  const handleImageUpload = async (field: ImageFieldKey, file: File) => {
+    setUploadingField(field);
+    setFormError(null);
+    setStatusMessage(null);
+    try {
+      const label = IMAGE_FIELD_LABELS[field];
+      const uploadedUrl = await uploadProductImage(file, label);
+      setImageField(field, uploadedUrl);
+      setImageErrors(prev => ({
+        ...prev,
+        [field]: null,
+      }));
+    } catch (uploadError) {
+      console.error('Failed to upload site image', uploadError);
+      setFormError("Impossible de téléverser l'image. Vérifiez votre connexion ou la configuration Cloudinary.");
+    } finally {
+      setUploadingField(null);
+    }
+  };
+
+  const handleClearImage = (field: ImageFieldKey) => {
+    setImageField(field, null);
+    setImageErrors(prev => ({
+      ...prev,
+      [field]: null,
+    }));
+  };
+
+  const handleSave = async () => {
+    if (!isDirty) {
+      return;
+    }
+
+    setSaving(true);
+    setStatusMessage(null);
+    setFormError(null);
+
+    try {
+      const updated = await updateContent(draft);
+      setDraft(updated);
+      setIsDirty(false);
+      setStatusMessage('Contenu mis à jour avec succès.');
+      setImageErrors({ ...INITIAL_IMAGE_ERRORS });
+    } catch (saveError) {
+      console.error('Failed to update site content', saveError);
+      setFormError("Impossible d'enregistrer les modifications. Veuillez réessayer.");
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const handleReset = () => {
+    setDraft(content);
+    setIsDirty(false);
+    setStatusMessage(null);
+    setFormError(null);
+    setImageErrors({ ...INITIAL_IMAGE_ERRORS });
+  };
+
+  const isUploading = (field: ImageFieldKey) => uploadingField === field;
+
+  return (
+    <div className="space-y-8">
+      <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold text-gray-900">Personnalisation du site</h1>
+          <p className="text-sm text-gray-500">
+            Ajustez les textes, visuels et coordonnées visibles sur la vitrine publique.
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <button
+            type="button"
+            onClick={handleReset}
+            className="ui-btn ui-btn-secondary"
+            disabled={!isDirty || saving}
+          >
+            Réinitialiser
+          </button>
+          <button
+            type="button"
+            onClick={handleSave}
+            className="ui-btn ui-btn-primary"
+            disabled={!isDirty || saving}
+            data-state={saving ? 'loading' : 'idle'}
+          >
+            {saving ? 'Enregistrement…' : 'Enregistrer'}
+          </button>
+        </div>
+      </div>
+
+      {(error || formError) && (
+        <div className="rounded-md border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          {formError ?? error}
+        </div>
+      )}
+
+      {statusMessage && (
+        <div className="rounded-md border border-emerald-200 bg-emerald-50 px-4 py-3 text-sm text-emerald-700">
+          {statusMessage}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex justify-center py-12">
+          <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-brand-primary" />
+        </div>
+      ) : (
+        <div className="space-y-10">
+          <section className={`${cardClass} space-y-6`}>
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-gray-900">Navigation & section hero</h2>
+              <p className="text-sm text-gray-500">Les éléments modifiés s'affichent instantanément dans l'aperçu.</p>
+            </div>
+            <div className="grid gap-6 lg:grid-cols-2">
+              <div className="space-y-4">
+                <div className="overflow-hidden rounded-xl border border-gray-200">
+                  <section className="section section-hero" style={previewHeroStyle}>
+                    <div className="section-hero__inner">
+                      <div className="hero-content">
+                        <h2 className="hero-title">{previewContent.hero.title}</h2>
+                        <p className="hero-subtitle">{previewContent.hero.subtitle}</p>
+                        <button type="button" className="ui-btn ui-btn-accent hero-cta" disabled>
+                          {previewContent.hero.ctaLabel}
+                        </button>
+                      </div>
+                    </div>
+                  </section>
+                </div>
+                <div className="rounded-xl border border-gray-200 bg-white p-4">
+                  <h3 className="text-sm font-semibold text-gray-700">Navigation</h3>
+                  <ul className="mt-3 space-y-2 text-sm text-gray-600">
+                    <li>{previewContent.navigation.links.home}</li>
+                    <li>{previewContent.navigation.links.about}</li>
+                    <li>{previewContent.navigation.links.menu}</li>
+                    <li>{previewContent.navigation.links.contact}</li>
+                    <li>{previewContent.navigation.links.loginCta}</li>
+                  </ul>
+                </div>
+              </div>
+              <div className="space-y-4">
+                <div>
+                  <label htmlFor="brand-name" className="block text-sm font-medium text-gray-700">
+                    Nom de la marque
+                  </label>
+                  <input
+                    id="brand-name"
+                    className="ui-input mt-1"
+                    value={draft.navigation.brand}
+                    onChange={handleBrandChange}
+                  />
+                </div>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div>
+                    <label htmlFor="nav-home" className="block text-sm font-medium text-gray-700">Lien Accueil</label>
+                    <input
+                      id="nav-home"
+                      className="ui-input mt-1"
+                      value={draft.navigation.links.home}
+                      onChange={handleNavigationChange('home')}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="nav-about" className="block text-sm font-medium text-gray-700">Lien À propos</label>
+                    <input
+                      id="nav-about"
+                      className="ui-input mt-1"
+                      value={draft.navigation.links.about}
+                      onChange={handleNavigationChange('about')}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="nav-menu" className="block text-sm font-medium text-gray-700">Lien Menu</label>
+                    <input
+                      id="nav-menu"
+                      className="ui-input mt-1"
+                      value={draft.navigation.links.menu}
+                      onChange={handleNavigationChange('menu')}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="nav-contact" className="block text-sm font-medium text-gray-700">Lien Contact</label>
+                    <input
+                      id="nav-contact"
+                      className="ui-input mt-1"
+                      value={draft.navigation.links.contact}
+                      onChange={handleNavigationChange('contact')}
+                    />
+                  </div>
+                </div>
+                <div>
+                  <label htmlFor="nav-login" className="block text-sm font-medium text-gray-700">Bouton personnel</label>
+                  <input
+                    id="nav-login"
+                    className="ui-input mt-1"
+                    value={draft.navigation.links.loginCta}
+                    onChange={handleNavigationChange('loginCta')}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="hero-title" className="block text-sm font-medium text-gray-700">Titre hero</label>
+                  <input
+                    id="hero-title"
+                    className="ui-input mt-1"
+                    value={draft.hero.title}
+                    onChange={handleHeroFieldChange('title')}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="hero-subtitle" className="block text-sm font-medium text-gray-700">Sous-titre</label>
+                  <textarea
+                    id="hero-subtitle"
+                    className="ui-textarea mt-1"
+                    value={draft.hero.subtitle}
+                    onChange={handleHeroFieldChange('subtitle')}
+                    rows={3}
+                  />
+                </div>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div>
+                    <label htmlFor="hero-cta" className="block text-sm font-medium text-gray-700">Texte du bouton</label>
+                    <input
+                      id="hero-cta"
+                      className="ui-input mt-1"
+                      value={draft.hero.ctaLabel}
+                      onChange={handleHeroFieldChange('ctaLabel')}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="hero-history" className="block text-sm font-medium text-gray-700">Titre historique</label>
+                    <input
+                      id="hero-history"
+                      className="ui-input mt-1"
+                      value={draft.hero.historyTitle}
+                      onChange={handleHeroFieldChange('historyTitle')}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="hero-reorder" className="block text-sm font-medium text-gray-700">Bouton de réassort</label>
+                    <input
+                      id="hero-reorder"
+                      className="ui-input mt-1"
+                      value={draft.hero.reorderCtaLabel}
+                      onChange={handleHeroFieldChange('reorderCtaLabel')}
+                    />
+                  </div>
+                </div>
+                <div>
+                  <label htmlFor="hero-image" className="block text-sm font-medium text-gray-700">
+                    {IMAGE_FIELD_LABELS['hero.backgroundImage']}
+                  </label>
+                  <input
+                    id="hero-image"
+                    className="ui-input mt-1"
+                    value={draft.hero.backgroundImage ?? ''}
+                    onChange={handleImageInputChange('hero.backgroundImage')}
+                    placeholder="https://res.cloudinary.com/..."
+                  />
+                  {imageErrors['hero.backgroundImage'] && (
+                    <p className="mt-1 text-xs text-red-600">{imageErrors['hero.backgroundImage']}</p>
+                  )}
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <label className="ui-btn ui-btn-secondary cursor-pointer">
+                      Importer une image
+                      <input
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        onChange={event => {
+                          const file = event.target.files?.[0];
+                          if (file) {
+                            void handleImageUpload('hero.backgroundImage', file);
+                            event.target.value = '';
+                          }
+                        }}
+                      />
+                    </label>
+                    <button
+                      type="button"
+                      className="ui-btn ui-btn-ghost"
+                      onClick={() => handleClearImage('hero.backgroundImage')}
+                      disabled={!draft.hero.backgroundImage || isUploading('hero.backgroundImage')}
+                    >
+                      Retirer l'image
+                    </button>
+                    {isUploading('hero.backgroundImage') && (
+                      <span className="text-sm text-gray-500">Téléversement en cours…</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className={`${cardClass} space-y-6`}>
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-gray-900">Section À propos</h2>
+              <p className="text-sm text-gray-500">Présentez l'histoire de votre établissement.</p>
+            </div>
+            <div className="grid gap-6 lg:grid-cols-2">
+              <div className="space-y-4">
+                <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+                  <div className="section section-surface">
+                    <div className="section-inner section-inner--center">
+                      <h3 className="section-title">{previewContent.about.title}</h3>
+                      <p className="section-text section-text--muted">{previewContent.about.description}</p>
+                      {previewContent.about.image && (
+                        <img
+                          src={previewContent.about.image}
+                          alt={previewContent.about.title}
+                          className="mt-6 h-64 w-full rounded-xl object-cover shadow-lg"
+                        />
+                      )}
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="space-y-4">
+                <div>
+                  <label htmlFor="about-title" className="block text-sm font-medium text-gray-700">Titre</label>
+                  <input
+                    id="about-title"
+                    className="ui-input mt-1"
+                    value={draft.about.title}
+                    onChange={handleAboutTitleChange}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="about-description" className="block text-sm font-medium text-gray-700">
+                    Description
+                  </label>
+                  <textarea
+                    id="about-description"
+                    className="ui-textarea mt-1"
+                    value={draft.about.description}
+                    onChange={handleAboutChange}
+                    rows={4}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="about-image" className="block text-sm font-medium text-gray-700">
+                    {IMAGE_FIELD_LABELS['about.image']}
+                  </label>
+                  <input
+                    id="about-image"
+                    className="ui-input mt-1"
+                    value={draft.about.image ?? ''}
+                    onChange={handleImageInputChange('about.image')}
+                    placeholder="https://res.cloudinary.com/..."
+                  />
+                  {imageErrors['about.image'] && (
+                    <p className="mt-1 text-xs text-red-600">{imageErrors['about.image']}</p>
+                  )}
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <label className="ui-btn ui-btn-secondary cursor-pointer">
+                      Importer une image
+                      <input
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        onChange={event => {
+                          const file = event.target.files?.[0];
+                          if (file) {
+                            void handleImageUpload('about.image', file);
+                            event.target.value = '';
+                          }
+                        }}
+                      />
+                    </label>
+                    <button
+                      type="button"
+                      className="ui-btn ui-btn-ghost"
+                      onClick={() => handleClearImage('about.image')}
+                      disabled={!draft.about.image || isUploading('about.image')}
+                    >
+                      Retirer l'image
+                    </button>
+                    {isUploading('about.image') && (
+                      <span className="text-sm text-gray-500">Téléversement en cours…</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className={`${cardClass} space-y-6`}>
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-gray-900">Section Menu</h2>
+              <p className="text-sm text-gray-500">Personnalisez l'en-tête de la section menu.</p>
+            </div>
+            <div className="grid gap-6 lg:grid-cols-2">
+              <div className="space-y-4">
+                <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+                  <div className="section section-muted">
+                    <div className="section-inner section-inner--wide section-inner--center">
+                      <h3 className="section-title">{previewContent.menu.title}</h3>
+                      {previewContent.menu.image && (
+                        <img
+                          src={previewContent.menu.image}
+                          alt={previewContent.menu.title}
+                          className="mb-8 h-64 w-full rounded-xl object-cover shadow-lg"
+                        />
+                      )}
+                      <p className="section-text section-text--muted">{previewContent.menu.loadingLabel}</p>
+                      <div className="mt-6">
+                        <button type="button" className="ui-btn ui-btn-primary hero-cta" disabled>
+                          {previewContent.menu.ctaLabel}
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="space-y-4">
+                <div>
+                  <label htmlFor="menu-title" className="block text-sm font-medium text-gray-700">Titre</label>
+                  <input
+                    id="menu-title"
+                    className="ui-input mt-1"
+                    value={draft.menu.title}
+                    onChange={handleMenuFieldChange('title')}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="menu-cta" className="block text-sm font-medium text-gray-700">Texte du bouton</label>
+                  <input
+                    id="menu-cta"
+                    className="ui-input mt-1"
+                    value={draft.menu.ctaLabel}
+                    onChange={handleMenuFieldChange('ctaLabel')}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="menu-loading" className="block text-sm font-medium text-gray-700">Texte de chargement</label>
+                  <input
+                    id="menu-loading"
+                    className="ui-input mt-1"
+                    value={draft.menu.loadingLabel}
+                    onChange={handleMenuFieldChange('loadingLabel')}
+                  />
+                </div>
+                <div>
+                  <label htmlFor="menu-image" className="block text-sm font-medium text-gray-700">
+                    {IMAGE_FIELD_LABELS['menu.image']}
+                  </label>
+                  <input
+                    id="menu-image"
+                    className="ui-input mt-1"
+                    value={draft.menu.image ?? ''}
+                    onChange={handleImageInputChange('menu.image')}
+                    placeholder="https://res.cloudinary.com/..."
+                  />
+                  {imageErrors['menu.image'] && (
+                    <p className="mt-1 text-xs text-red-600">{imageErrors['menu.image']}</p>
+                  )}
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <label className="ui-btn ui-btn-secondary cursor-pointer">
+                      Importer une image
+                      <input
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        onChange={event => {
+                          const file = event.target.files?.[0];
+                          if (file) {
+                            void handleImageUpload('menu.image', file);
+                            event.target.value = '';
+                          }
+                        }}
+                      />
+                    </label>
+                    <button
+                      type="button"
+                      className="ui-btn ui-btn-ghost"
+                      onClick={() => handleClearImage('menu.image')}
+                      disabled={!draft.menu.image || isUploading('menu.image')}
+                    >
+                      Retirer l'image
+                    </button>
+                    {isUploading('menu.image') && (
+                      <span className="text-sm text-gray-500">Téléversement en cours…</span>
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className={`${cardClass} space-y-6`}>
+            <div className="space-y-1">
+              <h2 className="text-lg font-semibold text-gray-900">Contact & pied de page</h2>
+              <p className="text-sm text-gray-500">Mettez à jour vos coordonnées et le message du pied de page.</p>
+            </div>
+            <div className="grid gap-6 lg:grid-cols-2">
+              <div className="space-y-4">
+                <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
+                  <div className="section section-surface">
+                    <div className="section-inner section-inner--wide section-inner--center">
+                      <h3 className="section-title">{previewContent.contact.title}</h3>
+                      {previewContent.contact.image && (
+                        <img
+                          src={previewContent.contact.image}
+                          alt={previewContent.contact.title}
+                          className="mb-8 h-64 w-full rounded-xl object-cover shadow-lg"
+                        />
+                      )}
+                      <div className="contact-grid">
+                        <div className="contact-card">
+                          <MapPin className="contact-card__icon" />
+                          <h4 className="contact-card__title">{previewContent.contact.addressLabel}</h4>
+                          <p className="contact-card__text">{previewContent.contact.address}</p>
+                        </div>
+                        <div className="contact-card">
+                          <Phone className="contact-card__icon" />
+                          <h4 className="contact-card__title">{previewContent.contact.phoneLabel}</h4>
+                          <p className="contact-card__text">{previewContent.contact.phone}</p>
+                        </div>
+                        <div className="contact-card">
+                          <Mail className="contact-card__icon" />
+                          <h4 className="contact-card__title">{previewContent.contact.emailLabel}</h4>
+                          <p className="contact-card__text">{previewContent.contact.email}</p>
+                        </div>
+                      </div>
+                      <p className="mt-6 text-sm text-gray-500">
+                        &copy; {new Date().getFullYear()} {previewContent.navigation.brand}. {previewContent.footer.text}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="space-y-4">
+                <div>
+                  <label htmlFor="contact-title" className="block text-sm font-medium text-gray-700">Titre</label>
+                  <input
+                    id="contact-title"
+                    className="ui-input mt-1"
+                    value={draft.contact.title}
+                    onChange={handleContactFieldChange('title')}
+                  />
+                </div>
+                <div className="grid gap-4 md:grid-cols-2">
+                  <div>
+                    <label htmlFor="contact-address-label" className="block text-sm font-medium text-gray-700">Libellé adresse</label>
+                    <input
+                      id="contact-address-label"
+                      className="ui-input mt-1"
+                      value={draft.contact.addressLabel}
+                      onChange={handleContactFieldChange('addressLabel')}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="contact-address" className="block text-sm font-medium text-gray-700">Adresse</label>
+                    <input
+                      id="contact-address"
+                      className="ui-input mt-1"
+                      value={draft.contact.address}
+                      onChange={handleContactFieldChange('address')}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="contact-phone-label" className="block text-sm font-medium text-gray-700">Libellé téléphone</label>
+                    <input
+                      id="contact-phone-label"
+                      className="ui-input mt-1"
+                      value={draft.contact.phoneLabel}
+                      onChange={handleContactFieldChange('phoneLabel')}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="contact-phone" className="block text-sm font-medium text-gray-700">Téléphone</label>
+                    <input
+                      id="contact-phone"
+                      className="ui-input mt-1"
+                      value={draft.contact.phone}
+                      onChange={handleContactFieldChange('phone')}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="contact-email-label" className="block text-sm font-medium text-gray-700">Libellé email</label>
+                    <input
+                      id="contact-email-label"
+                      className="ui-input mt-1"
+                      value={draft.contact.emailLabel}
+                      onChange={handleContactFieldChange('emailLabel')}
+                    />
+                  </div>
+                  <div>
+                    <label htmlFor="contact-email" className="block text-sm font-medium text-gray-700">Email</label>
+                    <input
+                      id="contact-email"
+                      className="ui-input mt-1"
+                      value={draft.contact.email}
+                      onChange={handleContactFieldChange('email')}
+                    />
+                  </div>
+                </div>
+                <div>
+                  <label htmlFor="contact-image" className="block text-sm font-medium text-gray-700">
+                    {IMAGE_FIELD_LABELS['contact.image']}
+                  </label>
+                  <input
+                    id="contact-image"
+                    className="ui-input mt-1"
+                    value={draft.contact.image ?? ''}
+                    onChange={handleImageInputChange('contact.image')}
+                    placeholder="https://res.cloudinary.com/..."
+                  />
+                  {imageErrors['contact.image'] && (
+                    <p className="mt-1 text-xs text-red-600">{imageErrors['contact.image']}</p>
+                  )}
+                  <div className="mt-3 flex flex-wrap gap-2">
+                    <label className="ui-btn ui-btn-secondary cursor-pointer">
+                      Importer une image
+                      <input
+                        type="file"
+                        accept="image/*"
+                        className="hidden"
+                        onChange={event => {
+                          const file = event.target.files?.[0];
+                          if (file) {
+                            void handleImageUpload('contact.image', file);
+                            event.target.value = '';
+                          }
+                        }}
+                      />
+                    </label>
+                    <button
+                      type="button"
+                      className="ui-btn ui-btn-ghost"
+                      onClick={() => handleClearImage('contact.image')}
+                      disabled={!draft.contact.image || isUploading('contact.image')}
+                    >
+                      Retirer l'image
+                    </button>
+                    {isUploading('contact.image') && (
+                      <span className="text-sm text-gray-500">Téléversement en cours…</span>
+                    )}
+                  </div>
+                </div>
+                <div>
+                  <label htmlFor="footer-text" className="block text-sm font-medium text-gray-700">Texte du pied de page</label>
+                  <input
+                    id="footer-text"
+                    className="ui-input mt-1"
+                    value={draft.footer.text}
+                    onChange={handleFooterTextChange}
+                  />
+                </div>
+              </div>
+            </div>
+          </section>
+        </div>
+      )}
+    </div>
+  );
+};
+
+export default SiteCustomization;

--- a/services/api.ts
+++ b/services/api.ts
@@ -20,8 +20,10 @@ import {
   SoldProduct,
   Sale,
   RoleLogin,
+  SiteContent,
 } from '../types';
-import { ROLE_HOME_PAGE_META_KEY } from '../constants';
+import { ROLE_HOME_PAGE_META_KEY, ROLES, SITE_CUSTOMIZER_PERMISSION_KEY } from '../constants';
+import { resolveSiteContent, sanitizeSiteContentInput } from '../utils/siteContent';
 
 type SupabasePermissions = Role['permissions'] & {
   [key in typeof ROLE_HOME_PAGE_META_KEY]?: string;
@@ -134,6 +136,12 @@ type SupabaseSaleRow = {
   sale_date: string;
 };
 
+type SupabaseSiteContentRow = {
+  id: string;
+  content: Partial<SiteContent> | null;
+  updated_at: string | null;
+};
+
 type SalesPeriod = {
   start?: Date | string;
   end?: Date | string;
@@ -164,6 +172,9 @@ const publishEvent = (event: string) => {
 };
 
 let ordersRealtimeChannel: ReturnType<typeof supabase.channel> | null = null;
+
+const SITE_CONTENT_TABLE = 'site_content';
+const SITE_CONTENT_SINGLETON_ID = 'default';
 
 const ensureOrdersRealtimeSubscription = () => {
   if (ordersRealtimeChannel || typeof (supabase as { channel?: unknown }).channel !== 'function') {
@@ -284,13 +295,35 @@ const mergeHomePageIntoPermissions = (
   return payload;
 };
 
+const isAdminRoleName = (name?: string | null): boolean => {
+  if (!name) {
+    return false;
+  }
+
+  const normalized = name.trim().toLowerCase();
+  return normalized === ROLES.ADMIN || normalized === 'administrateur';
+};
+
+const withSiteCustomizerPermission = (
+  permissions: Role['permissions'],
+  roleName?: string | null,
+): Role['permissions'] => {
+  const normalized: Role['permissions'] = { ...permissions };
+  if (!(SITE_CUSTOMIZER_PERMISSION_KEY in normalized)) {
+    normalized[SITE_CUSTOMIZER_PERMISSION_KEY] = isAdminRoleName(roleName) ? 'editor' : 'none';
+  }
+
+  return normalized;
+};
+
 const mapRoleRow = (row: SupabaseRoleRow, includePin: boolean): Role => {
   const { permissions, homePage } = extractPermissions(row.permissions);
+  const normalizedPermissions = withSiteCustomizerPermission(permissions, row.name);
   const role: Role = {
     id: row.id,
     name: row.name,
     homePage,
-    permissions,
+    permissions: normalizedPermissions,
 
   };
 
@@ -299,6 +332,14 @@ const mapRoleRow = (row: SupabaseRoleRow, includePin: boolean): Role => {
   }
 
   return role;
+};
+
+const mapSiteContentRow = (row: SupabaseSiteContentRow | null): SiteContent | null => {
+  if (!row?.content) {
+    return null;
+  }
+
+  return resolveSiteContent(row.content);
 };
 
 const mapIngredientRow = (row: SupabaseIngredientRow): Ingredient => ({
@@ -774,6 +815,46 @@ const publishOrderChange = (options?: PublishOrderChangeOptions) => {
 
 export const api = {
   notifications: notificationsService,
+
+  getSiteContent: async (): Promise<SiteContent | null> => {
+    const response = await supabase
+      .from(SITE_CONTENT_TABLE)
+      .select('id, content, updated_at')
+      .order('updated_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    const row = unwrapMaybe<SupabaseSiteContentRow>(
+      response as SupabaseResponse<SupabaseSiteContentRow | null>,
+    );
+
+    return mapSiteContentRow(row);
+  },
+
+  updateSiteContent: async (content: SiteContent): Promise<SiteContent> => {
+    const sanitized = sanitizeSiteContentInput(content);
+
+    const response = await supabase
+      .from(SITE_CONTENT_TABLE)
+      .upsert(
+        {
+          id: SITE_CONTENT_SINGLETON_ID,
+          content: sanitized,
+        },
+        { onConflict: 'id' },
+      )
+      .select('id, content, updated_at')
+      .single();
+
+    const row = unwrap<SupabaseSiteContentRow>(response as SupabaseResponse<SupabaseSiteContentRow>);
+    const mapped = mapSiteContentRow(row);
+
+    if (!mapped) {
+      throw new Error('Contenu du site introuvable après la mise à jour.');
+    }
+
+    return mapped;
+  },
 
   getRoles: async (): Promise<Role[]> => {
     const response = await supabase.from('roles').select('id, name, pin, permissions').order('name');

--- a/types/index.ts
+++ b/types/index.ts
@@ -10,6 +10,51 @@ export interface Role {
   };
 }
 
+export interface SiteContent {
+  navigation: {
+    brand: string;
+    links: {
+      home: string;
+      about: string;
+      menu: string;
+      contact: string;
+      loginCta: string;
+    };
+  };
+  hero: {
+    title: string;
+    subtitle: string;
+    ctaLabel: string;
+    backgroundImage: string | null;
+    historyTitle: string;
+    reorderCtaLabel: string;
+  };
+  about: {
+    title: string;
+    description: string;
+    image: string | null;
+  };
+  menu: {
+    title: string;
+    ctaLabel: string;
+    loadingLabel: string;
+    image: string | null;
+  };
+  contact: {
+    title: string;
+    addressLabel: string;
+    address: string;
+    phoneLabel: string;
+    phone: string;
+    emailLabel: string;
+    email: string;
+    image: string | null;
+  };
+  footer: {
+    text: string;
+  };
+}
+
 export interface Ingredient {
   id: string;
   nom: string;

--- a/utils/siteContent.ts
+++ b/utils/siteContent.ts
@@ -1,0 +1,171 @@
+import { SiteContent } from '../types';
+import { normalizeCloudinaryImageUrl } from '../services/cloudinary';
+
+const trimOrEmpty = (value: string): string => value.trim();
+
+const resolveString = (value: string | null | undefined, fallback: string): string => {
+  if (typeof value !== 'string') {
+    return fallback;
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : fallback;
+};
+
+const resolveImage = (value: string | null | undefined, fallback: string | null): string | null => {
+  if (value === undefined) {
+    return fallback ?? null;
+  }
+
+  if (value === null) {
+    return null;
+  }
+
+  const normalized = normalizeCloudinaryImageUrl(value);
+  return normalized ?? fallback ?? null;
+};
+
+const sanitizeImage = (value: string | null | undefined): string | null => {
+  const normalized = normalizeCloudinaryImageUrl(value);
+  return normalized ?? null;
+};
+
+export const DEFAULT_SITE_CONTENT: SiteContent = {
+  navigation: {
+    brand: 'OUIOUITACOS',
+    links: {
+      home: 'Accueil',
+      about: 'À propos',
+      menu: 'Menu',
+      contact: 'Contact',
+      loginCta: 'Staff Login',
+    },
+  },
+  hero: {
+    title: 'Le Goût Authentique du Mexique',
+    subtitle:
+      "Des tacos préparés avec passion, des ingrédients frais et une touche de tradition pour un voyage gustatif inoubliable.",
+    ctaLabel: 'Commander en ligne',
+    backgroundImage: 'https://picsum.photos/seed/tacosbg/1920/1080',
+    historyTitle: 'Vos dernières commandes',
+    reorderCtaLabel: 'Commander à nouveau',
+  },
+  about: {
+    title: 'Notre Histoire',
+    description:
+      "Fondé par des passionnés de la cuisine mexicaine, OUIOUITACOS est né d'un désir simple : partager le goût authentique des tacos faits maison. Chaque recette est un héritage familial, chaque ingrédient est choisi avec soin, et chaque plat est préparé avec le cœur. Venez découvrir une explosion de saveurs qui vous transportera directement dans les rues de Mexico.",
+    image: null,
+  },
+  menu: {
+    title: 'Nos Best-sellers',
+    ctaLabel: 'Voir le menu complet & Commander',
+    loadingLabel: 'Chargement du menu...',
+    image: null,
+  },
+  contact: {
+    title: 'Contactez-nous',
+    addressLabel: 'Adresse',
+    address: '123 Rue du Taco, 75000 Paris',
+    phoneLabel: 'Téléphone',
+    phone: '01 23 45 67 89',
+    emailLabel: 'Email',
+    email: 'contact@ouiouitacos.fr',
+    image: null,
+  },
+  footer: {
+    text: 'Tous droits réservés.',
+  },
+};
+
+export const resolveSiteContent = (content?: Partial<SiteContent> | null): SiteContent => {
+  const base = DEFAULT_SITE_CONTENT;
+  return {
+    navigation: {
+      brand: resolveString(content?.navigation?.brand, base.navigation.brand),
+      links: {
+        home: resolveString(content?.navigation?.links?.home, base.navigation.links.home),
+        about: resolveString(content?.navigation?.links?.about, base.navigation.links.about),
+        menu: resolveString(content?.navigation?.links?.menu, base.navigation.links.menu),
+        contact: resolveString(content?.navigation?.links?.contact, base.navigation.links.contact),
+        loginCta: resolveString(content?.navigation?.links?.loginCta, base.navigation.links.loginCta),
+      },
+    },
+    hero: {
+      title: resolveString(content?.hero?.title, base.hero.title),
+      subtitle: resolveString(content?.hero?.subtitle, base.hero.subtitle),
+      ctaLabel: resolveString(content?.hero?.ctaLabel, base.hero.ctaLabel),
+      backgroundImage: resolveImage(content?.hero?.backgroundImage, base.hero.backgroundImage),
+      historyTitle: resolveString(content?.hero?.historyTitle, base.hero.historyTitle),
+      reorderCtaLabel: resolveString(content?.hero?.reorderCtaLabel, base.hero.reorderCtaLabel),
+    },
+    about: {
+      title: resolveString(content?.about?.title, base.about.title),
+      description: resolveString(content?.about?.description, base.about.description),
+      image: resolveImage(content?.about?.image, base.about.image),
+    },
+    menu: {
+      title: resolveString(content?.menu?.title, base.menu.title),
+      ctaLabel: resolveString(content?.menu?.ctaLabel, base.menu.ctaLabel),
+      loadingLabel: resolveString(content?.menu?.loadingLabel, base.menu.loadingLabel),
+      image: resolveImage(content?.menu?.image, base.menu.image),
+    },
+    contact: {
+      title: resolveString(content?.contact?.title, base.contact.title),
+      addressLabel: resolveString(content?.contact?.addressLabel, base.contact.addressLabel),
+      address: resolveString(content?.contact?.address, base.contact.address),
+      phoneLabel: resolveString(content?.contact?.phoneLabel, base.contact.phoneLabel),
+      phone: resolveString(content?.contact?.phone, base.contact.phone),
+      emailLabel: resolveString(content?.contact?.emailLabel, base.contact.emailLabel),
+      email: resolveString(content?.contact?.email, base.contact.email),
+      image: resolveImage(content?.contact?.image, base.contact.image),
+    },
+    footer: {
+      text: resolveString(content?.footer?.text, base.footer.text),
+    },
+  };
+};
+
+export const sanitizeSiteContentInput = (content: SiteContent): SiteContent => ({
+  navigation: {
+    brand: trimOrEmpty(content.navigation.brand),
+    links: {
+      home: trimOrEmpty(content.navigation.links.home),
+      about: trimOrEmpty(content.navigation.links.about),
+      menu: trimOrEmpty(content.navigation.links.menu),
+      contact: trimOrEmpty(content.navigation.links.contact),
+      loginCta: trimOrEmpty(content.navigation.links.loginCta),
+    },
+  },
+  hero: {
+    title: trimOrEmpty(content.hero.title),
+    subtitle: trimOrEmpty(content.hero.subtitle),
+    ctaLabel: trimOrEmpty(content.hero.ctaLabel),
+    backgroundImage: sanitizeImage(content.hero.backgroundImage),
+    historyTitle: trimOrEmpty(content.hero.historyTitle),
+    reorderCtaLabel: trimOrEmpty(content.hero.reorderCtaLabel),
+  },
+  about: {
+    title: trimOrEmpty(content.about.title),
+    description: trimOrEmpty(content.about.description),
+    image: sanitizeImage(content.about.image),
+  },
+  menu: {
+    title: trimOrEmpty(content.menu.title),
+    ctaLabel: trimOrEmpty(content.menu.ctaLabel),
+    loadingLabel: trimOrEmpty(content.menu.loadingLabel),
+    image: sanitizeImage(content.menu.image),
+  },
+  contact: {
+    title: trimOrEmpty(content.contact.title),
+    addressLabel: trimOrEmpty(content.contact.addressLabel),
+    address: trimOrEmpty(content.contact.address),
+    phoneLabel: trimOrEmpty(content.contact.phoneLabel),
+    phone: trimOrEmpty(content.contact.phone),
+    emailLabel: trimOrEmpty(content.contact.emailLabel),
+    email: trimOrEmpty(content.contact.email),
+    image: sanitizeImage(content.contact.image),
+  },
+  footer: {
+    text: trimOrEmpty(content.footer.text),
+  },
+});


### PR DESCRIPTION
## Summary
- define the new `SiteContent` model with helpers and Supabase endpoints to load or persist marketing content
- update the public login page to consume dynamic copy and imagery via the `useSiteContent` hook
- add an authenticated site customization screen plus navigation entry and admin permission defaults

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68d986e227d0832aa1e97602c6df9c95