### PR TITLE
Enhance permission matrix UI for role manager

### DIFF
--- a/components/role-manager/PermissionMatrix.tsx
+++ b/components/role-manager/PermissionMatrix.tsx
@@ -1,4 +1,5 @@
-import React from 'react';
+import React, { useMemo } from 'react';
+import { NAV_LINKS } from '../../constants';
 import { Role } from '../../types';
 import { PermissionLevel } from './useRoleManager';
 
@@ -9,28 +10,195 @@ interface PermissionMatrixProps {
   getPermissionLabel: (key: string) => string;
 }
 
+interface PermissionSection {
+  id: string;
+  title: string;
+  keys: string[];
+}
+
+const PERMISSION_LEVELS: Array<{
+  value: PermissionLevel;
+  label: string;
+  headerDescription: string;
+  helper: string;
+  tooltip: string;
+}> = [
+  {
+    value: 'editor',
+    label: 'Éditeur',
+    headerDescription: 'Gestion complète',
+    helper: 'Créer, modifier et valider le contenu.',
+    tooltip: 'Autorise toutes les actions, y compris la modification et la validation des données.',
+  },
+  {
+    value: 'readonly',
+    label: 'Lecture seule',
+    headerDescription: 'Consultation',
+    helper: 'Visualiser les informations sans modifier.',
+    tooltip: 'Permet uniquement de consulter les informations sans pouvoir les modifier.',
+  },
+  {
+    value: 'none',
+    label: 'Aucun',
+    headerDescription: 'Accès bloqué',
+    helper: 'Masquer totalement la section.',
+    tooltip: 'Bloque complètement l’accès à la section ou à la fonctionnalité.',
+  },
+];
+
 const PermissionMatrix: React.FC<PermissionMatrixProps> = ({
   permissionKeys,
   permissions,
   onChange,
   getPermissionLabel,
-}) => (
-  <div className="max-h-60 space-y-3 overflow-y-auto rounded-md border border-gray-200 p-3">
-    {permissionKeys.map(key => (
-      <div key={key} className="flex items-center justify-between space-x-4">
-        <span className="text-sm font-medium text-gray-700">{getPermissionLabel(key)}</span>
-        <select
-          value={permissions[key] ?? 'none'}
-          onChange={event => onChange(key, event.target.value as PermissionLevel)}
-          className="rounded-md border border-gray-300 px-2 py-1 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
-        >
-          <option value="editor">Éditeur</option>
-          <option value="readonly">Lecture seule</option>
-          <option value="none">Aucun accès</option>
-        </select>
+}) => {
+  const sections = useMemo<PermissionSection[]>(() => {
+    if (permissionKeys.length === 0) {
+      return [];
+    }
+
+    const navOrder = NAV_LINKS.map(link => link.permissionKey);
+    const navSet = new Set(navOrder);
+    const navKeys = navOrder.filter(key => permissionKeys.includes(key));
+    const customKeys = permissionKeys
+      .filter(key => !navSet.has(key))
+      .sort((a, b) => getPermissionLabel(a).localeCompare(getPermissionLabel(b), 'fr'));
+
+    const computedSections: PermissionSection[] = [];
+
+    if (navKeys.length > 0) {
+      computedSections.push({
+        id: 'navigation',
+        title: 'Navigation principale',
+        keys: navKeys,
+      });
+    }
+
+    if (customKeys.length > 0) {
+      computedSections.push({
+        id: 'custom',
+        title: 'Permissions personnalisées',
+        keys: customKeys,
+      });
+    }
+
+    return computedSections;
+  }, [getPermissionLabel, permissionKeys]);
+
+  const applyBulkChange = (level: PermissionLevel) => {
+    permissionKeys.forEach(key => {
+      const currentLevel = permissions[key] ?? 'none';
+      if (currentLevel !== level) {
+        onChange(key, level);
+      }
+    });
+  };
+
+  if (permissionKeys.length === 0) {
+    return (
+      <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-center text-sm text-gray-500">
+        Aucune permission disponible pour ce rôle pour le moment.
       </div>
-    ))}
-  </div>
-);
+    );
+  }
+
+  return (
+    <div className="space-y-4">
+      <div className="flex flex-wrap gap-2">
+        <button
+          type="button"
+          className="permission-action-button"
+          onClick={() => applyBulkChange('editor')}
+          title="Autoriser toutes les sections en mode édition."
+        >
+          Tout autoriser
+        </button>
+        <button
+          type="button"
+          className="permission-action-button"
+          onClick={() => applyBulkChange('readonly')}
+          title="Basculer toutes les sections en lecture seule."
+        >
+          Lecture seule partout
+        </button>
+        <button
+          type="button"
+          className="permission-action-button is-danger"
+          onClick={() => applyBulkChange('none')}
+          title="Révoquer toutes les permissions."
+        >
+          Tout bloquer
+        </button>
+      </div>
+
+      <div className="overflow-hidden rounded-xl border border-gray-200 bg-white shadow-sm">
+        <div className="max-h-96 overflow-auto">
+          <div className="min-w-full">
+            <div className="grid grid-cols-[minmax(220px,2fr)_repeat(3,minmax(140px,1fr))]">
+              <div className="border-b border-gray-200 bg-gray-50 px-4 py-3 text-sm font-semibold text-gray-700">
+                Section / permission
+              </div>
+              {PERMISSION_LEVELS.map(level => (
+                <div
+                  key={level.value}
+                  className="border-b border-l border-gray-200 bg-gray-50 px-4 py-3 text-sm font-semibold text-gray-700"
+                >
+                  <div>{level.label}</div>
+                  <p className="mt-1 text-xs font-normal text-gray-500">{level.headerDescription}</p>
+                </div>
+              ))}
+
+              {sections.map(section => (
+                <React.Fragment key={section.id}>
+                  <div className="col-span-4 border-t border-gray-200 bg-gray-100 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-gray-600">
+                    {section.title}
+                  </div>
+                  {section.keys.map(key => {
+                    const currentValue = permissions[key] ?? 'none';
+                    const inputName = `permission-${key.replace(/[^a-zA-Z0-9_-]/g, '_')}`;
+
+                    return (
+                      <React.Fragment key={key}>
+                        <div className="border-t border-gray-100 px-4 py-3">
+                          <div className="text-sm font-semibold text-gray-800">{getPermissionLabel(key)}</div>
+                        </div>
+                        {PERMISSION_LEVELS.map(level => {
+                          const isActive = currentValue === level.value;
+
+                          return (
+                            <div
+                              key={level.value}
+                              className="border-t border-l border-gray-100 px-4 py-3"
+                            >
+                              <label
+                                className={`permission-choice${isActive ? ' is-active' : ''}`}
+                                title={level.tooltip}
+                              >
+                                <input
+                                  type="radio"
+                                  className="sr-only"
+                                  name={inputName}
+                                  value={level.value}
+                                  checked={isActive}
+                                  onChange={() => onChange(key, level.value)}
+                                />
+                                <span className="permission-choice__label">{level.label}</span>
+                                <span className="permission-choice__helper">{level.helper}</span>
+                              </label>
+                            </div>
+                          );
+                        })}
+                      </React.Fragment>
+                    );
+                  })}
+                </React.Fragment>
+              ))}
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
 
 export default PermissionMatrix;

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -1578,3 +1578,95 @@ p {
   }
 }
 
+
+.permission-action-button {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.35rem;
+  padding: 0.45rem 0.9rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.permission-action-button:hover {
+  border-color: var(--color-accent);
+  color: var(--color-accent);
+  background: var(--color-accent-soft);
+}
+
+.permission-action-button:focus-visible {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: var(--shadow-focus);
+}
+
+.permission-action-button.is-danger {
+  border-color: rgba(220, 38, 38, 0.4);
+  color: var(--color-danger);
+  background: rgba(220, 38, 38, 0.08);
+}
+
+.permission-action-button.is-danger:hover {
+  border-color: var(--color-danger);
+  background: rgba(220, 38, 38, 0.15);
+}
+
+.permission-action-button.is-danger:focus-visible {
+  border-color: var(--color-danger);
+  box-shadow: 0 0 0 3px rgba(220, 38, 38, 0.2);
+}
+
+.permission-choice {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.35rem;
+  width: 100%;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-muted);
+  cursor: pointer;
+  transition: border-color 0.2s ease, background-color 0.2s ease, color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.permission-choice:hover {
+  border-color: var(--color-border-strong);
+}
+
+.permission-choice:focus-within {
+  outline: none;
+  border-color: var(--color-accent);
+  box-shadow: var(--shadow-focus);
+}
+
+.permission-choice.is-active {
+  border-color: var(--color-accent);
+  background: var(--color-accent-soft);
+  color: var(--color-accent);
+}
+
+.permission-choice__label {
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: inherit;
+}
+
+.permission-choice__helper {
+  font-size: var(--font-size-xs);
+  color: inherit;
+  opacity: 0.8;
+}
+
+.permission-choice.is-active .permission-choice__helper {
+  opacity: 1;
+}
+


### PR DESCRIPTION
## Summary
- organize the permission matrix into sectioned grids with descriptive access level headers
- replace select inputs with radio-based segmented controls that provide labels, helper text, and tooltips
- add quick actions for bulk permission updates and shared styles for the new controls

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68da842c104c832a95bb5fa8f1eb6278