### PR TITLE
feat: allow managing custom permissions in role manager

### DIFF
--- a/components/role-manager/PermissionMatrix.tsx
+++ b/components/role-manager/PermissionMatrix.tsx
@@ -1,4 +1,5 @@
 import React, { useMemo } from 'react';
+import { Trash2 } from 'lucide-react';
 import { NAV_LINKS } from '../../constants';
 import { Role } from '../../types';
 import { PermissionLevel } from './useRoleManager';
@@ -8,6 +9,8 @@ interface PermissionMatrixProps {
   permissions: Role['permissions'];
   onChange: (key: string, value: PermissionLevel) => void;
   getPermissionLabel: (key: string) => string;
+  customPermissions: Record<string, string>;
+  onRemoveCustomPermission?: (key: string) => void;
 }
 
 interface PermissionSection {
@@ -51,6 +54,8 @@ const PermissionMatrix: React.FC<PermissionMatrixProps> = ({
   permissions,
   onChange,
   getPermissionLabel,
+  customPermissions,
+  onRemoveCustomPermission,
 }) => {
   const sections = useMemo<PermissionSection[]>(() => {
     if (permissionKeys.length === 0) {
@@ -156,11 +161,24 @@ const PermissionMatrix: React.FC<PermissionMatrixProps> = ({
                   {section.keys.map(key => {
                     const currentValue = permissions[key] ?? 'none';
                     const inputName = `permission-${key.replace(/[^a-zA-Z0-9_-]/g, '_')}`;
+                    const isCustom = key in customPermissions;
 
                     return (
                       <React.Fragment key={key}>
                         <div className="border-t border-gray-100 px-4 py-3">
-                          <div className="text-sm font-semibold text-gray-800">{getPermissionLabel(key)}</div>
+                          <div className="flex items-center justify-between gap-2">
+                            <div className="text-sm font-semibold text-gray-800">{getPermissionLabel(key)}</div>
+                            {isCustom && onRemoveCustomPermission && (
+                              <button
+                                type="button"
+                                onClick={() => onRemoveCustomPermission(key)}
+                                className="text-gray-400 transition-colors hover:text-red-500"
+                                title="Supprimer cette permission personnalisée"
+                              >
+                                <Trash2 className="h-4 w-4" />
+                              </button>
+                            )}
+                          </div>
                         </div>
                         {PERMISSION_LEVELS.map(level => {
                           const isActive = currentValue === level.value;

--- a/components/role-manager/RoleForm.tsx
+++ b/components/role-manager/RoleForm.tsx
@@ -1,4 +1,4 @@
-import React, { ChangeEvent, FormEvent } from 'react';
+import React, { ChangeEvent, FormEvent, useState } from 'react';
 import { Save } from 'lucide-react';
 import { NAV_LINKS } from '../../constants';
 import PermissionMatrix from './PermissionMatrix';
@@ -11,6 +11,8 @@ interface RoleFormProps {
   onInputChange: (event: ChangeEvent<HTMLInputElement>) => void;
   onHomePageChange: (value: string) => void;
   onPermissionChange: (key: string, value: PermissionLevel) => void;
+  onAddCustomPermission: (key: string, label: string) => void;
+  onRemoveCustomPermission: (key: string) => void;
   onCancel: () => void;
   isSubmitting: boolean;
   hasAccessibleHomePage: boolean;
@@ -26,19 +28,52 @@ const RoleForm: React.FC<RoleFormProps> = ({
   onInputChange,
   onHomePageChange,
   onPermissionChange,
+  onAddCustomPermission,
+  onRemoveCustomPermission,
   onCancel,
   isSubmitting,
   hasAccessibleHomePage,
   permissionKeys,
   getPermissionLabel,
   isPermissionGranted,
-}) => (
-  <div>
-    <h4 className="mb-4 text-lg font-semibold text-gray-800">
-      {mode === 'edit' ? 'Modifier le rôle sélectionné' : 'Créer un nouveau rôle'}
-    </h4>
-    <form onSubmit={onSubmit} className="space-y-4">
-      <div>
+}) => {
+  const [isAddingCustom, setIsAddingCustom] = useState(false);
+  const [customKeyInput, setCustomKeyInput] = useState('');
+  const [customLabelInput, setCustomLabelInput] = useState('');
+  const [customPermissionError, setCustomPermissionError] = useState<string | null>(null);
+
+  const resetCustomPermissionForm = () => {
+    setIsAddingCustom(false);
+    setCustomKeyInput('');
+    setCustomLabelInput('');
+    setCustomPermissionError(null);
+  };
+
+  const handleConfirmAddCustomPermission = () => {
+    const rawKey = customKeyInput.trim();
+    const rawLabel = customLabelInput.trim();
+
+    if (!rawKey || !rawLabel) {
+      setCustomPermissionError('La clé technique et le nom affiché sont obligatoires.');
+      return;
+    }
+
+    if (permissionKeys.includes(rawKey)) {
+      setCustomPermissionError('Cette clé de permission existe déjà.');
+      return;
+    }
+
+    onAddCustomPermission(rawKey, rawLabel);
+    resetCustomPermissionForm();
+  };
+
+  return (
+    <div>
+      <h4 className="mb-4 text-lg font-semibold text-gray-800">
+        {mode === 'edit' ? 'Modifier le rôle sélectionné' : 'Créer un nouveau rôle'}
+      </h4>
+      <form onSubmit={onSubmit} className="space-y-4">
+        <div>
         <label htmlFor="role-name" className="mb-1 block text-sm font-medium text-gray-700">
           Nom du rôle
         </label>
@@ -99,7 +134,73 @@ const RoleForm: React.FC<RoleFormProps> = ({
           permissions={formState.permissions}
           onChange={onPermissionChange}
           getPermissionLabel={getPermissionLabel}
+          customPermissions={formState.customPermissions}
+          onRemoveCustomPermission={onRemoveCustomPermission}
         />
+        <div className="mt-4 space-y-3">
+          {isAddingCustom ? (
+            <div className="rounded-md border border-dashed border-brand-primary/50 bg-brand-primary/5 p-4">
+              <div className="grid gap-3 md:grid-cols-2">
+                <div>
+                  <label className="mb-1 block text-xs font-semibold uppercase text-gray-600">Clé technique</label>
+                  <input
+                    type="text"
+                    value={customKeyInput}
+                    onChange={event => {
+                      setCustomKeyInput(event.target.value);
+                      setCustomPermissionError(null);
+                    }}
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+                    placeholder="ex. /rapports"
+                  />
+                </div>
+                <div>
+                  <label className="mb-1 block text-xs font-semibold uppercase text-gray-600">Nom affiché</label>
+                  <input
+                    type="text"
+                    value={customLabelInput}
+                    onChange={event => {
+                      setCustomLabelInput(event.target.value);
+                      setCustomPermissionError(null);
+                    }}
+                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+                    placeholder="ex. Rapports"
+                  />
+                </div>
+              </div>
+              {customPermissionError && (
+                <p className="mt-2 text-xs text-red-600">{customPermissionError}</p>
+              )}
+              <div className="mt-3 flex justify-end space-x-2">
+                <button
+                  type="button"
+                  onClick={resetCustomPermissionForm}
+                  className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-100"
+                >
+                  Annuler
+                </button>
+                <button
+                  type="button"
+                  onClick={handleConfirmAddCustomPermission}
+                  className="rounded-md bg-brand-primary px-3 py-1.5 text-xs font-semibold text-white hover:bg-brand-primary/90"
+                >
+                  Ajouter
+                </button>
+              </div>
+            </div>
+          ) : (
+            <button
+              type="button"
+              onClick={() => {
+                setIsAddingCustom(true);
+                setCustomPermissionError(null);
+              }}
+              className="text-sm font-medium text-brand-primary hover:underline"
+            >
+              Ajouter une permission
+            </button>
+          )}
+        </div>
       </div>
       <div className="flex justify-end space-x-2">
         {mode === 'edit' && (
@@ -122,6 +223,7 @@ const RoleForm: React.FC<RoleFormProps> = ({
       </div>
     </form>
   </div>
-);
+  );
+};
 
 export default RoleForm;

--- a/components/role-manager/RoleManagerDialog.tsx
+++ b/components/role-manager/RoleManagerDialog.tsx
@@ -31,6 +31,8 @@ const RoleManagerDialog: React.FC<RoleManagerDialogProps> = ({ isOpen, onClose }
     resetForm,
     getPermissionLabel,
     isPermissionGranted,
+    handleAddCustomPermission,
+    handleRemoveCustomPermission,
   } = useRoleManager({ isOpen, onClose });
 
   return (
@@ -63,6 +65,8 @@ const RoleManagerDialog: React.FC<RoleManagerDialogProps> = ({ isOpen, onClose }
             onInputChange={handleInputChange}
             onHomePageChange={handleHomePageChange}
             onPermissionChange={handlePermissionChange}
+            onAddCustomPermission={handleAddCustomPermission}
+            onRemoveCustomPermission={handleRemoveCustomPermission}
             onCancel={resetForm}
             isSubmitting={isSubmitting}
             hasAccessibleHomePage={hasAccessibleHomePage}

--- a/components/role-manager/useRoleManager.ts
+++ b/components/role-manager/useRoleManager.ts
@@ -12,6 +12,7 @@ export interface RoleFormState {
   pin: string;
   homePage: string;
   permissions: Role['permissions'];
+  customPermissions: Record<string, string>;
 }
 
 interface UseRoleManagerArgs {
@@ -33,6 +34,7 @@ const isAdminRoleName = (name?: string | null): boolean => {
 const ensureNavPermissions = (
   permissions?: Role['permissions'],
   roleName?: string | null,
+  customPermissions: Record<string, string> = {},
 ): Role['permissions'] => {
   const base: Record<string, PermissionLevel> = { ...(permissions || {}) };
   delete base[ROLE_HOME_PAGE_META_KEY];
@@ -47,6 +49,12 @@ const ensureNavPermissions = (
     }
   });
 
+  Object.keys(customPermissions).forEach(key => {
+    if (!(key in base)) {
+      base[key] = 'none';
+    }
+  });
+
   return base;
 };
 
@@ -55,13 +63,14 @@ const getDefaultHomePage = (permissions: Role['permissions']): string => {
   return accessibleLink?.permissionKey ?? DEFAULT_HOME_PAGE;
 };
 
-const createEmptyFormState = (): RoleFormState => {
-  const permissions = ensureNavPermissions();
+const createEmptyFormState = (customPermissions: Record<string, string>): RoleFormState => {
+  const permissions = ensureNavPermissions(undefined, undefined, customPermissions);
   return {
     name: '',
     pin: '',
     permissions,
     homePage: getDefaultHomePage(permissions),
+    customPermissions: { ...customPermissions },
   };
 };
 
@@ -70,7 +79,8 @@ export const isPermissionGranted = (permission?: PermissionLevel) => permission 
 export const useRoleManager = ({ isOpen, onClose }: UseRoleManagerArgs) => {
   const { refreshRole, role: currentRole } = useAuth();
   const [roles, setRoles] = useState<Role[]>([]);
-  const [formState, setFormState] = useState<RoleFormState>(createEmptyFormState);
+  const [customPermissionRegistry, setCustomPermissionRegistry] = useState<Record<string, string>>({});
+  const [formState, setFormState] = useState<RoleFormState>(() => createEmptyFormState({}));
   const [mode, setMode] = useState<'create' | 'edit'>('create');
   const [isFetching, setIsFetching] = useState(false);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -81,6 +91,12 @@ export const useRoleManager = ({ isOpen, onClose }: UseRoleManagerArgs) => {
   const permissionKeys = useMemo(() => {
     const navKeys = NAV_LINKS.map(link => link.permissionKey);
     const extraKeys = new Set<string>();
+
+    Object.keys(customPermissionRegistry).forEach(key => {
+      if (!navKeys.includes(key)) {
+        extraKeys.add(key);
+      }
+    });
 
     roles.forEach(role => {
       Object.keys(role.permissions).forEach(key => {
@@ -94,7 +110,7 @@ export const useRoleManager = ({ isOpen, onClose }: UseRoleManagerArgs) => {
     });
 
     return [...navKeys, ...Array.from(extraKeys)];
-  }, [roles]);
+  }, [roles, customPermissionRegistry]);
 
   const hasAccessibleHomePage = useMemo(
     () => NAV_LINKS.some(link => isPermissionGranted(formState.permissions[link.permissionKey])),
@@ -106,6 +122,25 @@ export const useRoleManager = ({ isOpen, onClose }: UseRoleManagerArgs) => {
     try {
       const fetchedRoles = await api.getRoles();
       setRoles(fetchedRoles);
+      setCustomPermissionRegistry(prev => {
+        const next = { ...prev };
+        let hasChanged = false;
+        const navKeys = new Set(NAV_LINKS.map(link => link.permissionKey));
+
+        fetchedRoles.forEach(role => {
+          Object.keys(role.permissions).forEach(key => {
+            if (key === ROLE_HOME_PAGE_META_KEY || navKeys.has(key)) {
+              return;
+            }
+            if (!(key in next)) {
+              next[key] = key;
+              hasChanged = true;
+            }
+          });
+        });
+
+        return hasChanged ? next : prev;
+      });
       setErrorMessage(null);
     } catch (error) {
       console.error('Failed to load roles:', error);
@@ -117,8 +152,8 @@ export const useRoleManager = ({ isOpen, onClose }: UseRoleManagerArgs) => {
 
   const resetForm = useCallback(() => {
     setMode('create');
-    setFormState(createEmptyFormState());
-  }, []);
+    setFormState(createEmptyFormState(customPermissionRegistry));
+  }, [customPermissionRegistry]);
 
   useEffect(() => {
     if (!isOpen) {
@@ -150,10 +185,46 @@ export const useRoleManager = ({ isOpen, onClose }: UseRoleManagerArgs) => {
     });
   }, [formState.permissions]);
 
-  const getPermissionLabel = useCallback((key: string) => {
-    const navLink = NAV_LINKS.find(link => link.permissionKey === key);
-    return navLink ? navLink.name : key;
-  }, []);
+  useEffect(() => {
+    setFormState(prev => {
+      const prevCustom = prev.customPermissions;
+      const nextCustom = customPermissionRegistry;
+
+      const prevKeys = Object.keys(prevCustom);
+      const nextKeys = Object.keys(nextCustom);
+
+      if (
+        prevKeys.length === nextKeys.length &&
+        prevKeys.every(key => nextCustom[key] === prevCustom[key])
+      ) {
+        return prev;
+      }
+
+      const nextPermissions = ensureNavPermissions(prev.permissions, prev.name, nextCustom);
+      const nextHomePage = isPermissionGranted(nextPermissions[prev.homePage])
+        ? prev.homePage
+        : getDefaultHomePage(nextPermissions);
+
+      return {
+        ...prev,
+        customPermissions: { ...nextCustom },
+        permissions: nextPermissions,
+        homePage: nextHomePage,
+      };
+    });
+  }, [customPermissionRegistry]);
+
+  const getPermissionLabel = useCallback(
+    (key: string) => {
+      const navLink = NAV_LINKS.find(link => link.permissionKey === key);
+      if (navLink) {
+        return navLink.name;
+      }
+
+      return customPermissionRegistry[key] ?? key;
+    },
+    [customPermissionRegistry],
+  );
 
   const handleInputChange = (event: ChangeEvent<HTMLInputElement>) => {
     const { name, value } = event.target;
@@ -181,7 +252,25 @@ export const useRoleManager = ({ isOpen, onClose }: UseRoleManagerArgs) => {
   };
 
   const handleSelectRole = (role: Role) => {
-    const permissions = ensureNavPermissions(role.permissions, role.name);
+    const navKeys = new Set(NAV_LINKS.map(link => link.permissionKey));
+    const nextCustomPermissions = { ...customPermissionRegistry };
+    let hasChanged = false;
+
+    Object.keys(role.permissions).forEach(key => {
+      if (key === ROLE_HOME_PAGE_META_KEY || navKeys.has(key)) {
+        return;
+      }
+      if (!(key in nextCustomPermissions)) {
+        nextCustomPermissions[key] = key;
+        hasChanged = true;
+      }
+    });
+
+    if (hasChanged) {
+      setCustomPermissionRegistry(nextCustomPermissions);
+    }
+
+    const permissions = ensureNavPermissions(role.permissions, role.name, hasChanged ? nextCustomPermissions : customPermissionRegistry);
     setMode('edit');
     setFormState({
       id: role.id,
@@ -189,6 +278,7 @@ export const useRoleManager = ({ isOpen, onClose }: UseRoleManagerArgs) => {
       pin: role.pin ?? '',
       permissions,
       homePage: role.homePage ?? getDefaultHomePage(permissions),
+      customPermissions: { ...(hasChanged ? nextCustomPermissions : customPermissionRegistry) },
     });
     setStatusMessage(null);
     setErrorMessage(null);
@@ -234,7 +324,11 @@ export const useRoleManager = ({ isOpen, onClose }: UseRoleManagerArgs) => {
     setIsSubmitting(true);
 
     try {
-      const permissions = ensureNavPermissions(formState.permissions, formState.name);
+      const permissions = ensureNavPermissions(
+        formState.permissions,
+        formState.name,
+        customPermissionRegistry,
+      );
       const resolvedHomePage = isPermissionGranted(permissions[formState.homePage])
         ? formState.homePage
         : getDefaultHomePage(permissions);
@@ -258,13 +352,18 @@ export const useRoleManager = ({ isOpen, onClose }: UseRoleManagerArgs) => {
           homePage: resolvedHomePage,
         });
         setStatusMessage('Rôle mis à jour avec succès.');
-        const nextPermissions = ensureNavPermissions(updatedRole.permissions, updatedRole.name);
+        const nextPermissions = ensureNavPermissions(
+          updatedRole.permissions,
+          updatedRole.name,
+          customPermissionRegistry,
+        );
         setFormState({
           id: updatedRole.id,
           name: updatedRole.name,
           pin: updatedRole.pin ?? '',
           permissions: nextPermissions,
           homePage: updatedRole.homePage ?? getDefaultHomePage(nextPermissions),
+          customPermissions: { ...customPermissionRegistry },
         });
         await loadRoles();
         if (currentRole?.id === updatedRole.id) {
@@ -284,6 +383,69 @@ export const useRoleManager = ({ isOpen, onClose }: UseRoleManagerArgs) => {
     setStatusMessage(null);
     setErrorMessage(null);
     onClose();
+  };
+
+  const handleAddCustomPermission = (key: string, label: string) => {
+    if (NAV_LINKS.some(link => link.permissionKey === key)) {
+      return;
+    }
+
+    setCustomPermissionRegistry(prev => {
+      if (prev[key] === label) {
+        return prev;
+      }
+
+      const next = { ...prev, [key]: label };
+
+      setFormState(prevForm => {
+        const nextPermissions = ensureNavPermissions(prevForm.permissions, prevForm.name, next);
+        if (!(key in nextPermissions)) {
+          nextPermissions[key] = 'none';
+        }
+
+        return {
+          ...prevForm,
+          customPermissions: { ...next },
+          permissions: nextPermissions,
+        };
+      });
+
+      return next;
+    });
+  };
+
+  const handleRemoveCustomPermission = (key: string) => {
+    if (NAV_LINKS.some(link => link.permissionKey === key)) {
+      return;
+    }
+
+    setCustomPermissionRegistry(prev => {
+      if (!(key in prev)) {
+        return prev;
+      }
+
+      const next = { ...prev };
+      delete next[key];
+
+      setFormState(prevForm => {
+        const { [key]: _removedCustom, ...restCustom } = prevForm.customPermissions;
+        const nextPermissionsBase = { ...prevForm.permissions };
+        delete nextPermissionsBase[key];
+        const nextPermissions = ensureNavPermissions(nextPermissionsBase, prevForm.name, next);
+        const nextHomePage = isPermissionGranted(nextPermissions[prevForm.homePage])
+          ? prevForm.homePage
+          : getDefaultHomePage(nextPermissions);
+
+        return {
+          ...prevForm,
+          customPermissions: { ...restCustom },
+          permissions: nextPermissions,
+          homePage: nextHomePage,
+        };
+      });
+
+      return next;
+    });
   };
 
   return {
@@ -307,6 +469,8 @@ export const useRoleManager = ({ isOpen, onClose }: UseRoleManagerArgs) => {
     resetForm,
     getPermissionLabel,
     isPermissionGranted,
+    handleAddCustomPermission,
+    handleRemoveCustomPermission,
   };
 };
 


### PR DESCRIPTION
## Summary
- add a shared custom-permission registry to the role manager state so ensureNavPermissions and label helpers include new keys
- let admins create custom permissions from the form with validation and remove them directly from the matrix
- merge custom permissions into saved role payloads and refresh roles so labels update immediately

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68da86c537b0832aaf386ab93bb26750