### PR TITLE
Improve role manager modal layout and contrast

### DIFF
--- a/components/Modal.tsx
+++ b/components/Modal.tsx
@@ -17,19 +17,25 @@ const Modal: React.FC<ModalProps> = ({ isOpen, onClose, title, children, size = 
     sm: 'max-w-sm',
     md: 'max-w-md',
     lg: 'max-w-lg',
-    xl: 'max-w-xl',
+    xl: 'max-w-4xl',
   };
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-50 z-50 flex justify-center items-center" onClick={onClose}>
-      <div className={`bg-white rounded-lg shadow-xl relative m-4 ${sizeClasses[size]} w-full`} onClick={e => e.stopPropagation()}>
-        <div className="flex justify-between items-center p-4 border-b">
-          <h3 className="text-xl font-semibold text-gray-800">{title}</h3>
-          <button onClick={onClose} className="text-gray-400 hover:text-gray-600">
-            <X size={24} />
+    <div
+      className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 px-4 py-6 sm:px-6"
+      onClick={onClose}
+    >
+      <div
+        className={`relative flex w-full flex-col overflow-hidden rounded-lg bg-white shadow-xl ${sizeClasses[size]} max-h-[90vh]`}
+        onClick={e => e.stopPropagation()}
+      >
+        <div className="flex items-center justify-between border-b px-4 py-3 sm:px-6">
+          <h3 className="text-xl font-semibold text-gray-900">{title}</h3>
+          <button onClick={onClose} className="rounded-full p-1 text-gray-500 transition-colors hover:text-gray-700">
+            <X size={20} />
           </button>
         </div>
-        <div className="p-6">
+        <div className="flex-1 overflow-y-auto px-4 py-5 sm:px-6 sm:py-6">
           {children}
         </div>
       </div>

--- a/components/role-manager/PermissionMatrix.tsx
+++ b/components/role-manager/PermissionMatrix.tsx
@@ -101,7 +101,7 @@ const PermissionMatrix: React.FC<PermissionMatrixProps> = ({
 
   if (permissionKeys.length === 0) {
     return (
-      <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-center text-sm text-gray-500">
+      <div className="rounded-xl border border-dashed border-gray-300 bg-gray-50 px-4 py-6 text-center text-sm font-medium text-gray-900">
         Aucune permission disponible pour ce rôle pour le moment.
       </div>
     );
@@ -140,22 +140,22 @@ const PermissionMatrix: React.FC<PermissionMatrixProps> = ({
         <div className="max-h-96 overflow-auto">
           <div className="min-w-full">
             <div className="grid grid-cols-[minmax(220px,2fr)_repeat(3,minmax(140px,1fr))]">
-              <div className="border-b border-gray-200 bg-gray-50 px-4 py-3 text-sm font-semibold text-gray-700">
+              <div className="border-b border-gray-200 bg-gray-50 px-4 py-3 text-sm font-semibold text-gray-900">
                 Section / permission
               </div>
               {PERMISSION_LEVELS.map(level => (
                 <div
                   key={level.value}
-                  className="border-b border-l border-gray-200 bg-gray-50 px-4 py-3 text-sm font-semibold text-gray-700"
+                  className="border-b border-l border-gray-200 bg-gray-50 px-4 py-3 text-sm font-semibold text-gray-900"
                 >
                   <div>{level.label}</div>
-                  <p className="mt-1 text-xs font-normal text-gray-500">{level.headerDescription}</p>
+                  <p className="mt-1 text-xs font-medium text-gray-900">{level.headerDescription}</p>
                 </div>
               ))}
 
               {sections.map(section => (
                 <React.Fragment key={section.id}>
-                  <div className="col-span-4 border-t border-gray-200 bg-gray-100 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-gray-600">
+                  <div className="col-span-4 border-t border-gray-200 bg-gray-100 px-4 py-2 text-xs font-semibold uppercase tracking-wide text-gray-900">
                     {section.title}
                   </div>
                   {section.keys.map(key => {
@@ -167,12 +167,12 @@ const PermissionMatrix: React.FC<PermissionMatrixProps> = ({
                       <React.Fragment key={key}>
                         <div className="border-t border-gray-100 px-4 py-3">
                           <div className="flex items-center justify-between gap-2">
-                            <div className="text-sm font-semibold text-gray-800">{getPermissionLabel(key)}</div>
+                            <div className="text-sm font-semibold text-gray-900">{getPermissionLabel(key)}</div>
                             {isCustom && onRemoveCustomPermission && (
                               <button
                                 type="button"
                                 onClick={() => onRemoveCustomPermission(key)}
-                                className="text-gray-400 transition-colors hover:text-red-500"
+                                className="text-gray-700 transition-colors hover:text-red-600"
                                 title="Supprimer cette permission personnalisée"
                               >
                                 <Trash2 className="h-4 w-4" />

--- a/components/role-manager/RoleForm.tsx
+++ b/components/role-manager/RoleForm.tsx
@@ -69,160 +69,160 @@ const RoleForm: React.FC<RoleFormProps> = ({
 
   return (
     <div>
-      <h4 className="mb-4 text-lg font-semibold text-gray-800">
+      <h4 className="mb-4 text-lg font-semibold text-gray-900">
         {mode === 'edit' ? 'Modifier le rôle sélectionné' : 'Créer un nouveau rôle'}
       </h4>
       <form onSubmit={onSubmit} className="space-y-4">
         <div>
-        <label htmlFor="role-name" className="mb-1 block text-sm font-medium text-gray-700">
-          Nom du rôle
-        </label>
-        <input
-          id="role-name"
-          name="name"
-          value={formState.name}
-          onChange={onInputChange}
-          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
-          placeholder="Ex. Manager"
-        />
-      </div>
-      <div>
-        <label htmlFor="role-pin" className="mb-1 block text-sm font-medium text-gray-700">
-          Code PIN d'accès
-        </label>
-        <input
-          id="role-pin"
-          name="pin"
-          value={formState.pin}
-          onChange={onInputChange}
-          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
-          placeholder="Ex. 1234"
-        />
-      </div>
-      <div>
-        <label htmlFor="role-home-page" className="mb-1 block text-sm font-medium text-gray-700">
-          Page d'accueil par défaut
-        </label>
-        <select
-          id="role-home-page"
-          name="homePage"
-          value={formState.homePage}
-          onChange={event => onHomePageChange(event.target.value)}
-          disabled={!hasAccessibleHomePage}
-          className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary disabled:cursor-not-allowed disabled:bg-gray-100"
-        >
-          {NAV_LINKS.map(link => {
-            const canAccess = isPermissionGranted(formState.permissions[link.permissionKey]);
-            return (
-              <option key={link.permissionKey} value={link.permissionKey} disabled={!canAccess}>
-                {getPermissionLabel(link.permissionKey)}
-                {!canAccess ? ' (accès requis)' : ''}
-              </option>
-            );
-          })}
-        </select>
-        {hasAccessibleHomePage ? (
-          <p className="mt-1 text-xs text-gray-500">Les pages sans permission sont désactivées.</p>
-        ) : (
-          <p className="mt-1 text-xs text-red-600">Accordez au moins une permission pour choisir une page d'accueil.</p>
-        )}
-      </div>
-      <div>
-        <p className="mb-2 text-sm font-semibold text-gray-800">Permissions par page</p>
-        <PermissionMatrix
-          permissionKeys={permissionKeys}
-          permissions={formState.permissions}
-          onChange={onPermissionChange}
-          getPermissionLabel={getPermissionLabel}
-          customPermissions={formState.customPermissions}
-          onRemoveCustomPermission={onRemoveCustomPermission}
-        />
-        <div className="mt-4 space-y-3">
-          {isAddingCustom ? (
-            <div className="rounded-md border border-dashed border-brand-primary/50 bg-brand-primary/5 p-4">
-              <div className="grid gap-3 md:grid-cols-2">
-                <div>
-                  <label className="mb-1 block text-xs font-semibold uppercase text-gray-600">Clé technique</label>
-                  <input
-                    type="text"
-                    value={customKeyInput}
-                    onChange={event => {
-                      setCustomKeyInput(event.target.value);
-                      setCustomPermissionError(null);
-                    }}
-                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
-                    placeholder="ex. /rapports"
-                  />
-                </div>
-                <div>
-                  <label className="mb-1 block text-xs font-semibold uppercase text-gray-600">Nom affiché</label>
-                  <input
-                    type="text"
-                    value={customLabelInput}
-                    onChange={event => {
-                      setCustomLabelInput(event.target.value);
-                      setCustomPermissionError(null);
-                    }}
-                    className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
-                    placeholder="ex. Rapports"
-                  />
-                </div>
-              </div>
-              {customPermissionError && (
-                <p className="mt-2 text-xs text-red-600">{customPermissionError}</p>
-              )}
-              <div className="mt-3 flex justify-end space-x-2">
-                <button
-                  type="button"
-                  onClick={resetCustomPermissionForm}
-                  className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-medium text-gray-700 hover:bg-gray-100"
-                >
-                  Annuler
-                </button>
-                <button
-                  type="button"
-                  onClick={handleConfirmAddCustomPermission}
-                  className="rounded-md bg-brand-primary px-3 py-1.5 text-xs font-semibold text-white hover:bg-brand-primary/90"
-                >
-                  Ajouter
-                </button>
-              </div>
-            </div>
+          <label htmlFor="role-name" className="mb-1 block text-sm font-medium text-gray-900">
+            Nom du rôle
+          </label>
+          <input
+            id="role-name"
+            name="name"
+            value={formState.name}
+            onChange={onInputChange}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+            placeholder="Ex. Manager"
+          />
+        </div>
+        <div>
+          <label htmlFor="role-pin" className="mb-1 block text-sm font-medium text-gray-900">
+            Code PIN d'accès
+          </label>
+          <input
+            id="role-pin"
+            name="pin"
+            value={formState.pin}
+            onChange={onInputChange}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+            placeholder="Ex. 1234"
+          />
+        </div>
+        <div>
+          <label htmlFor="role-home-page" className="mb-1 block text-sm font-medium text-gray-900">
+            Page d'accueil par défaut
+          </label>
+          <select
+            id="role-home-page"
+            name="homePage"
+            value={formState.homePage}
+            onChange={event => onHomePageChange(event.target.value)}
+            disabled={!hasAccessibleHomePage}
+            className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary disabled:cursor-not-allowed disabled:bg-gray-100"
+          >
+            {NAV_LINKS.map(link => {
+              const canAccess = isPermissionGranted(formState.permissions[link.permissionKey]);
+              return (
+                <option key={link.permissionKey} value={link.permissionKey} disabled={!canAccess}>
+                  {getPermissionLabel(link.permissionKey)}
+                  {!canAccess ? ' (accès requis)' : ''}
+                </option>
+              );
+            })}
+          </select>
+          {hasAccessibleHomePage ? (
+            <p className="mt-1 text-xs text-gray-900">Les pages sans permission sont désactivées.</p>
           ) : (
-            <button
-              type="button"
-              onClick={() => {
-                setIsAddingCustom(true);
-                setCustomPermissionError(null);
-              }}
-              className="text-sm font-medium text-brand-primary hover:underline"
-            >
-              Ajouter une permission
-            </button>
+            <p className="mt-1 text-xs font-medium text-red-700">Accordez au moins une permission pour choisir une page d'accueil.</p>
           )}
         </div>
-      </div>
-      <div className="flex justify-end space-x-2">
-        {mode === 'edit' && (
+        <div>
+          <p className="mb-2 text-sm font-semibold text-gray-900">Permissions par page</p>
+          <PermissionMatrix
+            permissionKeys={permissionKeys}
+            permissions={formState.permissions}
+            onChange={onPermissionChange}
+            getPermissionLabel={getPermissionLabel}
+            customPermissions={formState.customPermissions}
+            onRemoveCustomPermission={onRemoveCustomPermission}
+          />
+          <div className="mt-4 space-y-3">
+            {isAddingCustom ? (
+              <div className="rounded-md border border-dashed border-brand-primary/50 bg-brand-primary/5 p-4">
+                <div className="grid gap-3 md:grid-cols-2">
+                  <div>
+                    <label className="mb-1 block text-xs font-semibold uppercase text-gray-900">Clé technique</label>
+                    <input
+                      type="text"
+                      value={customKeyInput}
+                      onChange={event => {
+                        setCustomKeyInput(event.target.value);
+                        setCustomPermissionError(null);
+                      }}
+                      className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+                      placeholder="ex. /rapports"
+                    />
+                  </div>
+                  <div>
+                    <label className="mb-1 block text-xs font-semibold uppercase text-gray-900">Nom affiché</label>
+                    <input
+                      type="text"
+                      value={customLabelInput}
+                      onChange={event => {
+                        setCustomLabelInput(event.target.value);
+                        setCustomPermissionError(null);
+                      }}
+                      className="w-full rounded-md border border-gray-300 px-3 py-2 text-sm focus:border-brand-primary focus:outline-none focus:ring-1 focus:ring-brand-primary"
+                      placeholder="ex. Rapports"
+                    />
+                  </div>
+                </div>
+                {customPermissionError && (
+                  <p className="mt-2 text-xs font-medium text-red-700">{customPermissionError}</p>
+                )}
+                <div className="mt-3 flex justify-end space-x-2">
+                  <button
+                    type="button"
+                    onClick={resetCustomPermissionForm}
+                    className="rounded-md border border-gray-300 px-3 py-1.5 text-xs font-semibold text-gray-900 hover:bg-gray-100"
+                  >
+                    Annuler
+                  </button>
+                  <button
+                    type="button"
+                    onClick={handleConfirmAddCustomPermission}
+                    className="rounded-md bg-brand-primary px-3 py-1.5 text-xs font-semibold text-white hover:bg-brand-primary/90"
+                  >
+                    Ajouter
+                  </button>
+                </div>
+              </div>
+            ) : (
+              <button
+                type="button"
+                onClick={() => {
+                  setIsAddingCustom(true);
+                  setCustomPermissionError(null);
+                }}
+                className="text-sm font-semibold text-brand-primary hover:underline"
+              >
+                Ajouter une permission
+              </button>
+            )}
+          </div>
+        </div>
+        <div className="flex justify-end space-x-2">
+          {mode === 'edit' && (
+            <button
+              type="button"
+              onClick={onCancel}
+              className="rounded-md border border-gray-300 px-3 py-2 text-sm font-semibold text-gray-900 hover:bg-gray-100"
+            >
+              Annuler
+            </button>
+          )}
           <button
-            type="button"
-            onClick={onCancel}
-            className="rounded-md border border-gray-300 px-3 py-2 text-sm font-medium text-gray-700 hover:bg-gray-100"
+            type="submit"
+            disabled={isSubmitting}
+            className="inline-flex items-center rounded-md bg-brand-primary px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
           >
-            Annuler
+            <Save className="mr-2 h-4 w-4" />
+            {isSubmitting ? 'Enregistrement...' : mode === 'edit' ? 'Mettre à jour' : 'Créer'}
           </button>
-        )}
-        <button
-          type="submit"
-          disabled={isSubmitting}
-          className="inline-flex items-center rounded-md bg-brand-primary px-4 py-2 text-sm font-semibold text-white shadow hover:bg-brand-primary/90 disabled:cursor-not-allowed disabled:opacity-60"
-        >
-          <Save className="mr-2 h-4 w-4" />
-          {isSubmitting ? 'Enregistrement...' : mode === 'edit' ? 'Mettre à jour' : 'Créer'}
-        </button>
-      </div>
-    </form>
-  </div>
+        </div>
+      </form>
+    </div>
   );
 };
 

--- a/components/role-manager/RoleList.tsx
+++ b/components/role-manager/RoleList.tsx
@@ -28,61 +28,63 @@ const RoleList: React.FC<RoleListProps> = ({
   const isEmpty = !isFetching && roles.length === 0;
 
   return (
-    <div>
+    <div className="flex h-full flex-col">
       <div className="mb-4 flex items-center justify-between">
-        <h4 className="text-lg font-semibold text-gray-800">Rôles existants</h4>
+        <h4 className="text-lg font-semibold text-gray-900">Rôles existants</h4>
         <button
           type="button"
           onClick={onCreateRole}
-          className="inline-flex items-center rounded-md border border-brand-primary px-3 py-1.5 text-sm font-medium text-brand-primary hover:bg-brand-primary/10"
+          className="inline-flex items-center rounded-md border border-brand-primary px-2 py-1 text-sm font-medium text-brand-primary transition-colors hover:bg-brand-primary/10"
         >
-          <Plus className="mr-2 h-4 w-4" />
+          <Plus className="mr-1.5 h-4 w-4" />
           Nouveau rôle
         </button>
       </div>
-      <div className="max-h-80 space-y-3 overflow-y-auto rounded-md border border-gray-200 p-3">
+      <div className="flex-1 overflow-y-auto rounded-md border border-gray-200 p-3">
         {isFetching ? (
-          <p className="text-sm text-gray-500">Chargement des rôles...</p>
+          <p className="text-sm text-gray-900">Chargement des rôles...</p>
         ) : isEmpty ? (
-          <p className="text-sm text-gray-500">Aucun rôle configuré pour le moment.</p>
+          <p className="text-sm text-gray-900">Aucun rôle configuré pour le moment.</p>
         ) : (
-          roles.map(role => {
-            const isSelected = isEditing && selectedRoleId === role.id;
-            return (
-              <div
-                key={role.id}
-                className={`flex items-center justify-between rounded-md border px-3 py-2 ${
-                  isSelected ? 'border-brand-primary bg-brand-primary/10' : 'border-gray-200'
-                }`}
-              >
-                <div>
-                  <p className="font-semibold text-gray-800">{role.name}</p>
-                  <p className="text-xs text-gray-500">PIN : {role.pin ?? '—'}</p>
-                  {role.homePage && (
-                    <p className="text-xs text-gray-500">Accueil : {getPermissionLabel(role.homePage)}</p>
-                  )}
+          <div className="space-y-3">
+            {roles.map(role => {
+              const isSelected = isEditing && selectedRoleId === role.id;
+              return (
+                <div
+                  key={role.id}
+                  className={`flex items-center justify-between rounded-md border px-3 py-2 transition-colors ${
+                    isSelected ? 'border-brand-primary bg-brand-primary/10' : 'border-gray-200'
+                  }`}
+                >
+                  <div className="space-y-1">
+                    <p className="font-semibold text-gray-900">{role.name}</p>
+                    <p className="text-xs font-medium text-gray-900">PIN : {role.pin ?? '—'}</p>
+                    {role.homePage && (
+                      <p className="text-xs font-medium text-gray-900">Accueil : {getPermissionLabel(role.homePage)}</p>
+                    )}
+                  </div>
+                  <div className="flex items-center gap-2">
+                    <button
+                      type="button"
+                      onClick={() => onSelectRole(role)}
+                      className="rounded-md border border-gray-300 px-2 py-1 text-xs font-semibold text-gray-900 transition-colors hover:bg-gray-100"
+                    >
+                      Modifier
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => onDeleteRole(role.id)}
+                      disabled={deletingRoleId === role.id}
+                      className="inline-flex items-center rounded-md border border-red-300 px-2 py-1 text-xs font-semibold text-red-600 transition-colors hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
+                    >
+                      <Trash2 className="mr-1 h-3 w-3" />
+                      Supprimer
+                    </button>
+                  </div>
                 </div>
-                <div className="flex space-x-2">
-                  <button
-                    type="button"
-                    onClick={() => onSelectRole(role)}
-                    className="rounded-md border border-gray-300 px-2 py-1 text-xs font-medium text-gray-700 hover:bg-gray-100"
-                  >
-                    Modifier
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => onDeleteRole(role.id)}
-                    disabled={deletingRoleId === role.id}
-                    className="inline-flex items-center rounded-md border border-red-300 px-2 py-1 text-xs font-medium text-red-600 hover:bg-red-50 disabled:cursor-not-allowed disabled:opacity-60"
-                  >
-                    <Trash2 className="mr-1 h-3 w-3" />
-                    Supprimer
-                  </button>
-                </div>
-              </div>
-            );
-          })
+              );
+            })}
+          </div>
         )}
       </div>
     </div>

--- a/components/role-manager/RoleManagerDialog.tsx
+++ b/components/role-manager/RoleManagerDialog.tsx
@@ -37,43 +37,47 @@ const RoleManagerDialog: React.FC<RoleManagerDialogProps> = ({ isOpen, onClose }
 
   return (
     <Modal isOpen={isOpen} onClose={handleClose} title="Gestion des rôles" size="xl">
-      <div className="space-y-6">
+      <div className="flex flex-col gap-6">
         {statusMessage && (
-          <div className="rounded-md bg-green-100 px-4 py-2 text-sm text-green-800">{statusMessage}</div>
+          <div className="rounded-md bg-green-100 px-4 py-2 text-sm font-medium text-green-900">{statusMessage}</div>
         )}
         {errorMessage && (
-          <div className="rounded-md bg-red-100 px-4 py-2 text-sm text-red-800">{errorMessage}</div>
+          <div className="rounded-md bg-red-100 px-4 py-2 text-sm font-medium text-red-900">{errorMessage}</div>
         )}
 
-        <div className="grid gap-6 md:grid-cols-2">
-          <RoleList
-            roles={roles}
-            isFetching={isFetching}
-            onCreateRole={resetForm}
-            onSelectRole={handleSelectRole}
-            onDeleteRole={handleDeleteRole}
-            selectedRoleId={formState.id}
-            isEditing={mode === 'edit'}
-            deletingRoleId={deletingRoleId}
-            getPermissionLabel={getPermissionLabel}
-          />
+        <div className="flex flex-col gap-6 md:flex-row md:items-start md:gap-8">
+          <div className="md:w-[38%] md:flex-shrink-0 lg:w-[35%]">
+            <RoleList
+              roles={roles}
+              isFetching={isFetching}
+              onCreateRole={resetForm}
+              onSelectRole={handleSelectRole}
+              onDeleteRole={handleDeleteRole}
+              selectedRoleId={formState.id}
+              isEditing={mode === 'edit'}
+              deletingRoleId={deletingRoleId}
+              getPermissionLabel={getPermissionLabel}
+            />
+          </div>
 
-          <RoleForm
-            mode={mode}
-            formState={formState}
-            onSubmit={handleSubmit}
-            onInputChange={handleInputChange}
-            onHomePageChange={handleHomePageChange}
-            onPermissionChange={handlePermissionChange}
-            onAddCustomPermission={handleAddCustomPermission}
-            onRemoveCustomPermission={handleRemoveCustomPermission}
-            onCancel={resetForm}
-            isSubmitting={isSubmitting}
-            hasAccessibleHomePage={hasAccessibleHomePage}
-            permissionKeys={permissionKeys}
-            getPermissionLabel={getPermissionLabel}
-            isPermissionGranted={isPermissionGranted}
-          />
+          <div className="flex-1">
+            <RoleForm
+              mode={mode}
+              formState={formState}
+              onSubmit={handleSubmit}
+              onInputChange={handleInputChange}
+              onHomePageChange={handleHomePageChange}
+              onPermissionChange={handlePermissionChange}
+              onAddCustomPermission={handleAddCustomPermission}
+              onRemoveCustomPermission={handleRemoveCustomPermission}
+              onCancel={resetForm}
+              isSubmitting={isSubmitting}
+              hasAccessibleHomePage={hasAccessibleHomePage}
+              permissionKeys={permissionKeys}
+              getPermissionLabel={getPermissionLabel}
+              isPermissionGranted={isPermissionGranted}
+            />
+          </div>
         </div>
       </div>
     </Modal>


### PR DESCRIPTION
## Summary
- enlarge the modal template and make its content area flexible to avoid nested scrollbars
- rework the role manager dialog layout with compact controls and higher-contrast text
- update the role form and permission matrix typography colors to meet contrast guidance

## Testing
- `npm run dev -- --host 0.0.0.0 --port 4173` *(fails: existing duplicate "HelpCircle" declaration in pages/Produits.tsx)*

------
https://chatgpt.com/codex/tasks/task_b_68da951f8f4c832ab9adc83d37708ac3