### PR TITLE
Replace site customization forms with preview modals

### DIFF
--- a/components/SitePreviewCanvas.tsx
+++ b/components/SitePreviewCanvas.tsx
@@ -1,0 +1,225 @@
+import React from 'react';
+import { Mail, MapPin, Phone } from 'lucide-react';
+import { SiteContent } from '../types';
+
+export type EditableZoneKey = 'navigation' | 'hero' | 'about' | 'menu' | 'contact' | 'footer';
+
+interface SitePreviewCanvasProps {
+  content: SiteContent;
+  onEdit: (zone: EditableZoneKey) => void;
+}
+
+interface EditableZoneFrameProps {
+  zone: EditableZoneKey;
+  label: string;
+  onEdit: (zone: EditableZoneKey) => void;
+  children: React.ReactNode;
+  className?: string;
+  contentClassName?: string;
+}
+
+const EditableZoneFrame: React.FC<EditableZoneFrameProps> = ({
+  zone,
+  label,
+  onEdit,
+  children,
+  className,
+  contentClassName,
+}) => {
+  const outerClasses = [
+    'relative rounded-3xl border-2 border-dashed border-brand-primary/40 bg-white shadow-sm',
+    className,
+  ]
+    .filter(Boolean)
+    .join(' ');
+  const innerClasses = ['relative z-10', contentClassName].filter(Boolean).join(' ');
+
+  return (
+    <div className={outerClasses}>
+      <div className="absolute left-4 top-3 z-20">
+        <span className="inline-flex items-center rounded-full bg-brand-primary/10 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-brand-primary">
+          {label}
+        </span>
+      </div>
+      <button
+        type="button"
+        onClick={() => onEdit(zone)}
+        className="absolute right-4 top-3 z-20 rounded-full bg-brand-primary px-3 py-1 text-xs font-semibold text-white shadow-md transition hover:bg-brand-primary/90"
+      >
+        Modifier
+      </button>
+      <div className={innerClasses}>{children}</div>
+    </div>
+  );
+};
+
+const placeholderProducts = [
+  {
+    id: '1',
+    name: 'Taco al Pastor',
+    description: 'Porc mariné, ananas rôti et coriandre fraîche.',
+    price: '12,90€',
+  },
+  {
+    id: '2',
+    name: 'Burrito Barbacoa',
+    description: 'Bœuf effiloché, haricots noirs et pico de gallo.',
+    price: '14,50€',
+  },
+  {
+    id: '3',
+    name: 'Quesadilla Verde',
+    description: 'Fromage fondant, courgettes grillées et salsa verde.',
+    price: '11,40€',
+  },
+];
+
+const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({ content, onEdit }) => {
+  const heroBackgroundStyle = content.hero.backgroundImage
+    ? { backgroundImage: `url('${content.hero.backgroundImage}')` }
+    : undefined;
+
+  return (
+    <div className="space-y-6 rounded-[2.5rem] border border-gray-200 bg-slate-50 p-6 shadow-inner">
+      <EditableZoneFrame zone="navigation" label="Navigation" onEdit={onEdit} contentClassName="pt-16">
+        <header className="login-header">
+          <div className="layout-container login-header__inner">
+            <span className="login-brand">{content.navigation.brand}</span>
+            <nav className="login-nav" aria-label="Navigation principale">
+              <span className="login-nav__link">{content.navigation.links.home}</span>
+              <span className="login-nav__link">{content.navigation.links.about}</span>
+              <span className="login-nav__link">{content.navigation.links.menu}</span>
+              <span className="login-nav__link">{content.navigation.links.contact}</span>
+              <button type="button" className="ui-btn ui-btn-accent login-nav__cta" disabled>
+                {content.navigation.links.loginCta}
+              </button>
+            </nav>
+          </div>
+        </header>
+      </EditableZoneFrame>
+
+      <EditableZoneFrame zone="hero" label="Hero" onEdit={onEdit} className="overflow-hidden" contentClassName="pt-14">
+        <section className="section section-hero" style={heroBackgroundStyle}>
+          <div className="section-hero__inner">
+            <div className="hero-content">
+              <h2 className="hero-title">{content.hero.title}</h2>
+              <p className="hero-subtitle">{content.hero.subtitle}</p>
+              <button type="button" className="ui-btn ui-btn-accent hero-cta" disabled>
+                {content.hero.ctaLabel}
+              </button>
+              <div className="hero-history mt-6">
+                <p className="hero-history__title">{content.hero.historyTitle}</p>
+                <div className="hero-history__list">
+                  {[0, 1, 2].map(index => (
+                    <div key={index} className="hero-history__item">
+                      <div className="hero-history__meta">
+                        <p className="hero-history__date">Commande du 12/03/2024</p>
+                        <p className="hero-history__details">2 article(s) • 32€</p>
+                      </div>
+                      <button type="button" className="hero-history__cta" disabled>
+                        {content.hero.reorderCtaLabel}
+                      </button>
+                    </div>
+                  ))}
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      </EditableZoneFrame>
+
+      <EditableZoneFrame zone="about" label="À propos" onEdit={onEdit} className="overflow-hidden" contentClassName="pt-14">
+        <section className="section section-surface">
+          <div className="section-inner section-inner--center">
+            <h2 className="section-title">{content.about.title}</h2>
+            <p className="section-text section-text--muted">{content.about.description}</p>
+            {content.about.image && (
+              <img
+                src={content.about.image}
+                alt={content.about.title}
+                className="mt-6 h-64 w-full rounded-xl object-cover shadow-lg"
+              />
+            )}
+          </div>
+        </section>
+      </EditableZoneFrame>
+
+      <EditableZoneFrame zone="menu" label="Menu" onEdit={onEdit} className="overflow-hidden" contentClassName="pt-14">
+        <section className="section section-muted">
+          <div className="section-inner section-inner--wide section-inner--center">
+            <h2 className="section-title">{content.menu.title}</h2>
+            {content.menu.image && (
+              <img
+                src={content.menu.image}
+                alt={content.menu.title}
+                className="mb-8 h-64 w-full rounded-xl object-cover shadow-lg"
+              />
+            )}
+            <div className="menu-grid">
+              {placeholderProducts.map(product => (
+                <article key={product.id} className="ui-card menu-card">
+                  <div className="h-40 w-full rounded-t-xl bg-gradient-to-br from-orange-200 via-amber-100 to-orange-50" />
+                  <div className="menu-card__body">
+                    <h3 className="menu-card__title">{product.name}</h3>
+                    <p className="menu-card__description">{product.description}</p>
+                    <p className="menu-card__price">{product.price}</p>
+                  </div>
+                </article>
+              ))}
+            </div>
+            <div className="section-actions">
+              <button type="button" className="ui-btn ui-btn-primary hero-cta" disabled>
+                {content.menu.ctaLabel}
+              </button>
+              <p className="section-text section-text--muted">{content.menu.loadingLabel}</p>
+            </div>
+          </div>
+        </section>
+      </EditableZoneFrame>
+
+      <EditableZoneFrame zone="contact" label="Contact" onEdit={onEdit} className="overflow-hidden" contentClassName="pt-14">
+        <section className="section section-surface">
+          <div className="section-inner section-inner--wide section-inner--center">
+            <h2 className="section-title">{content.contact.title}</h2>
+            {content.contact.image && (
+              <img
+                src={content.contact.image}
+                alt={content.contact.title}
+                className="mb-8 h-64 w-full rounded-xl object-cover shadow-lg"
+              />
+            )}
+            <div className="contact-grid">
+              <div className="contact-card">
+                <MapPin className="contact-card__icon" />
+                <h3 className="contact-card__title">{content.contact.addressLabel}</h3>
+                <p className="contact-card__text">{content.contact.address}</p>
+              </div>
+              <div className="contact-card">
+                <Phone className="contact-card__icon" />
+                <h3 className="contact-card__title">{content.contact.phoneLabel}</h3>
+                <p className="contact-card__text">{content.contact.phone}</p>
+              </div>
+              <div className="contact-card">
+                <Mail className="contact-card__icon" />
+                <h3 className="contact-card__title">{content.contact.emailLabel}</h3>
+                <p className="contact-card__text">{content.contact.email}</p>
+              </div>
+            </div>
+          </div>
+        </section>
+      </EditableZoneFrame>
+
+      <EditableZoneFrame zone="footer" label="Pied de page" onEdit={onEdit} contentClassName="pt-14">
+        <footer className="site-footer">
+          <div className="layout-container site-footer__inner">
+            <p>
+              &copy; {new Date().getFullYear()} {content.navigation.brand}. {content.footer.text}
+            </p>
+          </div>
+        </footer>
+      </EditableZoneFrame>
+    </div>
+  );
+};
+
+export default SitePreviewCanvas;

--- a/pages/SiteCustomization.tsx
+++ b/pages/SiteCustomization.tsx
@@ -1,15 +1,48 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import { Mail, MapPin, Phone } from 'lucide-react';
 import useSiteContent from '../hooks/useSiteContent';
 import { SiteContent } from '../types';
 import { normalizeCloudinaryImageUrl, uploadProductImage } from '../services/cloudinary';
 import { resolveSiteContent } from '../utils/siteContent';
-
-const cardClass = 'rounded-2xl border border-gray-200 bg-white p-6 shadow-sm';
+import SitePreviewCanvas, { EditableZoneKey } from '../components/SitePreviewCanvas';
+import Modal from '../components/Modal';
 
 const imageWarning = "L'URL doit provenir de Cloudinary (https://*.cloudinary.com).";
 
 type ImageFieldKey = 'hero.backgroundImage' | 'about.image' | 'menu.image' | 'contact.image';
+type HeroFieldKey = Exclude<keyof SiteContent['hero'], 'backgroundImage'>;
+type MenuFieldKey = Exclude<keyof SiteContent['menu'], 'image'>;
+type ContactFieldKey = Exclude<keyof SiteContent['contact'], 'image'>;
+type NavigationFieldKey = keyof SiteContent['navigation']['links'];
+
+type NavigationChangeHandler = (key: NavigationFieldKey) => (event: React.ChangeEvent<HTMLInputElement>) => void;
+type HeroChangeHandler = (
+  key: HeroFieldKey,
+) => (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+type MenuChangeHandler = (key: MenuFieldKey) => (event: React.ChangeEvent<HTMLInputElement>) => void;
+type ContactChangeHandler = (key: ContactFieldKey) => (event: React.ChangeEvent<HTMLInputElement>) => void;
+type ImageInputHandler = (field: ImageFieldKey) => (event: React.ChangeEvent<HTMLInputElement>) => void;
+
+type ImageUploadHandler = (field: ImageFieldKey, file: File) => Promise<void>;
+type ImageClearHandler = (field: ImageFieldKey) => void;
+
+type SiteCustomizationModalsProps = {
+  activeZone: EditableZoneKey | null;
+  onClose: () => void;
+  draft: SiteContent;
+  handleBrandChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleNavigationChange: NavigationChangeHandler;
+  handleHeroFieldChange: HeroChangeHandler;
+  handleAboutTitleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleAboutChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  handleMenuFieldChange: MenuChangeHandler;
+  handleContactFieldChange: ContactChangeHandler;
+  handleFooterTextChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleImageInputChange: ImageInputHandler;
+  handleImageUpload: ImageUploadHandler;
+  handleClearImage: ImageClearHandler;
+  imageErrors: Record<ImageFieldKey, string | null>;
+  isUploading: (field: ImageFieldKey) => boolean;
+};
 
 const IMAGE_FIELD_LABELS: Record<ImageFieldKey, string> = {
   'hero.backgroundImage': 'Visuel de fond (hero)',
@@ -36,6 +69,7 @@ const SiteCustomization: React.FC = () => {
     ...INITIAL_IMAGE_ERRORS,
   });
   const [uploadingField, setUploadingField] = useState<ImageFieldKey | null>(null);
+  const [activeZone, setActiveZone] = useState<EditableZoneKey | null>(null);
 
   useEffect(() => {
     setDraft(content);
@@ -46,9 +80,6 @@ const SiteCustomization: React.FC = () => {
   }, [content]);
 
   const previewContent = useMemo(() => resolveSiteContent(draft), [draft]);
-  const previewHeroStyle = previewContent.hero.backgroundImage
-    ? { backgroundImage: `url('${previewContent.hero.backgroundImage}')` }
-    : undefined;
 
   const mutateDraft = (updater: (prev: SiteContent) => SiteContent) => {
     setDraft(prev => updater(prev));
@@ -57,20 +88,19 @@ const SiteCustomization: React.FC = () => {
     setFormError(null);
   };
 
-  const handleNavigationChange = (key: keyof SiteContent['navigation']['links']) =>
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value;
-      mutateDraft(prev => ({
-        ...prev,
-        navigation: {
-          ...prev.navigation,
-          links: {
-            ...prev.navigation.links,
-            [key]: value,
-          },
+  const handleNavigationChange: NavigationChangeHandler = key => event => {
+    const value = event.target.value;
+    mutateDraft(prev => ({
+      ...prev,
+      navigation: {
+        ...prev.navigation,
+        links: {
+          ...prev.navigation.links,
+          [key]: value,
         },
-      }));
-    };
+      },
+    }));
+  };
 
   const handleBrandChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
@@ -83,17 +113,16 @@ const SiteCustomization: React.FC = () => {
     }));
   };
 
-  const handleHeroFieldChange = (key: Exclude<keyof SiteContent['hero'], 'backgroundImage'>) =>
-    (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
-      const value = event.target.value;
-      mutateDraft(prev => ({
-        ...prev,
-        hero: {
-          ...prev.hero,
-          [key]: value,
-        },
-      }));
-    };
+  const handleHeroFieldChange: HeroChangeHandler = key => event => {
+    const value = event.target.value;
+    mutateDraft(prev => ({
+      ...prev,
+      hero: {
+        ...prev.hero,
+        [key]: value,
+      },
+    }));
+  };
 
   const handleAboutChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
     const value = event.target.value;
@@ -117,29 +146,27 @@ const SiteCustomization: React.FC = () => {
     }));
   };
 
-  const handleMenuFieldChange = (key: Exclude<keyof SiteContent['menu'], 'image'>) =>
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value;
-      mutateDraft(prev => ({
-        ...prev,
-        menu: {
-          ...prev.menu,
-          [key]: value,
-        },
-      }));
-    };
+  const handleMenuFieldChange: MenuChangeHandler = key => event => {
+    const value = event.target.value;
+    mutateDraft(prev => ({
+      ...prev,
+      menu: {
+        ...prev.menu,
+        [key]: value,
+      },
+    }));
+  };
 
-  const handleContactFieldChange = (key: Exclude<keyof SiteContent['contact'], 'image'>) =>
-    (event: React.ChangeEvent<HTMLInputElement>) => {
-      const value = event.target.value;
-      mutateDraft(prev => ({
-        ...prev,
-        contact: {
-          ...prev.contact,
-          [key]: value,
-        },
-      }));
-    };
+  const handleContactFieldChange: ContactChangeHandler = key => event => {
+    const value = event.target.value;
+    mutateDraft(prev => ({
+      ...prev,
+      contact: {
+        ...prev.contact,
+        [key]: value,
+      },
+    }));
+  };
 
   const handleFooterTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
     const value = event.target.value;
@@ -191,7 +218,7 @@ const SiteCustomization: React.FC = () => {
     });
   };
 
-  const handleImageInputChange = (field: ImageFieldKey) => (event: React.ChangeEvent<HTMLInputElement>) => {
+  const handleImageInputChange: ImageInputHandler = field => event => {
     const raw = event.target.value;
     const trimmed = raw.trim();
     const nextValue = trimmed.length > 0 ? trimmed : null;
@@ -203,7 +230,7 @@ const SiteCustomization: React.FC = () => {
     }));
   };
 
-  const handleImageUpload = async (field: ImageFieldKey, file: File) => {
+  const handleImageUpload: ImageUploadHandler = async (field, file) => {
     setUploadingField(field);
     setFormError(null);
     setStatusMessage(null);
@@ -223,7 +250,7 @@ const SiteCustomization: React.FC = () => {
     }
   };
 
-  const handleClearImage = (field: ImageFieldKey) => {
+  const handleClearImage: ImageClearHandler = field => {
     setImageField(field, null);
     setImageErrors(prev => ({
       ...prev,
@@ -260,6 +287,7 @@ const SiteCustomization: React.FC = () => {
     setStatusMessage(null);
     setFormError(null);
     setImageErrors({ ...INITIAL_IMAGE_ERRORS });
+    setActiveZone(null);
   };
 
   const isUploading = (field: ImageFieldKey) => uploadingField === field;
@@ -311,554 +339,484 @@ const SiteCustomization: React.FC = () => {
           <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-brand-primary" />
         </div>
       ) : (
-        <div className="space-y-10">
-          <section className={`${cardClass} space-y-6`}>
-            <div className="space-y-1">
-              <h2 className="text-lg font-semibold text-gray-900">Navigation & section hero</h2>
-              <p className="text-sm text-gray-500">Les éléments modifiés s'affichent instantanément dans l'aperçu.</p>
-            </div>
-            <div className="grid gap-6 lg:grid-cols-2">
-              <div className="space-y-4">
-                <div className="overflow-hidden rounded-xl border border-gray-200">
-                  <section className="section section-hero" style={previewHeroStyle}>
-                    <div className="section-hero__inner">
-                      <div className="hero-content">
-                        <h2 className="hero-title">{previewContent.hero.title}</h2>
-                        <p className="hero-subtitle">{previewContent.hero.subtitle}</p>
-                        <button type="button" className="ui-btn ui-btn-accent hero-cta" disabled>
-                          {previewContent.hero.ctaLabel}
-                        </button>
-                      </div>
-                    </div>
-                  </section>
-                </div>
-                <div className="rounded-xl border border-gray-200 bg-white p-4">
-                  <h3 className="text-sm font-semibold text-gray-700">Navigation</h3>
-                  <ul className="mt-3 space-y-2 text-sm text-gray-600">
-                    <li>{previewContent.navigation.links.home}</li>
-                    <li>{previewContent.navigation.links.about}</li>
-                    <li>{previewContent.navigation.links.menu}</li>
-                    <li>{previewContent.navigation.links.contact}</li>
-                    <li>{previewContent.navigation.links.loginCta}</li>
-                  </ul>
-                </div>
-              </div>
-              <div className="space-y-4">
-                <div>
-                  <label htmlFor="brand-name" className="block text-sm font-medium text-gray-700">
-                    Nom de la marque
-                  </label>
-                  <input
-                    id="brand-name"
-                    className="ui-input mt-1"
-                    value={draft.navigation.brand}
-                    onChange={handleBrandChange}
-                  />
-                </div>
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div>
-                    <label htmlFor="nav-home" className="block text-sm font-medium text-gray-700">Lien Accueil</label>
-                    <input
-                      id="nav-home"
-                      className="ui-input mt-1"
-                      value={draft.navigation.links.home}
-                      onChange={handleNavigationChange('home')}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="nav-about" className="block text-sm font-medium text-gray-700">Lien À propos</label>
-                    <input
-                      id="nav-about"
-                      className="ui-input mt-1"
-                      value={draft.navigation.links.about}
-                      onChange={handleNavigationChange('about')}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="nav-menu" className="block text-sm font-medium text-gray-700">Lien Menu</label>
-                    <input
-                      id="nav-menu"
-                      className="ui-input mt-1"
-                      value={draft.navigation.links.menu}
-                      onChange={handleNavigationChange('menu')}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="nav-contact" className="block text-sm font-medium text-gray-700">Lien Contact</label>
-                    <input
-                      id="nav-contact"
-                      className="ui-input mt-1"
-                      value={draft.navigation.links.contact}
-                      onChange={handleNavigationChange('contact')}
-                    />
-                  </div>
-                </div>
-                <div>
-                  <label htmlFor="nav-login" className="block text-sm font-medium text-gray-700">Bouton personnel</label>
-                  <input
-                    id="nav-login"
-                    className="ui-input mt-1"
-                    value={draft.navigation.links.loginCta}
-                    onChange={handleNavigationChange('loginCta')}
-                  />
-                </div>
-                <div>
-                  <label htmlFor="hero-title" className="block text-sm font-medium text-gray-700">Titre hero</label>
-                  <input
-                    id="hero-title"
-                    className="ui-input mt-1"
-                    value={draft.hero.title}
-                    onChange={handleHeroFieldChange('title')}
-                  />
-                </div>
-                <div>
-                  <label htmlFor="hero-subtitle" className="block text-sm font-medium text-gray-700">Sous-titre</label>
-                  <textarea
-                    id="hero-subtitle"
-                    className="ui-textarea mt-1"
-                    value={draft.hero.subtitle}
-                    onChange={handleHeroFieldChange('subtitle')}
-                    rows={3}
-                  />
-                </div>
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div>
-                    <label htmlFor="hero-cta" className="block text-sm font-medium text-gray-700">Texte du bouton</label>
-                    <input
-                      id="hero-cta"
-                      className="ui-input mt-1"
-                      value={draft.hero.ctaLabel}
-                      onChange={handleHeroFieldChange('ctaLabel')}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="hero-history" className="block text-sm font-medium text-gray-700">Titre historique</label>
-                    <input
-                      id="hero-history"
-                      className="ui-input mt-1"
-                      value={draft.hero.historyTitle}
-                      onChange={handleHeroFieldChange('historyTitle')}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="hero-reorder" className="block text-sm font-medium text-gray-700">Bouton de réassort</label>
-                    <input
-                      id="hero-reorder"
-                      className="ui-input mt-1"
-                      value={draft.hero.reorderCtaLabel}
-                      onChange={handleHeroFieldChange('reorderCtaLabel')}
-                    />
-                  </div>
-                </div>
-                <div>
-                  <label htmlFor="hero-image" className="block text-sm font-medium text-gray-700">
-                    {IMAGE_FIELD_LABELS['hero.backgroundImage']}
-                  </label>
-                  <input
-                    id="hero-image"
-                    className="ui-input mt-1"
-                    value={draft.hero.backgroundImage ?? ''}
-                    onChange={handleImageInputChange('hero.backgroundImage')}
-                    placeholder="https://res.cloudinary.com/..."
-                  />
-                  {imageErrors['hero.backgroundImage'] && (
-                    <p className="mt-1 text-xs text-red-600">{imageErrors['hero.backgroundImage']}</p>
-                  )}
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    <label className="ui-btn ui-btn-secondary cursor-pointer">
-                      Importer une image
-                      <input
-                        type="file"
-                        accept="image/*"
-                        className="hidden"
-                        onChange={event => {
-                          const file = event.target.files?.[0];
-                          if (file) {
-                            void handleImageUpload('hero.backgroundImage', file);
-                            event.target.value = '';
-                          }
-                        }}
-                      />
-                    </label>
-                    <button
-                      type="button"
-                      className="ui-btn ui-btn-ghost"
-                      onClick={() => handleClearImage('hero.backgroundImage')}
-                      disabled={!draft.hero.backgroundImage || isUploading('hero.backgroundImage')}
-                    >
-                      Retirer l'image
-                    </button>
-                    {isUploading('hero.backgroundImage') && (
-                      <span className="text-sm text-gray-500">Téléversement en cours…</span>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section className={`${cardClass} space-y-6`}>
-            <div className="space-y-1">
-              <h2 className="text-lg font-semibold text-gray-900">Section À propos</h2>
-              <p className="text-sm text-gray-500">Présentez l'histoire de votre établissement.</p>
-            </div>
-            <div className="grid gap-6 lg:grid-cols-2">
-              <div className="space-y-4">
-                <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
-                  <div className="section section-surface">
-                    <div className="section-inner section-inner--center">
-                      <h3 className="section-title">{previewContent.about.title}</h3>
-                      <p className="section-text section-text--muted">{previewContent.about.description}</p>
-                      {previewContent.about.image && (
-                        <img
-                          src={previewContent.about.image}
-                          alt={previewContent.about.title}
-                          className="mt-6 h-64 w-full rounded-xl object-cover shadow-lg"
-                        />
-                      )}
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div className="space-y-4">
-                <div>
-                  <label htmlFor="about-title" className="block text-sm font-medium text-gray-700">Titre</label>
-                  <input
-                    id="about-title"
-                    className="ui-input mt-1"
-                    value={draft.about.title}
-                    onChange={handleAboutTitleChange}
-                  />
-                </div>
-                <div>
-                  <label htmlFor="about-description" className="block text-sm font-medium text-gray-700">
-                    Description
-                  </label>
-                  <textarea
-                    id="about-description"
-                    className="ui-textarea mt-1"
-                    value={draft.about.description}
-                    onChange={handleAboutChange}
-                    rows={4}
-                  />
-                </div>
-                <div>
-                  <label htmlFor="about-image" className="block text-sm font-medium text-gray-700">
-                    {IMAGE_FIELD_LABELS['about.image']}
-                  </label>
-                  <input
-                    id="about-image"
-                    className="ui-input mt-1"
-                    value={draft.about.image ?? ''}
-                    onChange={handleImageInputChange('about.image')}
-                    placeholder="https://res.cloudinary.com/..."
-                  />
-                  {imageErrors['about.image'] && (
-                    <p className="mt-1 text-xs text-red-600">{imageErrors['about.image']}</p>
-                  )}
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    <label className="ui-btn ui-btn-secondary cursor-pointer">
-                      Importer une image
-                      <input
-                        type="file"
-                        accept="image/*"
-                        className="hidden"
-                        onChange={event => {
-                          const file = event.target.files?.[0];
-                          if (file) {
-                            void handleImageUpload('about.image', file);
-                            event.target.value = '';
-                          }
-                        }}
-                      />
-                    </label>
-                    <button
-                      type="button"
-                      className="ui-btn ui-btn-ghost"
-                      onClick={() => handleClearImage('about.image')}
-                      disabled={!draft.about.image || isUploading('about.image')}
-                    >
-                      Retirer l'image
-                    </button>
-                    {isUploading('about.image') && (
-                      <span className="text-sm text-gray-500">Téléversement en cours…</span>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section className={`${cardClass} space-y-6`}>
-            <div className="space-y-1">
-              <h2 className="text-lg font-semibold text-gray-900">Section Menu</h2>
-              <p className="text-sm text-gray-500">Personnalisez l'en-tête de la section menu.</p>
-            </div>
-            <div className="grid gap-6 lg:grid-cols-2">
-              <div className="space-y-4">
-                <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
-                  <div className="section section-muted">
-                    <div className="section-inner section-inner--wide section-inner--center">
-                      <h3 className="section-title">{previewContent.menu.title}</h3>
-                      {previewContent.menu.image && (
-                        <img
-                          src={previewContent.menu.image}
-                          alt={previewContent.menu.title}
-                          className="mb-8 h-64 w-full rounded-xl object-cover shadow-lg"
-                        />
-                      )}
-                      <p className="section-text section-text--muted">{previewContent.menu.loadingLabel}</p>
-                      <div className="mt-6">
-                        <button type="button" className="ui-btn ui-btn-primary hero-cta" disabled>
-                          {previewContent.menu.ctaLabel}
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div className="space-y-4">
-                <div>
-                  <label htmlFor="menu-title" className="block text-sm font-medium text-gray-700">Titre</label>
-                  <input
-                    id="menu-title"
-                    className="ui-input mt-1"
-                    value={draft.menu.title}
-                    onChange={handleMenuFieldChange('title')}
-                  />
-                </div>
-                <div>
-                  <label htmlFor="menu-cta" className="block text-sm font-medium text-gray-700">Texte du bouton</label>
-                  <input
-                    id="menu-cta"
-                    className="ui-input mt-1"
-                    value={draft.menu.ctaLabel}
-                    onChange={handleMenuFieldChange('ctaLabel')}
-                  />
-                </div>
-                <div>
-                  <label htmlFor="menu-loading" className="block text-sm font-medium text-gray-700">Texte de chargement</label>
-                  <input
-                    id="menu-loading"
-                    className="ui-input mt-1"
-                    value={draft.menu.loadingLabel}
-                    onChange={handleMenuFieldChange('loadingLabel')}
-                  />
-                </div>
-                <div>
-                  <label htmlFor="menu-image" className="block text-sm font-medium text-gray-700">
-                    {IMAGE_FIELD_LABELS['menu.image']}
-                  </label>
-                  <input
-                    id="menu-image"
-                    className="ui-input mt-1"
-                    value={draft.menu.image ?? ''}
-                    onChange={handleImageInputChange('menu.image')}
-                    placeholder="https://res.cloudinary.com/..."
-                  />
-                  {imageErrors['menu.image'] && (
-                    <p className="mt-1 text-xs text-red-600">{imageErrors['menu.image']}</p>
-                  )}
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    <label className="ui-btn ui-btn-secondary cursor-pointer">
-                      Importer une image
-                      <input
-                        type="file"
-                        accept="image/*"
-                        className="hidden"
-                        onChange={event => {
-                          const file = event.target.files?.[0];
-                          if (file) {
-                            void handleImageUpload('menu.image', file);
-                            event.target.value = '';
-                          }
-                        }}
-                      />
-                    </label>
-                    <button
-                      type="button"
-                      className="ui-btn ui-btn-ghost"
-                      onClick={() => handleClearImage('menu.image')}
-                      disabled={!draft.menu.image || isUploading('menu.image')}
-                    >
-                      Retirer l'image
-                    </button>
-                    {isUploading('menu.image') && (
-                      <span className="text-sm text-gray-500">Téléversement en cours…</span>
-                    )}
-                  </div>
-                </div>
-              </div>
-            </div>
-          </section>
-
-          <section className={`${cardClass} space-y-6`}>
-            <div className="space-y-1">
-              <h2 className="text-lg font-semibold text-gray-900">Contact & pied de page</h2>
-              <p className="text-sm text-gray-500">Mettez à jour vos coordonnées et le message du pied de page.</p>
-            </div>
-            <div className="grid gap-6 lg:grid-cols-2">
-              <div className="space-y-4">
-                <div className="overflow-hidden rounded-xl border border-gray-200 bg-white">
-                  <div className="section section-surface">
-                    <div className="section-inner section-inner--wide section-inner--center">
-                      <h3 className="section-title">{previewContent.contact.title}</h3>
-                      {previewContent.contact.image && (
-                        <img
-                          src={previewContent.contact.image}
-                          alt={previewContent.contact.title}
-                          className="mb-8 h-64 w-full rounded-xl object-cover shadow-lg"
-                        />
-                      )}
-                      <div className="contact-grid">
-                        <div className="contact-card">
-                          <MapPin className="contact-card__icon" />
-                          <h4 className="contact-card__title">{previewContent.contact.addressLabel}</h4>
-                          <p className="contact-card__text">{previewContent.contact.address}</p>
-                        </div>
-                        <div className="contact-card">
-                          <Phone className="contact-card__icon" />
-                          <h4 className="contact-card__title">{previewContent.contact.phoneLabel}</h4>
-                          <p className="contact-card__text">{previewContent.contact.phone}</p>
-                        </div>
-                        <div className="contact-card">
-                          <Mail className="contact-card__icon" />
-                          <h4 className="contact-card__title">{previewContent.contact.emailLabel}</h4>
-                          <p className="contact-card__text">{previewContent.contact.email}</p>
-                        </div>
-                      </div>
-                      <p className="mt-6 text-sm text-gray-500">
-                        &copy; {new Date().getFullYear()} {previewContent.navigation.brand}. {previewContent.footer.text}
-                      </p>
-                    </div>
-                  </div>
-                </div>
-              </div>
-              <div className="space-y-4">
-                <div>
-                  <label htmlFor="contact-title" className="block text-sm font-medium text-gray-700">Titre</label>
-                  <input
-                    id="contact-title"
-                    className="ui-input mt-1"
-                    value={draft.contact.title}
-                    onChange={handleContactFieldChange('title')}
-                  />
-                </div>
-                <div className="grid gap-4 md:grid-cols-2">
-                  <div>
-                    <label htmlFor="contact-address-label" className="block text-sm font-medium text-gray-700">Libellé adresse</label>
-                    <input
-                      id="contact-address-label"
-                      className="ui-input mt-1"
-                      value={draft.contact.addressLabel}
-                      onChange={handleContactFieldChange('addressLabel')}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="contact-address" className="block text-sm font-medium text-gray-700">Adresse</label>
-                    <input
-                      id="contact-address"
-                      className="ui-input mt-1"
-                      value={draft.contact.address}
-                      onChange={handleContactFieldChange('address')}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="contact-phone-label" className="block text-sm font-medium text-gray-700">Libellé téléphone</label>
-                    <input
-                      id="contact-phone-label"
-                      className="ui-input mt-1"
-                      value={draft.contact.phoneLabel}
-                      onChange={handleContactFieldChange('phoneLabel')}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="contact-phone" className="block text-sm font-medium text-gray-700">Téléphone</label>
-                    <input
-                      id="contact-phone"
-                      className="ui-input mt-1"
-                      value={draft.contact.phone}
-                      onChange={handleContactFieldChange('phone')}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="contact-email-label" className="block text-sm font-medium text-gray-700">Libellé email</label>
-                    <input
-                      id="contact-email-label"
-                      className="ui-input mt-1"
-                      value={draft.contact.emailLabel}
-                      onChange={handleContactFieldChange('emailLabel')}
-                    />
-                  </div>
-                  <div>
-                    <label htmlFor="contact-email" className="block text-sm font-medium text-gray-700">Email</label>
-                    <input
-                      id="contact-email"
-                      className="ui-input mt-1"
-                      value={draft.contact.email}
-                      onChange={handleContactFieldChange('email')}
-                    />
-                  </div>
-                </div>
-                <div>
-                  <label htmlFor="contact-image" className="block text-sm font-medium text-gray-700">
-                    {IMAGE_FIELD_LABELS['contact.image']}
-                  </label>
-                  <input
-                    id="contact-image"
-                    className="ui-input mt-1"
-                    value={draft.contact.image ?? ''}
-                    onChange={handleImageInputChange('contact.image')}
-                    placeholder="https://res.cloudinary.com/..."
-                  />
-                  {imageErrors['contact.image'] && (
-                    <p className="mt-1 text-xs text-red-600">{imageErrors['contact.image']}</p>
-                  )}
-                  <div className="mt-3 flex flex-wrap gap-2">
-                    <label className="ui-btn ui-btn-secondary cursor-pointer">
-                      Importer une image
-                      <input
-                        type="file"
-                        accept="image/*"
-                        className="hidden"
-                        onChange={event => {
-                          const file = event.target.files?.[0];
-                          if (file) {
-                            void handleImageUpload('contact.image', file);
-                            event.target.value = '';
-                          }
-                        }}
-                      />
-                    </label>
-                    <button
-                      type="button"
-                      className="ui-btn ui-btn-ghost"
-                      onClick={() => handleClearImage('contact.image')}
-                      disabled={!draft.contact.image || isUploading('contact.image')}
-                    >
-                      Retirer l'image
-                    </button>
-                    {isUploading('contact.image') && (
-                      <span className="text-sm text-gray-500">Téléversement en cours…</span>
-                    )}
-                  </div>
-                </div>
-                <div>
-                  <label htmlFor="footer-text" className="block text-sm font-medium text-gray-700">Texte du pied de page</label>
-                  <input
-                    id="footer-text"
-                    className="ui-input mt-1"
-                    value={draft.footer.text}
-                    onChange={handleFooterTextChange}
-                  />
-                </div>
-              </div>
-            </div>
-          </section>
-        </div>
+        <SitePreviewCanvas content={previewContent} onEdit={zone => setActiveZone(zone)} />
       )}
+
+      <SiteCustomizationModals
+        activeZone={activeZone}
+        onClose={() => setActiveZone(null)}
+        draft={draft}
+        handleBrandChange={handleBrandChange}
+        handleNavigationChange={handleNavigationChange}
+        handleHeroFieldChange={handleHeroFieldChange}
+        handleAboutChange={handleAboutChange}
+        handleAboutTitleChange={handleAboutTitleChange}
+        handleMenuFieldChange={handleMenuFieldChange}
+        handleContactFieldChange={handleContactFieldChange}
+        handleFooterTextChange={handleFooterTextChange}
+        handleImageInputChange={handleImageInputChange}
+        handleImageUpload={handleImageUpload}
+        handleClearImage={handleClearImage}
+        imageErrors={imageErrors}
+        isUploading={isUploading}
+      />
     </div>
   );
 };
+
+const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
+  activeZone,
+  onClose,
+  draft,
+  handleBrandChange,
+  handleNavigationChange,
+  handleHeroFieldChange,
+  handleAboutChange,
+  handleAboutTitleChange,
+  handleMenuFieldChange,
+  handleContactFieldChange,
+  handleFooterTextChange,
+  handleImageInputChange,
+  handleImageUpload,
+  handleClearImage,
+  imageErrors,
+  isUploading,
+}) => (
+  <>
+    <Modal isOpen={activeZone === 'navigation'} onClose={onClose} title="Modifier la navigation" size="lg">
+      <div className="space-y-5">
+        <div>
+          <label htmlFor="brand-name" className="block text-sm font-medium text-gray-700">
+            Nom de la marque
+          </label>
+          <input
+            id="brand-name"
+            className="ui-input mt-1"
+            value={draft.navigation.brand}
+            onChange={handleBrandChange}
+          />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor="nav-home" className="block text-sm font-medium text-gray-700">Lien Accueil</label>
+            <input
+              id="nav-home"
+              className="ui-input mt-1"
+              value={draft.navigation.links.home}
+              onChange={handleNavigationChange('home')}
+            />
+          </div>
+          <div>
+            <label htmlFor="nav-about" className="block text-sm font-medium text-gray-700">Lien À propos</label>
+            <input
+              id="nav-about"
+              className="ui-input mt-1"
+              value={draft.navigation.links.about}
+              onChange={handleNavigationChange('about')}
+            />
+          </div>
+          <div>
+            <label htmlFor="nav-menu" className="block text-sm font-medium text-gray-700">Lien Menu</label>
+            <input
+              id="nav-menu"
+              className="ui-input mt-1"
+              value={draft.navigation.links.menu}
+              onChange={handleNavigationChange('menu')}
+            />
+          </div>
+          <div>
+            <label htmlFor="nav-contact" className="block text-sm font-medium text-gray-700">Lien Contact</label>
+            <input
+              id="nav-contact"
+              className="ui-input mt-1"
+              value={draft.navigation.links.contact}
+              onChange={handleNavigationChange('contact')}
+            />
+          </div>
+        </div>
+        <div>
+          <label htmlFor="nav-login" className="block text-sm font-medium text-gray-700">Bouton personnel</label>
+          <input
+            id="nav-login"
+            className="ui-input mt-1"
+            value={draft.navigation.links.loginCta}
+            onChange={handleNavigationChange('loginCta')}
+          />
+        </div>
+      </div>
+    </Modal>
+
+    <Modal isOpen={activeZone === 'hero'} onClose={onClose} title="Modifier la section hero" size="xl">
+      <div className="space-y-5">
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor="hero-title" className="block text-sm font-medium text-gray-700">Titre</label>
+            <input
+              id="hero-title"
+              className="ui-input mt-1"
+              value={draft.hero.title}
+              onChange={handleHeroFieldChange('title')}
+            />
+          </div>
+          <div>
+            <label htmlFor="hero-cta" className="block text-sm font-medium text-gray-700">Texte du bouton</label>
+            <input
+              id="hero-cta"
+              className="ui-input mt-1"
+              value={draft.hero.ctaLabel}
+              onChange={handleHeroFieldChange('ctaLabel')}
+            />
+          </div>
+        </div>
+        <div>
+          <label htmlFor="hero-subtitle" className="block text-sm font-medium text-gray-700">Sous-titre</label>
+          <textarea
+            id="hero-subtitle"
+            className="ui-textarea mt-1"
+            value={draft.hero.subtitle}
+            rows={3}
+            onChange={handleHeroFieldChange('subtitle')}
+          />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor="hero-history" className="block text-sm font-medium text-gray-700">Titre historique</label>
+            <input
+              id="hero-history"
+              className="ui-input mt-1"
+              value={draft.hero.historyTitle}
+              onChange={handleHeroFieldChange('historyTitle')}
+            />
+          </div>
+          <div>
+            <label htmlFor="hero-reorder" className="block text-sm font-medium text-gray-700">Bouton de réassort</label>
+            <input
+              id="hero-reorder"
+              className="ui-input mt-1"
+              value={draft.hero.reorderCtaLabel}
+              onChange={handleHeroFieldChange('reorderCtaLabel')}
+            />
+          </div>
+        </div>
+        <div>
+          <label htmlFor="hero-image" className="block text-sm font-medium text-gray-700">
+            {IMAGE_FIELD_LABELS['hero.backgroundImage']}
+          </label>
+          <input
+            id="hero-image"
+            className="ui-input mt-1"
+            value={draft.hero.backgroundImage ?? ''}
+            onChange={handleImageInputChange('hero.backgroundImage')}
+            placeholder="https://res.cloudinary.com/..."
+          />
+          <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
+          {imageErrors['hero.backgroundImage'] && (
+            <p className="mt-1 text-xs text-red-600">{imageErrors['hero.backgroundImage']}</p>
+          )}
+          <div className="mt-3 flex flex-wrap gap-2">
+            <label className="ui-btn ui-btn-secondary cursor-pointer">
+              Importer une image
+              <input
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={event => {
+                  const file = event.target.files?.[0];
+                  if (file) {
+                    void handleImageUpload('hero.backgroundImage', file);
+                    event.target.value = '';
+                  }
+                }}
+              />
+            </label>
+            <button
+              type="button"
+              className="ui-btn ui-btn-ghost"
+              onClick={() => handleClearImage('hero.backgroundImage')}
+              disabled={!draft.hero.backgroundImage || isUploading('hero.backgroundImage')}
+            >
+              Retirer l'image
+            </button>
+            {isUploading('hero.backgroundImage') && (
+              <span className="text-sm text-gray-500">Téléversement en cours…</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </Modal>
+
+    <Modal isOpen={activeZone === 'about'} onClose={onClose} title="Modifier la section À propos" size="lg">
+      <div className="space-y-5">
+        <div>
+          <label htmlFor="about-title" className="block text-sm font-medium text-gray-700">Titre</label>
+          <input
+            id="about-title"
+            className="ui-input mt-1"
+            value={draft.about.title}
+            onChange={handleAboutTitleChange}
+          />
+        </div>
+        <div>
+          <label htmlFor="about-description" className="block text-sm font-medium text-gray-700">Description</label>
+          <textarea
+            id="about-description"
+            className="ui-textarea mt-1"
+            value={draft.about.description}
+            rows={4}
+            onChange={handleAboutChange}
+          />
+        </div>
+        <div>
+          <label htmlFor="about-image" className="block text-sm font-medium text-gray-700">
+            {IMAGE_FIELD_LABELS['about.image']}
+          </label>
+          <input
+            id="about-image"
+            className="ui-input mt-1"
+            value={draft.about.image ?? ''}
+            onChange={handleImageInputChange('about.image')}
+            placeholder="https://res.cloudinary.com/..."
+          />
+          <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
+          {imageErrors['about.image'] && (
+            <p className="mt-1 text-xs text-red-600">{imageErrors['about.image']}</p>
+          )}
+          <div className="mt-3 flex flex-wrap gap-2">
+            <label className="ui-btn ui-btn-secondary cursor-pointer">
+              Importer une image
+              <input
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={event => {
+                  const file = event.target.files?.[0];
+                  if (file) {
+                    void handleImageUpload('about.image', file);
+                    event.target.value = '';
+                  }
+                }}
+              />
+            </label>
+            <button
+              type="button"
+              className="ui-btn ui-btn-ghost"
+              onClick={() => handleClearImage('about.image')}
+              disabled={!draft.about.image || isUploading('about.image')}
+            >
+              Retirer l'image
+            </button>
+            {isUploading('about.image') && (
+              <span className="text-sm text-gray-500">Téléversement en cours…</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </Modal>
+
+    <Modal isOpen={activeZone === 'menu'} onClose={onClose} title="Modifier la section menu" size="lg">
+      <div className="space-y-5">
+        <div>
+          <label htmlFor="menu-title" className="block text-sm font-medium text-gray-700">Titre</label>
+          <input
+            id="menu-title"
+            className="ui-input mt-1"
+            value={draft.menu.title}
+            onChange={handleMenuFieldChange('title')}
+          />
+        </div>
+        <div>
+          <label htmlFor="menu-cta" className="block text-sm font-medium text-gray-700">Texte du bouton</label>
+          <input
+            id="menu-cta"
+            className="ui-input mt-1"
+            value={draft.menu.ctaLabel}
+            onChange={handleMenuFieldChange('ctaLabel')}
+          />
+        </div>
+        <div>
+          <label htmlFor="menu-loading" className="block text-sm font-medium text-gray-700">Texte de chargement</label>
+          <input
+            id="menu-loading"
+            className="ui-input mt-1"
+            value={draft.menu.loadingLabel}
+            onChange={handleMenuFieldChange('loadingLabel')}
+          />
+        </div>
+        <div>
+          <label htmlFor="menu-image" className="block text-sm font-medium text-gray-700">
+            {IMAGE_FIELD_LABELS['menu.image']}
+          </label>
+          <input
+            id="menu-image"
+            className="ui-input mt-1"
+            value={draft.menu.image ?? ''}
+            onChange={handleImageInputChange('menu.image')}
+            placeholder="https://res.cloudinary.com/..."
+          />
+          <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
+          {imageErrors['menu.image'] && (
+            <p className="mt-1 text-xs text-red-600">{imageErrors['menu.image']}</p>
+          )}
+          <div className="mt-3 flex flex-wrap gap-2">
+            <label className="ui-btn ui-btn-secondary cursor-pointer">
+              Importer une image
+              <input
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={event => {
+                  const file = event.target.files?.[0];
+                  if (file) {
+                    void handleImageUpload('menu.image', file);
+                    event.target.value = '';
+                  }
+                }}
+              />
+            </label>
+            <button
+              type="button"
+              className="ui-btn ui-btn-ghost"
+              onClick={() => handleClearImage('menu.image')}
+              disabled={!draft.menu.image || isUploading('menu.image')}
+            >
+              Retirer l'image
+            </button>
+            {isUploading('menu.image') && (
+              <span className="text-sm text-gray-500">Téléversement en cours…</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </Modal>
+
+    <Modal isOpen={activeZone === 'contact'} onClose={onClose} title="Modifier la section contact" size="xl">
+      <div className="space-y-5">
+        <div>
+          <label htmlFor="contact-title" className="block text-sm font-medium text-gray-700">Titre</label>
+          <input
+            id="contact-title"
+            className="ui-input mt-1"
+            value={draft.contact.title}
+            onChange={handleContactFieldChange('title')}
+          />
+        </div>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor="contact-address-label" className="block text-sm font-medium text-gray-700">Libellé adresse</label>
+            <input
+              id="contact-address-label"
+              className="ui-input mt-1"
+              value={draft.contact.addressLabel}
+              onChange={handleContactFieldChange('addressLabel')}
+            />
+          </div>
+          <div>
+            <label htmlFor="contact-address" className="block text-sm font-medium text-gray-700">Adresse</label>
+            <input
+              id="contact-address"
+              className="ui-input mt-1"
+              value={draft.contact.address}
+              onChange={handleContactFieldChange('address')}
+            />
+          </div>
+          <div>
+            <label htmlFor="contact-phone-label" className="block text-sm font-medium text-gray-700">Libellé téléphone</label>
+            <input
+              id="contact-phone-label"
+              className="ui-input mt-1"
+              value={draft.contact.phoneLabel}
+              onChange={handleContactFieldChange('phoneLabel')}
+            />
+          </div>
+          <div>
+            <label htmlFor="contact-phone" className="block text-sm font-medium text-gray-700">Téléphone</label>
+            <input
+              id="contact-phone"
+              className="ui-input mt-1"
+              value={draft.contact.phone}
+              onChange={handleContactFieldChange('phone')}
+            />
+          </div>
+          <div>
+            <label htmlFor="contact-email-label" className="block text-sm font-medium text-gray-700">Libellé email</label>
+            <input
+              id="contact-email-label"
+              className="ui-input mt-1"
+              value={draft.contact.emailLabel}
+              onChange={handleContactFieldChange('emailLabel')}
+            />
+          </div>
+          <div>
+            <label htmlFor="contact-email" className="block text-sm font-medium text-gray-700">Email</label>
+            <input
+              id="contact-email"
+              className="ui-input mt-1"
+              value={draft.contact.email}
+              onChange={handleContactFieldChange('email')}
+            />
+          </div>
+        </div>
+        <div>
+          <label htmlFor="contact-image" className="block text-sm font-medium text-gray-700">
+            {IMAGE_FIELD_LABELS['contact.image']}
+          </label>
+          <input
+            id="contact-image"
+            className="ui-input mt-1"
+            value={draft.contact.image ?? ''}
+            onChange={handleImageInputChange('contact.image')}
+            placeholder="https://res.cloudinary.com/..."
+          />
+          <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
+          {imageErrors['contact.image'] && (
+            <p className="mt-1 text-xs text-red-600">{imageErrors['contact.image']}</p>
+          )}
+          <div className="mt-3 flex flex-wrap gap-2">
+            <label className="ui-btn ui-btn-secondary cursor-pointer">
+              Importer une image
+              <input
+                type="file"
+                accept="image/*"
+                className="hidden"
+                onChange={event => {
+                  const file = event.target.files?.[0];
+                  if (file) {
+                    void handleImageUpload('contact.image', file);
+                    event.target.value = '';
+                  }
+                }}
+              />
+            </label>
+            <button
+              type="button"
+              className="ui-btn ui-btn-ghost"
+              onClick={() => handleClearImage('contact.image')}
+              disabled={!draft.contact.image || isUploading('contact.image')}
+            >
+              Retirer l'image
+            </button>
+            {isUploading('contact.image') && (
+              <span className="text-sm text-gray-500">Téléversement en cours…</span>
+            )}
+          </div>
+        </div>
+      </div>
+    </Modal>
+
+    <Modal isOpen={activeZone === 'footer'} onClose={onClose} title="Modifier le pied de page" size="sm">
+      <div className="space-y-4">
+        <div>
+          <label htmlFor="footer-text" className="block text-sm font-medium text-gray-700">Texte du pied de page</label>
+          <input
+            id="footer-text"
+            className="ui-input mt-1"
+            value={draft.footer.text}
+            onChange={handleFooterTextChange}
+          />
+        </div>
+      </div>
+    </Modal>
+  </>
+);
 
 export default SiteCustomization;


### PR DESCRIPTION
## Summary
- replace the stacked forms in SiteCustomization with a full-page SitePreviewCanvas preview wired to editable zones
- move navigation, hero, about, menu, contact and footer editors into modals that reuse mutateDraft and Cloudinary helpers

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68da99bf8068832a997968d0673eb618