### PR TITLE
Limit customer order history display

### DIFF
--- a/components/CustomerOrderTracker.tsx
+++ b/components/CustomerOrderTracker.tsx
@@ -16,11 +16,15 @@ const saveOrderToHistory = (order: Order) => {
         const historyJSON = localStorage.getItem('customer-order-history');
         const history: Order[] = historyJSON ? JSON.parse(historyJSON) : [];
         const existingIndex = history.findIndex(h => h.id === order.id);
-        if (existingIndex === -1) {
-            history.unshift(order); // Add to the beginning
-            const trimmedHistory = history.slice(0, 10); // Keep last 10 orders
-            localStorage.setItem('customer-order-history', JSON.stringify(trimmedHistory));
+
+        if (existingIndex !== -1) {
+            history.splice(existingIndex, 1);
         }
+
+        history.unshift(order); // Add to the beginning so most recent stays first
+
+        const trimmedHistory = history.slice(0, 10); // Keep last 10 orders
+        localStorage.setItem('customer-order-history', JSON.stringify(trimmedHistory));
     } catch (e) {
         console.error("Failed to save order to history:", e);
     }

--- a/pages/CommandeClient.tsx
+++ b/pages/CommandeClient.tsx
@@ -293,7 +293,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                         <div className="bg-white p-4 rounded-xl shadow-md mb-8">
                             <h2 className="text-xl font-bold flex items-center gap-2 mb-3 text-gray-700"><History /> Repasser une commande ?</h2>
                             <div className="space-y-2">
-                                {orderHistory.map(order => (
+                                {orderHistory.slice(0, 3).map(order => (
                                     <div key={order.id} className="flex justify-between items-center bg-gray-50 p-3 rounded-lg">
                                         <div>
                                             <p className="font-semibold text-gray-700">Commande du {new Date(order.date_creation).toLocaleDateString()}</p>


### PR DESCRIPTION
## Summary
- limit the reorder suggestion list to the three most recent customer orders
- ensure saved order history always keeps the most recent entry at the front even when updating existing records

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68daa4a57844832a9a5f0bd604be736e