### PR TITLE
feat: manage best seller product metadata

### DIFF
--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -122,7 +122,7 @@ const Login: React.FC = () => {
   const { navigation, hero, about, menu: menuContent, contact, footer } = siteContent;
   const heroBackgroundStyle = hero.backgroundImage ? { backgroundImage: `url('${hero.backgroundImage}')` } : undefined;
 
-  const [products, setProducts] = useState<Product[]>([]);
+  const [bestSellers, setBestSellers] = useState<Product[]>([]);
   const [orderHistory, setOrderHistory] = useState<Order[]>([]);
   const [menuLoading, setMenuLoading] = useState(true);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
@@ -164,8 +164,8 @@ const Login: React.FC = () => {
     const fetchMenuPreview = async () => {
       try {
         setMenuLoading(true);
-        const topProducts = await api.getTopSellingProducts();
-        setProducts(topProducts);
+        const bestSellerProducts = await api.getBestSellerProducts();
+        setBestSellers(bestSellerProducts.slice(0, 6));
       } catch (error) {
         console.error("Failed to fetch menu preview:", error);
       } finally {
@@ -322,7 +322,7 @@ const Login: React.FC = () => {
               <p className="section-text section-text--muted">{menuContent.loadingLabel}</p>
             ) : (
               <div className="menu-grid">
-                {products.map(product => (
+                {bestSellers.slice(0, 6).map(product => (
                   <article key={product.id} className="ui-card menu-card">
                     <img src={product.image} alt={product.nom_produit} className="menu-card__media" />
                     <div className="menu-card__body">

--- a/pages/Produits.tsx
+++ b/pages/Produits.tsx
@@ -9,6 +9,8 @@ import Modal from '../components/Modal';
 import { PlusCircle, Edit, Trash2, Search, Settings, GripVertical, CheckCircle, Clock, XCircle, MoreVertical, Upload, HelpCircle } from 'lucide-react';
 import { formatIntegerAmount } from '../utils/formatIntegerAmount';
 
+const BEST_SELLER_RANKS = [1, 2, 3, 4, 5, 6];
+
 const getStatusInfo = (status: Product['estado']) => {
     switch (status) {
         case 'disponible':
@@ -72,6 +74,16 @@ const Produits: React.FC = () => {
             (p.nom_produit.toLowerCase().includes(searchTerm.toLowerCase())) &&
             (categoryFilter === 'all' || p.categoria_id === categoryFilter)
         ), [products, searchTerm, categoryFilter]);
+
+    const occupiedBestSellerPositions = useMemo(() => {
+        const map = new Map<number, Product>();
+        products.forEach(prod => {
+            if (prod.is_best_seller && prod.best_seller_rank != null) {
+                map.set(prod.best_seller_rank, prod);
+            }
+        });
+        return map;
+    }, [products]);
 
     const handleOpenModal = (type: 'product' | 'category' | 'delete', mode: 'add' | 'edit' = 'add', product: Product | null = null) => {
         if (type === 'product') {
@@ -157,6 +169,7 @@ const Produits: React.FC = () => {
                     mode={modalMode}
                     categories={categories}
                     ingredients={ingredients}
+                    occupiedPositions={occupiedBestSellerPositions}
                 />
             )}
             {isCategoryModalOpen && canEdit && (
@@ -231,8 +244,20 @@ const ProductCard: React.FC<{ product: Product; category?: Category; onEdit: () 
 };
 
 
-const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSuccess: () => void; product: Product | null; mode: 'add' | 'edit'; categories: Category[]; ingredients: Ingredient[]; }> = ({ isOpen, onClose, onSuccess, product, mode, categories, ingredients }) => {
-    const [formData, setFormData] = useState({
+type ProductFormState = {
+    nom_produit: string;
+    prix_vente: number;
+    categoria_id: string;
+    estado: Product['estado'];
+    image: string;
+    description: string;
+    recipe: RecipeItem[];
+    is_best_seller: boolean;
+    best_seller_rank: number | null;
+};
+
+const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSuccess: () => void; product: Product | null; mode: 'add' | 'edit'; categories: Category[]; ingredients: Ingredient[]; occupiedPositions: Map<number, Product>; }> = ({ isOpen, onClose, onSuccess, product, mode, categories, ingredients, occupiedPositions }) => {
+    const [formData, setFormData] = useState<ProductFormState>({
         nom_produit: product?.nom_produit || '',
         prix_vente: product?.prix_vente || 0,
         categoria_id: product?.categoria_id || (categories[0]?.id ?? ''),
@@ -240,9 +265,39 @@ const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSu
         image: product?.image ?? '',
         description: product?.description || '',
         recipe: product?.recipe || [],
+        is_best_seller: product?.is_best_seller ?? false,
+        best_seller_rank: product?.best_seller_rank ?? null,
     });
     const [imageFile, setImageFile] = useState<File | null>(null);
     const [isSubmitting, setSubmitting] = useState(false);
+
+    const findFirstAvailablePosition = useCallback(() => {
+        for (const rank of BEST_SELLER_RANKS) {
+            const occupant = occupiedPositions.get(rank);
+            if (!occupant || occupant.id === product?.id) {
+                return rank;
+            }
+        }
+        return null;
+    }, [occupiedPositions, product?.id]);
+
+    const handleBestSellerToggle = useCallback(
+        (checked: boolean) => {
+            setFormData(prev => {
+                if (checked) {
+                    const nextRank = prev.best_seller_rank ?? findFirstAvailablePosition();
+                    return { ...prev, is_best_seller: true, best_seller_rank: nextRank ?? null };
+                }
+                return { ...prev, is_best_seller: false, best_seller_rank: null };
+            });
+        },
+        [findFirstAvailablePosition],
+    );
+
+    const handleBestSellerRankChange = useCallback((event: React.ChangeEvent<HTMLSelectElement>) => {
+        const value = event.target.value;
+        setFormData(prev => ({ ...prev, best_seller_rank: value ? Number(value) : null }));
+    }, []);
 
     const ingredientMap = useMemo(() => new Map(ingredients.map(ing => [ing.id, ing])), [ingredients]);
 
@@ -286,6 +341,17 @@ const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSu
             alert("Veuillez ajouter au moins un ingrédient à la recette.");
             return;
         }
+        if (formData.is_best_seller) {
+            if (formData.best_seller_rank == null) {
+                alert('Veuillez sélectionner une position de best seller disponible.');
+                return;
+            }
+            const occupant = occupiedPositions.get(formData.best_seller_rank);
+            if (occupant && occupant.id !== product?.id) {
+                alert(`La position ${formData.best_seller_rank} est déjà occupée par ${occupant.nom_produit}.`);
+                return;
+            }
+        }
         setSubmitting(true);
         try {
             let imageUrl = formData.image?.trim() ?? '';
@@ -293,7 +359,12 @@ const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSu
                 imageUrl = await uploadProductImage(imageFile, formData.nom_produit);
             }
 
-            const finalData = { ...formData, image: imageUrl };
+            const finalData = {
+                ...formData,
+                image: imageUrl,
+                is_best_seller: formData.is_best_seller,
+                best_seller_rank: formData.is_best_seller ? formData.best_seller_rank : null,
+            };
 
             if (mode === 'edit' && product) {
                 await api.updateProduct(product.id, finalData);
@@ -338,6 +409,46 @@ const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSu
                                 <option value="agotado_temporal">Rupture (Temp.)</option>
                                 <option value="agotado_indefinido">Indisponible</option>
                             </select>
+                        </div>
+                        <div className="sm:col-span-2 flex items-center gap-2 pt-2">
+                            <input
+                                id="best-seller-toggle"
+                                type="checkbox"
+                                checked={formData.is_best_seller}
+                                onChange={event => handleBestSellerToggle(event.target.checked)}
+                                className="h-4 w-4 rounded border-gray-300 text-brand-primary focus:ring-brand-primary"
+                            />
+                            <label htmlFor="best-seller-toggle" className="text-sm font-medium text-gray-700">Best seller</label>
+                        </div>
+                        <div className="sm:col-span-2">
+                            <label className="block text-sm font-medium text-gray-700" htmlFor="best-seller-rank">Position dans le classement</label>
+                            <select
+                                id="best-seller-rank"
+                                value={formData.best_seller_rank ?? ''}
+                                onChange={handleBestSellerRankChange}
+                                disabled={!formData.is_best_seller}
+                                className="mt-1 ui-select"
+                            >
+                                <option value="">Sélectionner une position</option>
+                                {BEST_SELLER_RANKS.map(rank => {
+                                    const occupant = occupiedPositions.get(rank);
+                                    const isCurrentProduct = occupant?.id === product?.id;
+                                    const isDisabled = Boolean(occupant && !isCurrentProduct);
+                                    const label = occupant
+                                        ? isCurrentProduct
+                                            ? `${rank} – Position actuelle`
+                                            : `${rank} – Occupé par ${occupant.nom_produit}`
+                                        : `${rank}`;
+                                    return (
+                                        <option key={rank} value={rank} disabled={isDisabled}>
+                                            {label}
+                                        </option>
+                                    );
+                                })}
+                            </select>
+                            {formData.is_best_seller && formData.best_seller_rank === null && (
+                                <p className="mt-1 text-xs text-red-600">Sélectionnez une position disponible pour ce best seller.</p>
+                            )}
                         </div>
                     </div>
 

--- a/services/api.ts
+++ b/services/api.ts
@@ -65,6 +65,8 @@ type SupabaseProductRow = {
   categoria_id: string;
   estado: Product['estado'];
   image: string | null;
+  is_best_seller: boolean | null;
+  best_seller_rank: number | null;
   product_recipes: SupabaseRecipeRow[] | null;
 };
 
@@ -372,6 +374,8 @@ const mapProductRow = (row: SupabaseProductRow, ingredientMap?: Map<string, Ingr
     estado: row.estado,
     image: resolveProductImageUrl(row.image),
     recipe,
+    is_best_seller: Boolean(row.is_best_seller),
+    best_seller_rank: row.best_seller_rank,
   };
 
   if (ingredientMap) {
@@ -611,8 +615,10 @@ const selectOrdersQuery = () =>
     )
     .order('date_creation', { ascending: false });
 
-const selectProductsQuery = () =>
-  supabase
+const selectProductsQuery = (
+  options?: { orderBy?: { column: string; ascending?: boolean; nullsFirst?: boolean } },
+) => {
+  let query = supabase
     .from('products')
     .select(
       `
@@ -623,13 +629,26 @@ const selectProductsQuery = () =>
         categoria_id,
         estado,
         image,
+        is_best_seller,
+        best_seller_rank,
         product_recipes (
           ingredient_id,
           qte_utilisee
         )
       `,
-    )
-    .order('nom_produit');
+    );
+
+  if (options?.orderBy) {
+    query = query.order(options.orderBy.column, {
+      ascending: options.orderBy.ascending ?? true,
+      nullsFirst: options.orderBy.nullsFirst,
+    });
+  } else {
+    query = query.order('nom_produit');
+  }
+
+  return query;
+};
 
 const fetchOrderById = async (orderId: string): Promise<Order | null> => {
   const response = await selectOrdersQuery().eq('id', orderId).maybeSingle();
@@ -1172,50 +1191,25 @@ export const api = {
     return rows.map(row => mapProductRow(row, ingredientMap));
   },
 
-  getTopSellingProducts: async (): Promise<Product[]> => {
-    const targetCategories = ['Tacos', 'Quesadillas', 'Entradas'];
-    const salesResponse = await supabase
-      .from('sales')
-      .select('product_id, product_name, category_name, total_price, quantity');
-    const salesRows = unwrap<{
-      product_id: string;
-      product_name: string;
-      category_name: string;
-      total_price: number;
-      quantity: number;
-    }[]>(salesResponse as SupabaseResponse<{
-      product_id: string;
-      product_name: string;
-      category_name: string;
-      total_price: number;
-      quantity: number;
-    }[]>);
+  getBestSellerProducts: async (): Promise<Product[]> => {
+    const [productsResponse, ingredients] = await Promise.all([
+      selectProductsQuery({ orderBy: { column: 'best_seller_rank', ascending: true, nullsFirst: false } })
+        .eq('is_best_seller', true)
+        .limit(6),
+      fetchIngredients(),
+    ]);
 
-    const filtered = salesRows.filter(row => targetCategories.includes(row.category_name));
-    const aggregated = new Map<string, { quantity: number }>();
-
-    filtered.forEach(row => {
-      const current = aggregated.get(row.product_id) ?? { quantity: 0 };
-      current.quantity += row.quantity;
-      aggregated.set(row.product_id, current);
-    });
-
-    const topIds = Array.from(aggregated.entries())
-      .sort((a, b) => b[1].quantity - a[1].quantity)
-      .slice(0, 6)
-      .map(([productId]) => productId);
-
-    if (topIds.length === 0) {
-      return [];
-    }
-
-    const productsResponse = await selectProductsQuery().in('id', topIds);
     const productRows = unwrap<SupabaseProductRow[]>(productsResponse as SupabaseResponse<SupabaseProductRow[]>);
-    const ingredients = await fetchIngredients();
     const ingredientMap = new Map(ingredients.map(ingredient => [ingredient.id, ingredient]));
 
     return productRows
       .filter(row => row.estado !== 'archive')
+      .sort((a, b) => {
+        const rankA = a.best_seller_rank ?? Number.POSITIVE_INFINITY;
+        const rankB = b.best_seller_rank ?? Number.POSITIVE_INFINITY;
+        return rankA - rankB;
+      })
+      .slice(0, 6)
       .map(row => mapProductRow(row, ingredientMap));
   },
 
@@ -1916,7 +1910,8 @@ export const api = {
         categoria_id: product.categoria_id,
         estado: product.estado,
         image: normalizeCloudinaryImageUrl(product.image),
-
+        is_best_seller: product.is_best_seller,
+        best_seller_rank: product.is_best_seller ? product.best_seller_rank : null,
       })
       .select('id')
       .single();
@@ -1967,7 +1962,17 @@ export const api = {
 
     if (rest.image !== undefined) {
       updatePayload.image = normalizeCloudinaryImageUrl(rest.image);
+    }
 
+    if (rest.best_seller_rank !== undefined) {
+      updatePayload.best_seller_rank = rest.best_seller_rank;
+    }
+
+    if (rest.is_best_seller !== undefined) {
+      updatePayload.is_best_seller = rest.is_best_seller;
+      if (!rest.is_best_seller) {
+        updatePayload.best_seller_rank = null;
+      }
     }
 
     if (Object.keys(updatePayload).length > 0) {

--- a/types/index.ts
+++ b/types/index.ts
@@ -79,6 +79,8 @@ export interface Product {
   image: string; // URL from Cloud Storage
   recipe: RecipeItem[];
   cout_revient?: number;
+  is_best_seller: boolean;
+  best_seller_rank: number | null;
 }
 
 export interface Category {


### PR DESCRIPTION
## Summary
- extend product types and Supabase mapping to carry best seller flags and rankings
- replace the top-selling query with a best seller fetcher that reuses the unified product selector
- expose best seller assignments in the product modal and update the login page preview to use the new data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dab92186cc832a93615d6e8dc1e866