### PR TITLE
Handle ingredient permission errors for public ordering flow

### DIFF
--- a/pages/CommandeClient.tsx
+++ b/pages/CommandeClient.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../services/api';
 import { uploadPaymentReceipt } from '../services/cloudinary';
-import { Product, Category, Ingredient, OrderItem, Order } from '../types';
+import { Product, Category, OrderItem, Order } from '../types';
 import Modal from '../components/Modal';
 import { ArrowLeft, ShoppingCart, Plus, Minus, X, Upload, MessageCircle, CheckCircle, History } from 'lucide-react';
 import CustomerOrderTracker from '../components/CustomerOrderTracker';
@@ -19,7 +19,6 @@ interface ItemCustomizationModalProps {
   onAddToCart: (item: OrderItem) => void;
   product: Product;
   item?: OrderItem;
-  ingredients: Ingredient[];
 }
 
 const ItemCustomizationModal: React.FC<ItemCustomizationModalProps> = ({ isOpen, onClose, onAddToCart, product, item }) => {
@@ -115,7 +114,6 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({ isOpen, onClose, 
 const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({ onOrderSubmitted }) => {
     const [products, setProducts] = useState<Product[]>([]);
     const [categories, setCategories] = useState<Category[]>([]);
-    const [ingredients, setIngredients] = useState<Ingredient[]>([]);
     const [activeCategoryId, setActiveCategoryId] = useState<string>('all');
     const [cart, setCart] = useState<OrderItem[]>([]);
     const [isModalOpen, setModalOpen] = useState(false);
@@ -142,14 +140,12 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
     const fetchData = useCallback(async () => {
         try {
             setLoading(true);
-            const [productsData, categoriesData, ingredientsData] = await Promise.all([
+            const [productsData, categoriesData] = await Promise.all([
                 api.getProducts(),
                 api.getCategories(),
-                api.getIngredients()
             ]);
             setProducts(productsData);
             setCategories(categoriesData);
-            setIngredients(ingredientsData);
         } catch (err) {
             setError('Impossible de charger le menu. Veuillez réessayer plus tard.');
             console.error(err);
@@ -408,7 +404,6 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                     onAddToCart={handleAddToCart}
                     product={selectedProduct.product}
                     item={selectedProduct.item}
-                    ingredients={ingredients}
                 />
             )}
             

--- a/services/api.ts
+++ b/services/api.ts
@@ -665,6 +665,43 @@ const fetchIngredients = async (): Promise<Ingredient[]> => {
   return rows.map(mapIngredientRow);
 };
 
+const isPermissionError = (error: unknown): boolean => {
+  if (!error) {
+    return false;
+  }
+
+  if (typeof error === 'string') {
+    return error.toLowerCase().includes('permission');
+  }
+
+  if (error instanceof Error) {
+    return error.message.toLowerCase().includes('permission');
+  }
+
+  if (typeof error === 'object' && 'message' in error) {
+    const message = String((error as { message?: unknown }).message ?? '');
+    return message.toLowerCase().includes('permission');
+  }
+
+  return false;
+};
+
+const fetchIngredientsOrWarn = async (context: string): Promise<Ingredient[]> => {
+  try {
+    return await fetchIngredients();
+  } catch (error) {
+    if (isPermissionError(error)) {
+      console.warn(
+        `[api.${context}] Impossible de récupérer les ingrédients (permissions insuffisantes). Poursuite avec une liste vide.`,
+        error,
+      );
+      return [];
+    }
+
+    throw error;
+  }
+};
+
 const fetchCategories = async (): Promise<Category[]> => {
   const response = await supabase
     .from('categories')
@@ -1184,10 +1221,12 @@ export const api = {
   getProducts: async (): Promise<Product[]> => {
     const [productRows, ingredients] = await Promise.all([
       selectProductsQuery().neq('estado', 'archive'),
-      fetchIngredients(),
+      fetchIngredientsOrWarn('getProducts'),
     ]);
     const rows = unwrap<SupabaseProductRow[]>(productRows as SupabaseResponse<SupabaseProductRow[]>);
-    const ingredientMap = new Map(ingredients.map(ingredient => [ingredient.id, ingredient]));
+    const ingredientMap = ingredients.length > 0
+      ? new Map(ingredients.map(ingredient => [ingredient.id, ingredient]))
+      : undefined;
     return rows.map(row => mapProductRow(row, ingredientMap));
   },
 
@@ -1196,11 +1235,13 @@ export const api = {
       selectProductsQuery({ orderBy: { column: 'best_seller_rank', ascending: true, nullsFirst: false } })
         .eq('is_best_seller', true)
         .limit(6),
-      fetchIngredients(),
+      fetchIngredientsOrWarn('getBestSellerProducts'),
     ]);
 
     const productRows = unwrap<SupabaseProductRow[]>(productsResponse as SupabaseResponse<SupabaseProductRow[]>);
-    const ingredientMap = new Map(ingredients.map(ingredient => [ingredient.id, ingredient]));
+    const ingredientMap = ingredients.length > 0
+      ? new Map(ingredients.map(ingredient => [ingredient.id, ingredient]))
+      : undefined;
 
     return productRows
       .filter(row => row.estado !== 'archive')


### PR DESCRIPTION
## Summary
- simplify the customer order page by only fetching products and categories and removing the unused ingredient state/prop
- guard product fetches so ingredient permission errors log a warning and still return products with empty ingredient data

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dac0ff91c0832a8eb2a1f8bb9452f1