### PR TITLE
Fix best seller display and layout handling

### DIFF
--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -109,6 +109,24 @@ const PinInput = React.forwardRef<HTMLInputElement, PinInputProps>(({ pin, onPin
 
 PinInput.displayName = 'PinInput';
 
+const computeMenuGridClassName = (count: number): string => {
+  if (count === 1) return 'menu-grid menu-grid--single';
+  if (count === 2) return 'menu-grid menu-grid--double';
+  if (count === 3) return 'menu-grid menu-grid--triple';
+  if (count >= 6) return 'menu-grid menu-grid--six';
+  if (count > 0) return 'menu-grid menu-grid--multi';
+  return 'menu-grid';
+};
+
+const computeMenuCardClassName = (count: number): string => {
+  const baseClass = 'ui-card menu-card';
+  if (count === 1) return `${baseClass} menu-card--single`;
+  if (count === 2) return `${baseClass} menu-card--double`;
+  if (count === 3) return `${baseClass} menu-card--triple`;
+  if (count >= 6) return `${baseClass} menu-card--compact`;
+  return baseClass;
+};
+
 
 const Login: React.FC = () => {
   const [isModalOpen, setIsModalOpen] = useState(false);
@@ -128,6 +146,10 @@ const Login: React.FC = () => {
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [activeOrder, setActiveOrder] = useState(() => getActiveCustomerOrder());
   const activeOrderId = activeOrder?.orderId ?? null;
+  const bestSellersToDisplay = bestSellers.slice(0, 6);
+  const bestSellerCount = bestSellersToDisplay.length;
+  const menuGridClassName = computeMenuGridClassName(bestSellerCount);
+  const menuCardClassName = computeMenuCardClassName(bestSellerCount);
 
   const submitPin = useCallback(async (pinToSubmit: string) => {
     if (loading) return;
@@ -321,9 +343,9 @@ const Login: React.FC = () => {
             {menuLoading ? (
               <p className="section-text section-text--muted">{menuContent.loadingLabel}</p>
             ) : (
-              <div className="menu-grid">
-                {bestSellers.slice(0, 6).map(product => (
-                  <article key={product.id} className="ui-card menu-card">
+              <div className={menuGridClassName}>
+                {bestSellersToDisplay.map(product => (
+                  <article key={product.id} className={menuCardClassName}>
                     <img src={product.image} alt={product.nom_produit} className="menu-card__media" />
                     <div className="menu-card__body">
                       <h3 className="menu-card__title">{product.nom_produit}</h3>

--- a/pages/Produits.tsx
+++ b/pages/Produits.tsx
@@ -204,7 +204,14 @@ const ProductCard: React.FC<{ product: Product; category?: Category; onEdit: () 
 
     return (
         <div className="ui-card flex flex-col overflow-hidden">
-            <img src={product.image} alt={product.nom_produit} className="w-full h-40 object-cover" />
+            <div className="relative">
+                <img src={product.image} alt={product.nom_produit} className="w-full h-40 object-cover" />
+                {product.is_best_seller && (
+                    <span className="absolute top-2 left-2 rounded-full bg-brand-primary/90 px-3 py-1 text-xs font-semibold uppercase tracking-wide text-white shadow-md">
+                        Best seller{product.best_seller_rank ? ` #${product.best_seller_rank}` : ''}
+                    </span>
+                )}
+            </div>
             <div className="p-4 flex flex-col flex-grow">
                 <div className="flex justify-between items-start">
                     <div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -288,6 +288,84 @@ body {
   grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
+.menu-grid--single {
+  grid-template-columns: minmax(320px, 520px);
+  justify-content: center;
+  justify-items: center;
+}
+
+.menu-card--single {
+  max-width: 520px;
+}
+
+.menu-card--single .menu-card__media {
+  height: clamp(260px, 50vw, 360px);
+}
+
+.menu-card--single .menu-card__body {
+  padding: clamp(1.75rem, 4vw, 2.25rem);
+}
+
+.menu-card--single .menu-card__title {
+  font-size: clamp(1.75rem, 4vw, 2.5rem);
+}
+
+.menu-card--single .menu-card__price {
+  font-size: clamp(1.5rem, 3.5vw, 2.25rem);
+}
+
+.menu-grid--double {
+  grid-template-columns: repeat(2, minmax(260px, 360px));
+  justify-content: center;
+  justify-items: center;
+}
+
+.menu-card--double {
+  max-width: 360px;
+  width: 100%;
+}
+
+.menu-card--double .menu-card__media {
+  height: clamp(220px, 35vw, 280px);
+}
+
+.menu-grid--triple {
+  grid-template-columns: repeat(3, minmax(240px, 1fr));
+}
+
+.menu-card--triple .menu-card__media {
+  height: clamp(200px, 28vw, 240px);
+}
+
+.menu-grid--six {
+  grid-template-columns: repeat(auto-fill, minmax(220px, 1fr));
+}
+
+@media (min-width: 1024px) {
+  .menu-grid--six {
+    grid-template-columns: repeat(3, minmax(220px, 1fr));
+  }
+}
+
+.menu-card--compact .menu-card__media {
+  height: 200px;
+}
+
+.menu-grid--multi {
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+}
+
+@media (max-width: 640px) {
+  .menu-grid--single,
+  .menu-grid--double {
+    grid-template-columns: minmax(0, 1fr);
+  }
+
+  .menu-grid--triple {
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+  }
+}
+
 .menu-card {
   display: flex;
   flex-direction: column;


### PR DESCRIPTION
## Summary
- show a persistent best seller badge and rank on product cards
- compute menu grid classes on the customer page so flagged best sellers render in the hero menu
- extend the shared styles to adapt the best seller section for 1, 2, 3, or 6 items

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dad85aabf8832ab193c8116b537b43