### PR TITLE
Fix customer scroll and best seller handling

### DIFF
--- a/pages/CommandeClient.tsx
+++ b/pages/CommandeClient.tsx
@@ -129,6 +129,10 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
     const [hasProcessedQueuedReorder, setHasProcessedQueuedReorder] = useState(false);
 
     useEffect(() => {
+        window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+    }, []);
+
+    useEffect(() => {
         try {
             const historyJSON = localStorage.getItem('customer-order-history');
             if (historyJSON) {

--- a/pages/Produits.tsx
+++ b/pages/Produits.tsx
@@ -278,6 +278,23 @@ const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSu
     const [imageFile, setImageFile] = useState<File | null>(null);
     const [isSubmitting, setSubmitting] = useState(false);
 
+    useEffect(() => {
+        if (!isOpen) return;
+
+        setFormData({
+            nom_produit: product?.nom_produit || '',
+            prix_vente: product?.prix_vente || 0,
+            categoria_id: product?.categoria_id || (categories[0]?.id ?? ''),
+            estado: product?.estado || 'disponible',
+            image: product?.image ?? '',
+            description: product?.description || '',
+            recipe: product?.recipe || [],
+            is_best_seller: product?.is_best_seller ?? false,
+            best_seller_rank: product?.best_seller_rank ?? null,
+        });
+        setImageFile(null);
+    }, [isOpen, product, categories]);
+
     const findFirstAvailablePosition = useCallback(() => {
         for (const rank of BEST_SELLER_RANKS) {
             const occupant = occupiedPositions.get(rank);

--- a/services/api.ts
+++ b/services/api.ts
@@ -618,13 +618,22 @@ const selectOrdersQuery = () =>
 type SelectProductsQueryOptions = {
   orderBy?: { column: string; ascending?: boolean; nullsFirst?: boolean };
   includeBestSellerColumns?: boolean;
+  includeRecipes?: boolean;
 };
 
-const buildProductSelectColumns = (includeBestSellerColumns: boolean): string => {
+const buildProductSelectColumns = (includeBestSellerColumns: boolean, includeRecipes: boolean): string => {
   const bestSellerColumns = includeBestSellerColumns
     ? `,
         is_best_seller,
         best_seller_rank`
+    : '';
+
+  const recipeColumns = includeRecipes
+    ? `,
+        product_recipes (
+          ingredient_id,
+          qte_utilisee
+        )`
     : '';
 
   return `
@@ -634,17 +643,16 @@ const buildProductSelectColumns = (includeBestSellerColumns: boolean): string =>
         prix_vente,
         categoria_id,
         estado,
-        image${bestSellerColumns},
-        product_recipes (
-          ingredient_id,
-          qte_utilisee
-        )
+        image${bestSellerColumns}${recipeColumns}
       `;
 };
 
 const selectProductsQuery = (options?: SelectProductsQueryOptions) => {
   const includeBestSellerColumns = options?.includeBestSellerColumns !== false;
-  let query = supabase.from('products').select(buildProductSelectColumns(includeBestSellerColumns));
+  const includeRecipes = options?.includeRecipes !== false;
+  let query = supabase
+    .from('products')
+    .select(buildProductSelectColumns(includeBestSellerColumns, includeRecipes));
 
   if (options?.orderBy) {
     query = query.order(options.orderBy.column, {
@@ -1284,7 +1292,7 @@ export const api = {
         }
 
         return query.eq('is_best_seller', true).order('best_seller_rank', { ascending: true, nullsFirst: false }).limit(6);
-      }),
+      }, { includeRecipes: false }),
       fetchIngredientsOrWarn('getBestSellerProducts'),
     ]);
 


### PR DESCRIPTION
## Summary
- ensure the client ordering page scrolls to the top each time it opens so previous orders are visible immediately
- reset the product form when the modal opens so the best seller flag persists across edits
- allow best seller queries to skip recipe data, preventing permission errors and restoring the public menu preview

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dadfd7ea6c832aa55d76c6e610a76f