### PR TITLE
Ensure Supabase update errors are surfaced

### DIFF
--- a/pages/Produits.tsx
+++ b/pages/Produits.tsx
@@ -104,6 +104,8 @@ const Produits: React.FC = () => {
             fetchData();
         } catch (error) {
             console.error("Failed to update status", error);
+            const message = error instanceof Error ? error.message : "Une erreur inconnue s'est produite.";
+            alert(`Échec de la mise à jour du statut du produit : ${message}`);
         }
     }
 

--- a/services/api.ts
+++ b/services/api.ts
@@ -2078,19 +2078,22 @@ export const api = {
     }
 
     if (Object.keys(updatePayload).length > 0) {
-      await supabase.from('products').update(updatePayload).eq('id', productId);
+      const updateResponse = await supabase.from('products').update(updatePayload).eq('id', productId);
+      unwrap(updateResponse as SupabaseResponse<unknown>);
     }
 
     if (recipe) {
-      await supabase.from('product_recipes').delete().eq('product_id', productId);
+      const deleteRecipeResponse = await supabase.from('product_recipes').delete().eq('product_id', productId);
+      unwrap(deleteRecipeResponse as SupabaseResponse<unknown>);
       if (recipe.length > 0) {
-        await supabase.from('product_recipes').insert(
+        const insertRecipeResponse = await supabase.from('product_recipes').insert(
           recipe.map(item => ({
             product_id: productId,
             ingredient_id: item.ingredient_id,
             qte_utilisee: item.qte_utilisee,
           })),
         );
+        unwrap(insertRecipeResponse as SupabaseResponse<unknown>);
       }
     }
 


### PR DESCRIPTION
## Summary
- unwrap Supabase update and recipe mutations in `updateProduct` to surface database errors immediately
- guard product recipe delete/insert calls against ignored Supabase failures
- notify users about failures when updating product status in the Produits page

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_b_68dae841b214832a9ded3ee0194c2647