### PR TITLE
Add order item snapshot comparison utility and tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite",
     "build": "vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@supabase/supabase-js": "^2.47.12",
@@ -23,6 +24,7 @@
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.16",
     "typescript": "~5.8.2",
-    "vite": "^6.2.0"
+    "vite": "^6.2.0",
+    "vitest": "^2.1.5"
   }
 }

--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState, useCallback, useMemo, useRef } from 'react';
+import type { MutableRefObject } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { api } from '../services/api';
 import { uploadPaymentReceipt } from '../services/cloudinary';
@@ -7,6 +8,7 @@ import { PlusCircle, MinusCircle, Send, DollarSign, AlertTriangle, Check, ArrowL
 import { formatIntegerAmount } from '../utils/formatIntegerAmount';
 import PaymentModal from '../components/PaymentModal';
 import Modal from '../components/Modal';
+import { createOrderItemsSnapshot, areOrderItemSnapshotsEqual, type OrderItemsSnapshot } from '../utils/orderSync';
 
 const isPersistedItemId = (value?: string) =>
     !!value && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
@@ -38,6 +40,13 @@ const haveSameExcludedIngredients = (a: string[] = [], b: string[] = []) => {
     return sortedA.every((value, index) => value === sortedB[index]);
 };
 
+type OrderItemsSnapshotCache = {
+    source: OrderItem[];
+    snapshot: OrderItemsSnapshot;
+};
+
+const EMPTY_ORDER_ITEMS_SNAPSHOT = createOrderItemsSnapshot([]);
+
 const Commande: React.FC = () => {
     const { tableId } = useParams<{ tableId: string }>();
     const navigate = useNavigate();
@@ -60,6 +69,40 @@ const Commande: React.FC = () => {
     const pendingServerOrderRef = useRef<Order | null>(null);
     const itemsSyncTimeoutRef = useRef<number | null>(null);
     const syncQueueRef = useRef<Promise<void>>(Promise.resolve());
+    const currentItemsSnapshotCacheRef = useRef<OrderItemsSnapshotCache | null>(null);
+    const originalItemsSnapshotCacheRef = useRef<OrderItemsSnapshotCache | null>(null);
+
+    const updateSnapshotCache = (
+        cacheRef: MutableRefObject<OrderItemsSnapshotCache | null>,
+        items: OrderItem[] | undefined,
+        snapshot?: OrderItemsSnapshot,
+    ): OrderItemsSnapshot => {
+        if (!items || items.length === 0) {
+            cacheRef.current = null;
+            return EMPTY_ORDER_ITEMS_SNAPSHOT;
+        }
+
+        const computedSnapshot = snapshot ?? createOrderItemsSnapshot(items);
+        cacheRef.current = { source: items, snapshot: computedSnapshot };
+        return computedSnapshot;
+    };
+
+    const getCachedSnapshot = (
+        items: OrderItem[] | undefined,
+        cacheRef: MutableRefObject<OrderItemsSnapshotCache | null>,
+    ): OrderItemsSnapshot => {
+        if (!items || items.length === 0) {
+            cacheRef.current = null;
+            return EMPTY_ORDER_ITEMS_SNAPSHOT;
+        }
+
+        const cachedSnapshot = cacheRef.current;
+        if (cachedSnapshot && cachedSnapshot.source === items) {
+            return cachedSnapshot.snapshot;
+        }
+
+        return updateSnapshotCache(cacheRef, items);
+    };
 
     useEffect(() => {
         orderRef.current = order;
@@ -71,31 +114,50 @@ const Commande: React.FC = () => {
 
     const isOrderSynced = useCallback((comparisonOrder?: Order | null) => {
         const currentOrder = orderRef.current;
-        if (!currentOrder) return true;
+        if (!currentOrder) {
+            return true;
+        }
+
         const referenceOrder = comparisonOrder ?? originalOrderRef.current;
-        if (!referenceOrder) return true;
-        return JSON.stringify(referenceOrder.items) === JSON.stringify(currentOrder.items);
+        if (!referenceOrder) {
+            return true;
+        }
+
+        const currentSnapshot = getCachedSnapshot(currentOrder.items, currentItemsSnapshotCacheRef);
+        const referenceSnapshot = comparisonOrder
+            ? createOrderItemsSnapshot(referenceOrder.items)
+            : getCachedSnapshot(referenceOrder.items, originalItemsSnapshotCacheRef);
+
+        return areOrderItemSnapshotsEqual(referenceSnapshot, currentSnapshot);
     }, []);
 
     const applyPendingServerSnapshot = useCallback(() => {
         const pendingOrder = pendingServerOrderRef.current;
-        if (!pendingOrder) return;
+        if (!pendingOrder) {
+            return;
+        }
 
+        const pendingItemsSnapshot = createOrderItemsSnapshot(pendingOrder.items);
         serverOrderRef.current = cloneOrder(pendingOrder);
 
         const currentOrder = orderRef.current;
-        if (currentOrder && JSON.stringify(currentOrder) === JSON.stringify(pendingOrder)) {
-            pendingServerOrderRef.current = null;
-            return;
+        if (currentOrder) {
+            const currentSnapshot = getCachedSnapshot(currentOrder.items, currentItemsSnapshotCacheRef);
+            if (areOrderItemSnapshotsEqual(currentSnapshot, pendingItemsSnapshot)) {
+                pendingServerOrderRef.current = null;
+                return;
+            }
         }
 
         pendingServerOrderRef.current = null;
         orderRef.current = pendingOrder;
         setOrder(pendingOrder);
+        updateSnapshotCache(currentItemsSnapshotCacheRef, pendingOrder.items, pendingItemsSnapshot);
 
         const originalSnapshot = cloneOrder(pendingOrder);
         originalOrderRef.current = originalSnapshot;
         setOriginalOrder(originalSnapshot);
+        updateSnapshotCache(originalItemsSnapshotCacheRef, originalSnapshot.items);
     }, []);
 
     const fetchOrderData = useCallback(async (isRefresh = false) => {
@@ -113,10 +175,12 @@ const Commande: React.FC = () => {
                     pendingServerOrderRef.current = null;
                     setOrder(orderData);
                     orderRef.current = orderData;
+                    updateSnapshotCache(currentItemsSnapshotCacheRef, orderData.items);
 
                     const originalSnapshot = cloneOrder(orderData);
                     originalOrderRef.current = originalSnapshot;
                     setOriginalOrder(originalSnapshot);
+                    updateSnapshotCache(originalItemsSnapshotCacheRef, originalSnapshot.items);
                 } else {
                     const confirmedOrder = originalOrderRef.current;
                     if (confirmedOrder && JSON.stringify(confirmedOrder) === JSON.stringify(orderData)) {
@@ -137,9 +201,11 @@ const Commande: React.FC = () => {
             serverOrderRef.current = cloneOrder(orderData);
             setOrder(orderData);
             orderRef.current = orderData;
+            updateSnapshotCache(currentItemsSnapshotCacheRef, orderData.items);
             const originalSnapshot = cloneOrder(orderData);
             setOriginalOrder(originalSnapshot);
             originalOrderRef.current = originalSnapshot;
+            updateSnapshotCache(originalItemsSnapshotCacheRef, originalSnapshot.items);
             setProducts(productsData);
             setCategories(categoriesData);
             setIngredients(ingredientsData);
@@ -231,6 +297,7 @@ const Commande: React.FC = () => {
 
         setOrder(optimisticOrder);
         orderRef.current = optimisticOrder;
+        updateSnapshotCache(currentItemsSnapshotCacheRef, optimisticOrder.items);
 
         if (options?.isLocalUpdate) return;
 
@@ -270,9 +337,11 @@ const Commande: React.FC = () => {
                 );
                 setOrder(updatedOrder);
                 orderRef.current = updatedOrder;
+                updateSnapshotCache(currentItemsSnapshotCacheRef, updatedOrder.items);
                 const updatedOriginalSnapshot = cloneOrder(updatedOrder);
                 setOriginalOrder(updatedOriginalSnapshot);
                 originalOrderRef.current = updatedOriginalSnapshot;
+                updateSnapshotCache(originalItemsSnapshotCacheRef, updatedOriginalSnapshot.items);
                 serverOrderRef.current = cloneOrder(updatedOrder);
 
                 void api.getIngredients()
@@ -430,7 +499,12 @@ const Commande: React.FC = () => {
 
             const updatedOrder = await api.sendOrderToKitchen(latestOrder.id, itemsToSend);
             setOrder(updatedOrder);
-            setOriginalOrder(JSON.parse(JSON.stringify(updatedOrder)));
+            orderRef.current = updatedOrder;
+            updateSnapshotCache(currentItemsSnapshotCacheRef, updatedOrder.items);
+            const syncedOriginal = cloneOrder(updatedOrder);
+            setOriginalOrder(syncedOriginal);
+            originalOrderRef.current = syncedOriginal;
+            updateSnapshotCache(originalItemsSnapshotCacheRef, syncedOriginal.items);
             navigate('/ventes');
         } catch (error) {
             console.error("Failed to send order to kitchen", error);
@@ -445,6 +519,8 @@ const Commande: React.FC = () => {
         try {
             const updatedOrder = await api.markOrderAsServed(order.id);
             setOrder(updatedOrder);
+            orderRef.current = updatedOrder;
+            updateSnapshotCache(currentItemsSnapshotCacheRef, updatedOrder.items);
         } catch (error) {
             console.error("Failed to mark order as served", error);
         }

--- a/stubs/orderSync.test.ts
+++ b/stubs/orderSync.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from 'vitest';
+import { areOrderItemArraysEqual } from '../utils/orderSync';
+import type { OrderItem } from '../types';
+
+const createItem = (overrides: Partial<OrderItem> = {}): OrderItem => ({
+    id: 'item-1',
+    produitRef: 'product-1',
+    nom_produit: 'Produit 1',
+    prix_unitaire: 500,
+    quantite: 1,
+    excluded_ingredients: [],
+    commentaire: '',
+    estado: 'en_attente',
+    ...overrides,
+});
+
+describe('areOrderItemArraysEqual', () => {
+    it('returns false when an item is added', () => {
+        const baseItems = [createItem()];
+        const withExtraItem = [...baseItems, createItem({ id: 'item-2' })];
+
+        expect(areOrderItemArraysEqual(baseItems, withExtraItem)).toBe(false);
+    });
+
+    it('returns false when a quantity differs', () => {
+        const baseItems = [createItem()];
+        const updatedItems = [createItem({ quantite: 2 })];
+
+        expect(areOrderItemArraysEqual(baseItems, updatedItems)).toBe(false);
+    });
+
+    it('returns false when a comment differs', () => {
+        const baseItems = [createItem()];
+        const updatedItems = [createItem({ commentaire: 'Sans oignons' })];
+
+        expect(areOrderItemArraysEqual(baseItems, updatedItems)).toBe(false);
+    });
+
+    it('ignores excluded ingredient order', () => {
+        const baseItems = [createItem({ excluded_ingredients: ['a', 'b'] })];
+        const shuffled = [createItem({ excluded_ingredients: ['b', 'a'] })];
+
+        expect(areOrderItemArraysEqual(baseItems, shuffled)).toBe(true);
+    });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,7 +11,8 @@
     ],
     "skipLibCheck": true,
     "types": [
-      "node"
+      "node",
+      "vitest"
     ],
     "moduleResolution": "bundler",
     "isolatedModules": true,

--- a/utils/orderSync.ts
+++ b/utils/orderSync.ts
@@ -1,0 +1,85 @@
+import type { OrderItem } from '../types';
+
+export interface OrderItemsSnapshotEntry {
+    quantite: number;
+    commentaire: string;
+    excludedIngredients: string[];
+}
+
+export interface OrderItemsSnapshot {
+    size: number;
+    itemsById: Map<string, OrderItemsSnapshotEntry>;
+}
+
+const normalizeComment = (value?: string | null) => value ?? '';
+
+const normalizeExcludedIngredients = (values?: string[] | null) => {
+    if (!values || values.length === 0) {
+        return [] as string[];
+    }
+
+    const normalized = values.slice().sort();
+    return normalized;
+};
+
+export const createOrderItemsSnapshot = (items: OrderItem[] = []): OrderItemsSnapshot => {
+    const itemsById = new Map<string, OrderItemsSnapshotEntry>();
+
+    for (const item of items) {
+        itemsById.set(item.id, {
+            quantite: item.quantite,
+            commentaire: normalizeComment(item.commentaire),
+            excludedIngredients: normalizeExcludedIngredients(item.excluded_ingredients),
+        });
+    }
+
+    return { size: items.length, itemsById };
+};
+
+export const areOrderItemSnapshotsEqual = (a: OrderItemsSnapshot, b: OrderItemsSnapshot): boolean => {
+    if (a === b) {
+        return true;
+    }
+
+    if (a.size !== b.size) {
+        return false;
+    }
+
+    for (const [id, leftItem] of a.itemsById) {
+        const rightItem = b.itemsById.get(id);
+        if (!rightItem) {
+            return false;
+        }
+
+        if (leftItem.quantite !== rightItem.quantite) {
+            return false;
+        }
+
+        if (leftItem.commentaire !== rightItem.commentaire) {
+            return false;
+        }
+
+        if (leftItem.excludedIngredients.length !== rightItem.excludedIngredients.length) {
+            return false;
+        }
+
+        for (let index = 0; index < leftItem.excludedIngredients.length; index += 1) {
+            if (leftItem.excludedIngredients[index] !== rightItem.excludedIngredients[index]) {
+                return false;
+            }
+        }
+    }
+
+    return true;
+};
+
+export const areOrderItemArraysEqual = (left: OrderItem[] = [], right: OrderItem[] = []): boolean => {
+    if (left === right) {
+        return true;
+    }
+
+    const leftSnapshot = createOrderItemsSnapshot(left);
+    const rightSnapshot = createOrderItemsSnapshot(right);
+
+    return areOrderItemSnapshotsEqual(leftSnapshot, rightSnapshot);
+};


### PR DESCRIPTION
## Summary
- add an order item snapshot utility to compare cart contents by ID, quantity, comment, and exclusions
- refactor Commande synchronization logic to reuse cached snapshots instead of JSON serialization
- add targeted tests for the new comparison helper and wire up a Vitest test script

## Testing
- npm run build
- npm run test *(fails: Vitest is unavailable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_b_68daef90d468832a9ddd62a9f950fa8e