### PR TITLE
Extract order summary component

### DIFF
--- a/components/commande/OrderSummary.tsx
+++ b/components/commande/OrderSummary.tsx
@@ -1,0 +1,174 @@
+import React from 'react';
+import { Check, DollarSign, MessageSquare, MinusCircle, PlusCircle, Send } from 'lucide-react';
+import type { Order, OrderItem } from '../../types';
+import { formatIntegerAmount } from '../../utils/formatIntegerAmount';
+
+export type CategorizedOrderItems = {
+    pending: { item: OrderItem; index: number }[];
+    sent: { item: OrderItem; index: number }[];
+};
+
+export interface OrderSummaryProps {
+    categorizedItems: CategorizedOrderItems;
+    total: number;
+    onQuantityChange: (itemIndex: number, change: number) => void;
+    onCommentChange: (itemIndex: number, newComment: string) => void;
+    onPersistComment: (itemIndex: number) => void;
+    onStartEditingComment: (itemId: string) => void;
+    onSendToKitchen: () => void | Promise<void>;
+    onServeOrder: () => void | Promise<void>;
+    onOpenPayment: () => void;
+    isSending: boolean;
+    hasPending: boolean;
+    orderStatus: Order['estado_cocina'];
+    editingCommentId: string | null;
+}
+
+const OrderSummary: React.FC<OrderSummaryProps> = ({
+    categorizedItems,
+    total,
+    onQuantityChange,
+    onCommentChange,
+    onPersistComment,
+    onStartEditingComment,
+    onSendToKitchen,
+    onServeOrder,
+    onOpenPayment,
+    isSending,
+    hasPending,
+    orderStatus,
+    editingCommentId,
+}) => {
+    const totalItemsCount = categorizedItems.pending.length + categorizedItems.sent.length;
+
+    return (
+        <div className="ui-card flex flex-col">
+            <div className="p-4 border-b">
+                <h2 className="text-2xl font-semibold text-brand-secondary">Commande</h2>
+            </div>
+            <div className="flex-1 p-4 space-y-3 overflow-y-auto">
+                {totalItemsCount === 0 ? (
+                    <p className="text-gray-500">La commande est vide.</p>
+                ) : (
+                    <>
+                        <div className="space-y-3">
+                            <div className="flex items-center justify-between">
+                                <h3 className="text-lg font-semibold text-brand-secondary">Articles à envoyer</h3>
+                                <span className="text-sm text-gray-500">{categorizedItems.pending.length}</span>
+                            </div>
+                            {categorizedItems.pending.length === 0 ? (
+                                <p className="text-sm text-gray-500">Aucun article en attente.</p>
+                            ) : (
+                                categorizedItems.pending.map(({ item, index }) => (
+                                    <div key={item.id} className="p-3 rounded-lg bg-yellow-100">
+                                        <div className="flex justify-between items-start">
+                                            <p className="font-bold text-gray-900 flex-1">
+                                                {item.quantite}x {item.nom_produit}
+                                            </p>
+                                            <p className="font-bold text-gray-900">
+                                                {formatIntegerAmount(item.quantite * item.prix_unitaire)}€
+                                            </p>
+                                        </div>
+                                        <div className="flex justify-between items-center mt-2">
+                                            <p className="text-sm text-gray-700">
+                                                {formatIntegerAmount(item.prix_unitaire)} € /u
+                                            </p>
+                                            <div className="flex items-center space-x-2 text-gray-800">
+                                                <button onClick={() => onQuantityChange(index, -1)} className="p-1">
+                                                    <MinusCircle size={20} />
+                                                </button>
+                                                <span className="font-bold w-6 text-center">{item.quantite}</span>
+                                                <button onClick={() => onQuantityChange(index, 1)} className="p-1">
+                                                    <PlusCircle size={20} />
+                                                </button>
+                                            </div>
+                                        </div>
+                                        {editingCommentId === item.id || item.commentaire ? (
+                                            <input
+                                                type="text"
+                                                placeholder="Ajouter un commentaire..."
+                                                value={item.commentaire ?? ''}
+                                                onChange={(event) => onCommentChange(index, event.target.value)}
+                                                onBlur={() => onPersistComment(index)}
+                                                autoFocus={editingCommentId === item.id}
+                                                className="mt-2 ui-input text-sm"
+                                            />
+                                        ) : (
+                                            <button
+                                                onClick={() => onStartEditingComment(item.id)}
+                                                className="mt-2 text-xs text-blue-600 hover:underline flex items-center gap-1"
+                                            >
+                                                <MessageSquare size={12} /> Ajouter un commentaire
+                                            </button>
+                                        )}
+                                    </div>
+                                ))
+                            )}
+                        </div>
+
+                        {categorizedItems.sent.length > 0 && (
+                            <div className="space-y-3 pt-6 border-t border-gray-700">
+                                <div className="flex items-center justify-between">
+                                    <h3 className="text-lg font-semibold text-brand-secondary">Envoyés en cuisine</h3>
+                                    <span className="text-sm text-gray-500">{categorizedItems.sent.length}</span>
+                                </div>
+                                {categorizedItems.sent.map(({ item }) => (
+                                    <div key={item.id} className="p-3 rounded-lg bg-green-100">
+                                        <div className="flex justify-between items-start">
+                                            <p className="font-bold text-gray-900 flex-1">
+                                                {item.quantite}x {item.nom_produit}
+                                            </p>
+                                            <p className="font-bold text-gray-900">
+                                                {formatIntegerAmount(item.quantite * item.prix_unitaire)}€
+                                            </p>
+                                        </div>
+                                        <p className="text-sm text-gray-700 mt-2">
+                                            {formatIntegerAmount(item.prix_unitaire)} € /u
+                                        </p>
+                                        {item.commentaire && (
+                                            <p className="mt-2 text-sm italic text-gray-600 pl-2">"{item.commentaire}"</p>
+                                        )}
+                                    </div>
+                                ))}
+                            </div>
+                        )}
+                    </>
+                )}
+            </div>
+            <div className="p-4 border-t space-y-4">
+                <div className="flex justify-between text-2xl font-semibold text-brand-secondary">
+                    <span>Total</span>
+                    <span>{formatIntegerAmount(total)} €</span>
+                </div>
+
+                {orderStatus === 'listo' && (
+                    <button onClick={onServeOrder} className="w-full ui-btn-info justify-center py-3">
+                        <Check size={20} />
+                        <span>Entregada</span>
+                    </button>
+                )}
+
+                <div className="flex space-x-2">
+                    <button
+                        onClick={onSendToKitchen}
+                        disabled={isSending || !hasPending}
+                        className="flex-1 ui-btn-accent justify-center py-3 disabled:opacity-60"
+                    >
+                        <Send size={20} />
+                        <span>{isSending ? 'Synchronisation…' : 'Envoyer en Cuisine'}</span>
+                    </button>
+                    <button
+                        onClick={onOpenPayment}
+                        disabled={orderStatus !== 'servido'}
+                        className="flex-1 ui-btn-success justify-center py-3 disabled:opacity-60"
+                    >
+                        <DollarSign size={20} />
+                        <span>Finaliser</span>
+                    </button>
+                </div>
+            </div>
+        </div>
+    );
+};
+
+export default OrderSummary;

--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -4,12 +4,12 @@ import { useParams, useNavigate } from 'react-router-dom';
 import { api } from '../services/api';
 import { uploadPaymentReceipt } from '../services/cloudinary';
 import { Order, Product, Category, OrderItem, Ingredient } from '../types';
-import { PlusCircle, MinusCircle, Send, DollarSign, Check, ArrowLeft, MessageSquare } from 'lucide-react';
-import { formatIntegerAmount } from '../utils/formatIntegerAmount';
+import { ArrowLeft } from 'lucide-react';
 import PaymentModal from '../components/PaymentModal';
 import Modal from '../components/Modal';
 import { createOrderItemsSnapshot, areOrderItemSnapshotsEqual, type OrderItemsSnapshot } from '../utils/orderSync';
 import ProductGrid from '../components/commande/ProductGrid';
+import OrderSummary from '../components/commande/OrderSummary';
 
 const isPersistedItemId = (value?: string) =>
     !!value && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
@@ -595,6 +595,14 @@ const Commande: React.FC = () => {
         }
     }, [addProductToOrder]);
 
+    const handleOpenPaymentModal = useCallback(() => {
+        setIsPaymentModalOpen(true);
+    }, []);
+
+    const startEditingComment = useCallback((itemId: string) => {
+        setEditingCommentId(itemId);
+    }, []);
+
     const hasPendingItems = categorizedItems.pending.length > 0;
 
     if (loading) return <div className="text-center p-10 text-gray-800">Chargement de la commande...</div>;
@@ -632,107 +640,21 @@ const Commande: React.FC = () => {
             </div>
 
             {/* Order Summary Section */}
-            <div className="ui-card flex flex-col">
-                <div className="p-4 border-b">
-                    <h2 className="text-2xl font-semibold text-brand-secondary">Commande</h2>
-                </div>
-                <div className="flex-1 p-4 space-y-3 overflow-y-auto">
-                    {order.items.length === 0 ? (
-                        <p className="text-gray-500">La commande est vide.</p>
-                    ) : (
-                        <>
-                            <div className="space-y-3">
-                                <div className="flex items-center justify-between">
-                                    <h3 className="text-lg font-semibold text-brand-secondary">Articles à envoyer</h3>
-                                    <span className="text-sm text-gray-500">{categorizedItems.pending.length}</span>
-                                </div>
-                                {categorizedItems.pending.length === 0 ? (
-                                    <p className="text-sm text-gray-500">Aucun article en attente.</p>
-                                ) : (
-                                    categorizedItems.pending.map(({ item, index }) => (
-                                        <div key={item.id} className="p-3 rounded-lg bg-yellow-100">
-                                            <div className="flex justify-between items-start">
-                                                <p className="font-bold text-gray-900 flex-1">{item.quantite}x {item.nom_produit}</p>
-                                                <p className="font-bold text-gray-900">{formatIntegerAmount(item.quantite * item.prix_unitaire)}€</p>
-                                            </div>
-                                            <div className="flex justify-between items-center mt-2">
-                                                <p className="text-sm text-gray-700">{formatIntegerAmount(item.prix_unitaire)} € /u</p>
-                                                <div className="flex items-center space-x-2 text-gray-800">
-                                                    <button onClick={() => handleQuantityChange(index, -1)} className="p-1"><MinusCircle size={20} /></button>
-                                                    <span className="font-bold w-6 text-center">{item.quantite}</span>
-                                                    <button onClick={() => handleQuantityChange(index, 1)} className="p-1"><PlusCircle size={20} /></button>
-                                                </div>
-                                            </div>
-                                            {(editingCommentId === item.id || item.commentaire) ? (
-                                                <input
-                                                    type="text"
-                                                    placeholder="Ajouter un commentaire..."
-                                                    value={item.commentaire}
-                                                    onChange={(e) => handleCommentChange(index, e.target.value)}
-                                                    onBlur={() => persistCommentChange(index)}
-                                                    autoFocus={editingCommentId === item.id}
-                                                    className="mt-2 ui-input text-sm"
-                                                />
-                                            ) : (
-                                                <button onClick={() => setEditingCommentId(item.id)} className="mt-2 text-xs text-blue-600 hover:underline flex items-center gap-1">
-                                                    <MessageSquare size={12}/> Ajouter un commentaire
-                                                </button>
-                                            )}
-                                        </div>
-                                    ))
-                                )}
-                            </div>
-
-                            {categorizedItems.sent.length > 0 && (
-                                <div className="space-y-3 pt-6 border-t border-gray-700">
-                                    <div className="flex items-center justify-between">
-                                        <h3 className="text-lg font-semibold text-brand-secondary">Envoyés en cuisine</h3>
-                                        <span className="text-sm text-gray-500">{categorizedItems.sent.length}</span>
-                                    </div>
-                                    {categorizedItems.sent.map(({ item }) => (
-                                        <div key={item.id} className="p-3 rounded-lg bg-green-100">
-                                            <div className="flex justify-between items-start">
-                                                <p className="font-bold text-gray-900 flex-1">{item.quantite}x {item.nom_produit}</p>
-                                                <p className="font-bold text-gray-900">{formatIntegerAmount(item.quantite * item.prix_unitaire)}€</p>
-                                            </div>
-                                            <p className="text-sm text-gray-700 mt-2">{formatIntegerAmount(item.prix_unitaire)} € /u</p>
-                                            {item.commentaire && (
-                                                <p className="mt-2 text-sm italic text-gray-600 pl-2">"{item.commentaire}"</p>
-                                            )}
-                                        </div>
-                                    ))}
-                                </div>
-                            )}
-                        </>
-                    )}
-                </div>
-                <div className="p-4 border-t space-y-4">
-                    <div className="flex justify-between text-2xl font-semibold text-brand-secondary">
-                        <span>Total</span>
-                        <span>{formatIntegerAmount(order.total)} €</span>
-                    </div>
-
-                    {order.estado_cocina === 'listo' && (
-                        <button onClick={handleServeOrder} className="w-full ui-btn-info justify-center py-3">
-                            <Check size={20} /><span>Entregada</span>
-                        </button>
-                    )}
-
-                    <div className="flex space-x-2">
-                        <button onClick={handleSendToKitchen}
-                            disabled={isSendingToKitchen || !hasPendingItems}
-                            className="flex-1 ui-btn-accent justify-center py-3 disabled:opacity-60">
-                            <Send size={20} />
-                            <span>{isSendingToKitchen ? 'Synchronisation…' : 'Envoyer en Cuisine'}</span>
-                        </button>
-                        <button onClick={() => setIsPaymentModalOpen(true)}
-                                disabled={order.estado_cocina !== 'servido'}
-                                className="flex-1 ui-btn-success justify-center py-3 disabled:opacity-60">
-                            <DollarSign size={20} /><span>Finaliser</span>
-                        </button>
-                    </div>
-                </div>
-            </div>
+            <OrderSummary
+                categorizedItems={categorizedItems}
+                total={order.total}
+                onQuantityChange={handleQuantityChange}
+                onCommentChange={handleCommentChange}
+                onPersistComment={persistCommentChange}
+                onStartEditingComment={startEditingComment}
+                onSendToKitchen={handleSendToKitchen}
+                onServeOrder={handleServeOrder}
+                onOpenPayment={handleOpenPaymentModal}
+                isSending={isSendingToKitchen}
+                hasPending={hasPendingItems}
+                orderStatus={order.estado_cocina}
+                editingCommentId={editingCommentId}
+            />
         </div>
         <PaymentModal 
             isOpen={isPaymentModalOpen}


### PR DESCRIPTION
## Summary
- extract the order summary UI into a dedicated `OrderSummary` component
- wire the `Commande` page to pass the necessary data and callbacks to the new component

## Testing
- npm run test *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_b_68daf735e2b4832a90f3a67bb0c76c6f