### PR TITLE
Add customization modal for table orders

### DIFF
--- a/components/commande/ItemCustomizationModal.tsx
+++ b/components/commande/ItemCustomizationModal.tsx
@@ -1,0 +1,110 @@
+import React, { useEffect, useState } from 'react';
+import { Minus, Plus } from 'lucide-react';
+import Modal from '../Modal';
+import type { Product } from '../../types';
+import { formatIntegerAmount } from '../../utils/formatIntegerAmount';
+
+export interface ItemCustomizationResult {
+    quantity: number;
+    comment: string;
+}
+
+export interface ItemCustomizationModalProps {
+    isOpen: boolean;
+    product: Product | null;
+    onClose: () => void;
+    onSave: (result: ItemCustomizationResult) => void;
+}
+
+const ItemCustomizationModal: React.FC<ItemCustomizationModalProps> = ({
+    isOpen,
+    product,
+    onClose,
+    onSave,
+}) => {
+    const [quantity, setQuantity] = useState(1);
+    const [comment, setComment] = useState('');
+
+    useEffect(() => {
+        if (!isOpen) {
+            return;
+        }
+
+        setQuantity(1);
+        setComment('');
+    }, [isOpen, product?.id]);
+
+    if (!product) {
+        return null;
+    }
+
+    const handleDecrease = () => {
+        setQuantity(prev => Math.max(1, prev - 1));
+    };
+
+    const handleIncrease = () => {
+        setQuantity(prev => prev + 1);
+    };
+
+    const handleSave = () => {
+        onSave({
+            quantity,
+            comment,
+        });
+    };
+
+    return (
+        <Modal isOpen={isOpen} onClose={onClose} title={product.nom_produit}>
+            <div className="space-y-4">
+                <img
+                    src={product.image}
+                    alt={product.nom_produit}
+                    className="w-full h-48 object-cover rounded-lg"
+                />
+                {product.description && (
+                    <p className="text-gray-200 text-sm">{product.description}</p>
+                )}
+                <div>
+                    <label className="block text-sm font-medium text-gray-200">Commentaire</label>
+                    <textarea
+                        value={comment}
+                        onChange={(event) => setComment(event.target.value)}
+                        rows={2}
+                        className="mt-1 block w-full rounded-md border border-gray-600 bg-gray-900/60 py-2 px-3 text-sm text-gray-100 focus:border-brand-primary focus:outline-none focus:ring-2 focus:ring-brand-primary"
+                        placeholder="Allergies, instructions spécifiques…"
+                    />
+                </div>
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                        <button
+                            type="button"
+                            onClick={handleDecrease}
+                            className="p-2 rounded-full bg-gray-800 text-gray-100 hover:bg-gray-700"
+                            aria-label="Diminuer la quantité"
+                        >
+                            <Minus size={18} />
+                        </button>
+                        <span className="w-8 text-center text-lg font-bold text-gray-100">{quantity}</span>
+                        <button
+                            type="button"
+                            onClick={handleIncrease}
+                            className="p-2 rounded-full bg-gray-800 text-gray-100 hover:bg-gray-700"
+                            aria-label="Augmenter la quantité"
+                        >
+                            <Plus size={18} />
+                        </button>
+                    </div>
+                    <button
+                        type="button"
+                        onClick={handleSave}
+                        className="rounded-lg bg-brand-primary py-2 px-6 font-semibold text-brand-secondary transition hover:bg-yellow-400"
+                    >
+                        Ajouter ({formatIntegerAmount(product.prix_vente * quantity)} €)
+                    </button>
+                </div>
+            </div>
+        </Modal>
+    );
+};
+
+export default ItemCustomizationModal;

--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -10,6 +10,7 @@ import Modal from '../components/Modal';
 import { createOrderItemsSnapshot, areOrderItemSnapshotsEqual, type OrderItemsSnapshot } from '../utils/orderSync';
 import ProductGrid from '../components/commande/ProductGrid';
 import OrderSummary from '../components/commande/OrderSummary';
+import ItemCustomizationModal, { type ItemCustomizationResult } from '../components/commande/ItemCustomizationModal';
 
 const isPersistedItemId = (value?: string) =>
     !!value && /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(value);
@@ -41,6 +42,49 @@ const haveSameExcludedIngredients = (a: string[] = [], b: string[] = []) => {
     return sortedA.every((value, index) => value === sortedB[index]);
 };
 
+export const mergeProductIntoPendingItems = (
+    items: OrderItem[],
+    product: Product,
+    result: ItemCustomizationResult,
+    generateId: () => string,
+    defaultExcludedIngredients: string[] = [],
+): OrderItem[] => {
+    const trimmedComment = normalizeComment(result.comment);
+    const sanitizedQuantity = Number.isFinite(result.quantity)
+        ? Math.max(1, Math.floor(result.quantity))
+        : 1;
+
+    if (!trimmedComment) {
+        const existingIndex = items.findIndex(
+            item => item.produitRef === product.id
+                && item.estado === 'en_attente'
+                && normalizeComment(item.commentaire) === ''
+                && haveSameExcludedIngredients(item.excluded_ingredients ?? [], defaultExcludedIngredients),
+        );
+
+        if (existingIndex > -1) {
+            return items.map((item, index) => (
+                index === existingIndex
+                    ? { ...item, quantite: item.quantite + sanitizedQuantity }
+                    : item
+            ));
+        }
+    }
+
+    const newItem: OrderItem = {
+        id: generateId(),
+        produitRef: product.id,
+        nom_produit: product.nom_produit,
+        prix_unitaire: product.prix_vente,
+        quantite: sanitizedQuantity,
+        excluded_ingredients: [...defaultExcludedIngredients],
+        commentaire: trimmedComment,
+        estado: 'en_attente',
+    };
+
+    return [...items, newItem];
+};
+
 type OrderItemsSnapshotCache = {
     source: OrderItem[];
     snapshot: OrderItemsSnapshot;
@@ -63,6 +107,7 @@ const Commande: React.FC = () => {
     const [isExitConfirmOpen, setExitConfirmOpen] = useState(false);
     const [editingCommentId, setEditingCommentId] = useState<string | null>(null);
     const [isSendingToKitchen, setIsSendingToKitchen] = useState(false);
+    const [selectedProductForCustomization, setSelectedProductForCustomization] = useState<Product | null>(null);
 
     const orderRef = useRef<Order | null>(order);
     const originalOrderRef = useRef<Order | null>(originalOrder);
@@ -398,40 +443,24 @@ const Commande: React.FC = () => {
         scheduleItemsSync();
     }, [scheduleItemsSync, updateOrderItems]);
 
-    const addProductToOrder = useCallback((product: Product) => {
-        const defaultComment = normalizeComment('');
-        const defaultExcludedIngredients: string[] = [];
+    const handleProductSelection = useCallback((product: Product) => {
+        setSelectedProductForCustomization(product);
+    }, []);
 
-        applyLocalItemsUpdate(items => {
-            const existingItemIndex = items.findIndex(
-                item => item.produitRef === product.id
-                    && item.estado === 'en_attente'
-                    && normalizeComment(item.commentaire) === defaultComment
-                    && haveSameExcludedIngredients(item.excluded_ingredients ?? [], defaultExcludedIngredients)
-            );
+    const closeCustomizationModal = useCallback(() => {
+        setSelectedProductForCustomization(null);
+    }, []);
 
-            if (existingItemIndex > -1) {
-                return items.map((item, index) => (
-                    index === existingItemIndex
-                        ? { ...item, quantite: item.quantite + 1 }
-                        : item
-                ));
-            }
+    const handleSaveCustomizedProduct = useCallback((result: ItemCustomizationResult) => {
+        if (!selectedProductForCustomization) {
+            return;
+        }
 
-            const newItem: OrderItem = {
-                id: generateTempId(),
-                produitRef: product.id,
-                nom_produit: product.nom_produit,
-                prix_unitaire: product.prix_vente,
-                quantite: 1,
-                excluded_ingredients: [...defaultExcludedIngredients],
-                commentaire: defaultComment,
-                estado: 'en_attente',
-            };
-
-            return [...items, newItem];
-        });
-    }, [applyLocalItemsUpdate]);
+        applyLocalItemsUpdate(items =>
+            mergeProductIntoPendingItems(items, selectedProductForCustomization, result, generateTempId),
+        );
+        setSelectedProductForCustomization(null);
+    }, [applyLocalItemsUpdate, selectedProductForCustomization]);
 
     const handleQuantityChange = useCallback((itemIndex: number, change: number) => {
         applyLocalItemsUpdate(items => {
@@ -602,9 +631,9 @@ const Commande: React.FC = () => {
     const handleProductKeyDown = useCallback((product: Product) => (event: React.KeyboardEvent<HTMLButtonElement>) => {
         if (event.key === 'Enter' || event.key === ' ') {
             event.preventDefault();
-            addProductToOrder(product);
+            handleProductSelection(product);
         }
-    }, [addProductToOrder]);
+    }, [handleProductSelection]);
 
     const handleOpenPaymentModal = useCallback(() => {
         setIsPaymentModalOpen(true);
@@ -640,7 +669,7 @@ const Commande: React.FC = () => {
                 <ProductGrid
                     filteredProducts={filteredProducts}
                     quantities={productQuantitiesInCart}
-                    onAdd={addProductToOrder}
+                    onAdd={handleProductSelection}
                     activeCategoryId={activeCategoryId}
                     categories={categories}
                     onSelectCategory={setActiveCategoryId}
@@ -667,7 +696,13 @@ const Commande: React.FC = () => {
                 editingCommentId={editingCommentId}
             />
         </div>
-        <PaymentModal 
+        <ItemCustomizationModal
+            isOpen={selectedProductForCustomization !== null}
+            product={selectedProductForCustomization}
+            onClose={closeCustomizationModal}
+            onSave={handleSaveCustomizedProduct}
+        />
+        <PaymentModal
             isOpen={isPaymentModalOpen}
             onClose={() => setIsPaymentModalOpen(false)}
             order={order}

--- a/stubs/orderItemCustomization.test.ts
+++ b/stubs/orderItemCustomization.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest';
+import { mergeProductIntoPendingItems } from '../pages/Commande';
+import type { OrderItem, Product } from '../types';
+import type { ItemCustomizationResult } from '../components/commande/ItemCustomizationModal';
+
+const createProduct = (overrides: Partial<Product> = {}): Product => ({
+    id: 'product-1',
+    nom_produit: 'Produit 1',
+    description: 'Délicieux',
+    prix_vente: 500,
+    categoria_id: 'cat-1',
+    estado: 'disponible',
+    image: 'image.jpg',
+    recipe: [],
+    is_best_seller: false,
+    best_seller_rank: null,
+    ...overrides,
+});
+
+const createItem = (overrides: Partial<OrderItem> = {}): OrderItem => ({
+    id: 'item-1',
+    produitRef: 'product-1',
+    nom_produit: 'Produit 1',
+    prix_unitaire: 500,
+    quantite: 1,
+    excluded_ingredients: [],
+    commentaire: '',
+    estado: 'en_attente',
+    ...overrides,
+});
+
+const createResult = (overrides: Partial<ItemCustomizationResult> = {}): ItemCustomizationResult => ({
+    quantity: 1,
+    comment: '',
+    ...overrides,
+});
+
+describe('mergeProductIntoPendingItems', () => {
+    it('increments quantity when the comment is blank', () => {
+        const product = createProduct();
+        const items = [createItem()];
+        const result = mergeProductIntoPendingItems(items, product, createResult({ quantity: 2 }), () => 'generated-1');
+
+        expect(result).toHaveLength(1);
+        expect(result[0].quantite).toBe(3);
+    });
+
+    it('adds a separate line when a comment is provided', () => {
+        const product = createProduct();
+        const items = [createItem()];
+        const updated = mergeProductIntoPendingItems(
+            items,
+            product,
+            createResult({ quantity: 2, comment: 'Sans oignons' }),
+            () => 'generated-2',
+        );
+
+        expect(updated).toHaveLength(2);
+        expect(updated[1].id).toBe('generated-2');
+        expect(updated[1].quantite).toBe(2);
+        expect(updated[1].commentaire).toBe('Sans oignons');
+        expect(updated[0].quantite).toBe(1);
+    });
+
+    it('trims comments before saving them', () => {
+        const product = createProduct();
+        const items: OrderItem[] = [];
+        const updated = mergeProductIntoPendingItems(
+            items,
+            product,
+            createResult({ quantity: 1, comment: '  Extra sauce  ' }),
+            () => 'generated-3',
+        );
+
+        expect(updated).toHaveLength(1);
+        expect(updated[0].commentaire).toBe('Extra sauce');
+    });
+
+    it('does not merge items that already have a comment even if the same comment is provided', () => {
+        const product = createProduct();
+        const items = [createItem({ id: 'item-2', commentaire: 'Sans oignons' })];
+        const updated = mergeProductIntoPendingItems(
+            items,
+            product,
+            createResult({ quantity: 1, comment: 'Sans oignons' }),
+            () => 'generated-4',
+        );
+
+        expect(updated).toHaveLength(2);
+        expect(updated[0].id).toBe('item-2');
+        expect(updated[1].id).toBe('generated-4');
+    });
+
+    it('defaults to a minimum quantity of 1 when an invalid value is provided', () => {
+        const product = createProduct();
+        const items: OrderItem[] = [];
+        const updated = mergeProductIntoPendingItems(
+            items,
+            product,
+            createResult({ quantity: 0 }),
+            () => 'generated-5',
+        );
+
+        expect(updated).toHaveLength(1);
+        expect(updated[0].quantite).toBe(1);
+    });
+});


### PR DESCRIPTION
## Summary
- add an item customization modal for table orders with quantity and comment controls
- update the Commande flow to open the modal on product selection and merge items by comment when saving
- cover the merge helper with unit tests to ensure commented items stay on separate lines in the summary

## Testing
- npm run build
- npx vitest run *(fails: npm registry access is forbidden in this environment)*

------
https://chatgpt.com/codex/tasks/task_b_68dafe6da174832aaab3e1f2418b8d04