### PR TITLE
Add section style customization and apply styles

### DIFF
--- a/components/SitePreviewCanvas.tsx
+++ b/components/SitePreviewCanvas.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { Mail, MapPin, Phone } from 'lucide-react';
 import { SiteContent } from '../types';
+import {
+  createBackgroundStyle,
+  createBodyTextStyle,
+  createHeroBackgroundStyle,
+  createTextStyle,
+} from '../utils/siteStyleHelpers';
 
 export type EditableZoneKey = 'navigation' | 'hero' | 'about' | 'menu' | 'contact' | 'footer';
 
@@ -75,22 +81,51 @@ const placeholderProducts = [
 ];
 
 const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({ content, onEdit }) => {
-  const heroBackgroundStyle = content.hero.backgroundImage
-    ? { backgroundImage: `url('${content.hero.backgroundImage}')` }
-    : undefined;
+  const navigationBackgroundStyle = createBackgroundStyle(content.navigation.style);
+  const navigationTextStyle = createTextStyle(content.navigation.style);
+  const navigationBodyStyle = createBodyTextStyle(content.navigation.style);
+  const heroBackgroundStyle = createHeroBackgroundStyle(content.hero.style, content.hero.backgroundImage);
+  const heroTextStyle = createTextStyle(content.hero.style);
+  const heroBodyTextStyle = createBodyTextStyle(content.hero.style);
+  const aboutBackgroundStyle = createBackgroundStyle(content.about.style);
+  const aboutTextStyle = createTextStyle(content.about.style);
+  const aboutBodyTextStyle = createBodyTextStyle(content.about.style);
+  const menuBackgroundStyle = createBackgroundStyle(content.menu.style);
+  const menuTextStyle = createTextStyle(content.menu.style);
+  const menuBodyTextStyle = createBodyTextStyle(content.menu.style);
+  const contactBackgroundStyle = createBackgroundStyle(content.contact.style);
+  const contactTextStyle = createTextStyle(content.contact.style);
+  const contactBodyTextStyle = createBodyTextStyle(content.contact.style);
+  const footerBackgroundStyle = createBackgroundStyle(content.footer.style);
+  const footerTextStyle = createBodyTextStyle(content.footer.style);
 
   return (
     <div className="space-y-6 rounded-[2.5rem] border border-gray-200 bg-slate-50 p-6 shadow-inner">
       <EditableZoneFrame zone="navigation" label="Navigation" onEdit={onEdit} contentClassName="pt-16">
-        <header className="login-header">
-          <div className="layout-container login-header__inner">
-            <span className="login-brand">{content.navigation.brand}</span>
+        <header className="login-header" style={navigationBackgroundStyle}>
+          <div className="layout-container login-header__inner" style={navigationTextStyle}>
+            <span className="login-brand" style={navigationTextStyle}>
+              {content.navigation.brand}
+            </span>
             <nav className="login-nav" aria-label="Navigation principale">
-              <span className="login-nav__link">{content.navigation.links.home}</span>
-              <span className="login-nav__link">{content.navigation.links.about}</span>
-              <span className="login-nav__link">{content.navigation.links.menu}</span>
-              <span className="login-nav__link">{content.navigation.links.contact}</span>
-              <button type="button" className="ui-btn ui-btn-accent login-nav__cta" disabled>
+              <span className="login-nav__link" style={navigationBodyStyle}>
+                {content.navigation.links.home}
+              </span>
+              <span className="login-nav__link" style={navigationBodyStyle}>
+                {content.navigation.links.about}
+              </span>
+              <span className="login-nav__link" style={navigationBodyStyle}>
+                {content.navigation.links.menu}
+              </span>
+              <span className="login-nav__link" style={navigationBodyStyle}>
+                {content.navigation.links.contact}
+              </span>
+              <button
+                type="button"
+                className="ui-btn ui-btn-accent login-nav__cta"
+                style={{ fontFamily: content.navigation.style.fontFamily }}
+                disabled
+              >
                 {content.navigation.links.loginCta}
               </button>
             </nav>
@@ -99,24 +134,44 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({ content, onEdit }
       </EditableZoneFrame>
 
       <EditableZoneFrame zone="hero" label="Hero" onEdit={onEdit} className="overflow-hidden" contentClassName="pt-14">
-        <section className="section section-hero" style={heroBackgroundStyle}>
+        <section className="section section-hero" style={{ ...heroBackgroundStyle, ...heroTextStyle }}>
           <div className="section-hero__inner">
-            <div className="hero-content">
-              <h2 className="hero-title">{content.hero.title}</h2>
-              <p className="hero-subtitle">{content.hero.subtitle}</p>
-              <button type="button" className="ui-btn ui-btn-accent hero-cta" disabled>
+            <div className="hero-content" style={heroTextStyle}>
+              <h2 className="hero-title" style={heroTextStyle}>
+                {content.hero.title}
+              </h2>
+              <p className="hero-subtitle" style={heroBodyTextStyle}>
+                {content.hero.subtitle}
+              </p>
+              <button
+                type="button"
+                className="ui-btn ui-btn-accent hero-cta"
+                style={{ fontFamily: content.hero.style.fontFamily }}
+                disabled
+              >
                 {content.hero.ctaLabel}
               </button>
               <div className="hero-history mt-6">
-                <p className="hero-history__title">{content.hero.historyTitle}</p>
+                <p className="hero-history__title" style={heroBodyTextStyle}>
+                  {content.hero.historyTitle}
+                </p>
                 <div className="hero-history__list">
                   {[0, 1, 2].map(index => (
                     <div key={index} className="hero-history__item">
                       <div className="hero-history__meta">
-                        <p className="hero-history__date">Commande du 12/03/2024</p>
-                        <p className="hero-history__details">2 article(s) • 32€</p>
+                        <p className="hero-history__date" style={heroBodyTextStyle}>
+                          Commande du 12/03/2024
+                        </p>
+                        <p className="hero-history__details" style={heroBodyTextStyle}>
+                          2 article(s) • 32€
+                        </p>
                       </div>
-                      <button type="button" className="hero-history__cta" disabled>
+                      <button
+                        type="button"
+                        className="hero-history__cta"
+                        style={{ fontFamily: content.hero.style.fontFamily }}
+                        disabled
+                      >
                         {content.hero.reorderCtaLabel}
                       </button>
                     </div>
@@ -129,10 +184,14 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({ content, onEdit }
       </EditableZoneFrame>
 
       <EditableZoneFrame zone="about" label="À propos" onEdit={onEdit} className="overflow-hidden" contentClassName="pt-14">
-        <section className="section section-surface">
-          <div className="section-inner section-inner--center">
-            <h2 className="section-title">{content.about.title}</h2>
-            <p className="section-text section-text--muted">{content.about.description}</p>
+        <section className="section section-surface" style={{ ...aboutBackgroundStyle, ...aboutTextStyle }}>
+          <div className="section-inner section-inner--center" style={aboutTextStyle}>
+            <h2 className="section-title" style={aboutTextStyle}>
+              {content.about.title}
+            </h2>
+            <p className="section-text section-text--muted" style={aboutBodyTextStyle}>
+              {content.about.description}
+            </p>
             {content.about.image && (
               <img
                 src={content.about.image}
@@ -145,9 +204,11 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({ content, onEdit }
       </EditableZoneFrame>
 
       <EditableZoneFrame zone="menu" label="Menu" onEdit={onEdit} className="overflow-hidden" contentClassName="pt-14">
-        <section className="section section-muted">
-          <div className="section-inner section-inner--wide section-inner--center">
-            <h2 className="section-title">{content.menu.title}</h2>
+        <section className="section section-muted" style={{ ...menuBackgroundStyle, ...menuTextStyle }}>
+          <div className="section-inner section-inner--wide section-inner--center" style={menuTextStyle}>
+            <h2 className="section-title" style={menuTextStyle}>
+              {content.menu.title}
+            </h2>
             {content.menu.image && (
               <img
                 src={content.menu.image}
@@ -160,27 +221,42 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({ content, onEdit }
                 <article key={product.id} className="ui-card menu-card">
                   <div className="h-40 w-full rounded-t-xl bg-gradient-to-br from-orange-200 via-amber-100 to-orange-50" />
                   <div className="menu-card__body">
-                    <h3 className="menu-card__title">{product.name}</h3>
-                    <p className="menu-card__description">{product.description}</p>
-                    <p className="menu-card__price">{product.price}</p>
+                    <h3 className="menu-card__title" style={menuTextStyle}>
+                      {product.name}
+                    </h3>
+                    <p className="menu-card__description" style={menuBodyTextStyle}>
+                      {product.description}
+                    </p>
+                    <p className="menu-card__price" style={menuBodyTextStyle}>
+                      {product.price}
+                    </p>
                   </div>
                 </article>
               ))}
             </div>
             <div className="section-actions">
-              <button type="button" className="ui-btn ui-btn-primary hero-cta" disabled>
+              <button
+                type="button"
+                className="ui-btn ui-btn-primary hero-cta"
+                style={{ fontFamily: content.menu.style.fontFamily }}
+                disabled
+              >
                 {content.menu.ctaLabel}
               </button>
-              <p className="section-text section-text--muted">{content.menu.loadingLabel}</p>
+              <p className="section-text section-text--muted" style={menuBodyTextStyle}>
+                {content.menu.loadingLabel}
+              </p>
             </div>
           </div>
         </section>
       </EditableZoneFrame>
 
       <EditableZoneFrame zone="contact" label="Contact" onEdit={onEdit} className="overflow-hidden" contentClassName="pt-14">
-        <section className="section section-surface">
-          <div className="section-inner section-inner--wide section-inner--center">
-            <h2 className="section-title">{content.contact.title}</h2>
+        <section className="section section-surface" style={{ ...contactBackgroundStyle, ...contactTextStyle }}>
+          <div className="section-inner section-inner--wide section-inner--center" style={contactTextStyle}>
+            <h2 className="section-title" style={contactTextStyle}>
+              {content.contact.title}
+            </h2>
             {content.contact.image && (
               <img
                 src={content.contact.image}
@@ -189,20 +265,32 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({ content, onEdit }
               />
             )}
             <div className="contact-grid">
-              <div className="contact-card">
+              <div className="contact-card" style={contactTextStyle}>
                 <MapPin className="contact-card__icon" />
-                <h3 className="contact-card__title">{content.contact.addressLabel}</h3>
-                <p className="contact-card__text">{content.contact.address}</p>
+                <h3 className="contact-card__title" style={contactTextStyle}>
+                  {content.contact.addressLabel}
+                </h3>
+                <p className="contact-card__text" style={contactBodyTextStyle}>
+                  {content.contact.address}
+                </p>
               </div>
-              <div className="contact-card">
+              <div className="contact-card" style={contactTextStyle}>
                 <Phone className="contact-card__icon" />
-                <h3 className="contact-card__title">{content.contact.phoneLabel}</h3>
-                <p className="contact-card__text">{content.contact.phone}</p>
+                <h3 className="contact-card__title" style={contactTextStyle}>
+                  {content.contact.phoneLabel}
+                </h3>
+                <p className="contact-card__text" style={contactBodyTextStyle}>
+                  {content.contact.phone}
+                </p>
               </div>
-              <div className="contact-card">
+              <div className="contact-card" style={contactTextStyle}>
                 <Mail className="contact-card__icon" />
-                <h3 className="contact-card__title">{content.contact.emailLabel}</h3>
-                <p className="contact-card__text">{content.contact.email}</p>
+                <h3 className="contact-card__title" style={contactTextStyle}>
+                  {content.contact.emailLabel}
+                </h3>
+                <p className="contact-card__text" style={contactBodyTextStyle}>
+                  {content.contact.email}
+                </p>
               </div>
             </div>
           </div>
@@ -210,9 +298,9 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({ content, onEdit }
       </EditableZoneFrame>
 
       <EditableZoneFrame zone="footer" label="Pied de page" onEdit={onEdit} contentClassName="pt-14">
-        <footer className="site-footer">
-          <div className="layout-container site-footer__inner">
-            <p>
+        <footer className="site-footer" style={{ ...footerBackgroundStyle, ...footerTextStyle }}>
+          <div className="layout-container site-footer__inner" style={footerTextStyle}>
+            <p style={footerTextStyle}>
               &copy; {new Date().getFullYear()} {content.navigation.brand}. {content.footer.text}
             </p>
           </div>

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -9,6 +9,12 @@ import CustomerOrderTracker from '../components/CustomerOrderTracker';
 import { clearActiveCustomerOrder, getActiveCustomerOrder } from '../services/customerOrderStorage';
 import { formatIntegerAmount } from '../utils/formatIntegerAmount';
 import useSiteContent from '../hooks/useSiteContent';
+import {
+  createBackgroundStyle,
+  createBodyTextStyle,
+  createHeroBackgroundStyle,
+  createTextStyle,
+} from '../utils/siteStyleHelpers';
 
 type PinInputProps = {
   pin: string;
@@ -138,7 +144,23 @@ const Login: React.FC = () => {
   const navigate = useNavigate();
   const { content: siteContent } = useSiteContent();
   const { navigation, hero, about, menu: menuContent, contact, footer } = siteContent;
-  const heroBackgroundStyle = hero.backgroundImage ? { backgroundImage: `url('${hero.backgroundImage}')` } : undefined;
+  const navigationBackgroundStyle = createBackgroundStyle(navigation.style);
+  const navigationTextStyle = createTextStyle(navigation.style);
+  const navigationBodyStyle = createBodyTextStyle(navigation.style);
+  const heroBackgroundStyle = createHeroBackgroundStyle(hero.style, hero.backgroundImage);
+  const heroTextStyle = createTextStyle(hero.style);
+  const heroBodyTextStyle = createBodyTextStyle(hero.style);
+  const aboutBackgroundStyle = createBackgroundStyle(about.style);
+  const aboutTextStyle = createTextStyle(about.style);
+  const aboutBodyTextStyle = createBodyTextStyle(about.style);
+  const menuBackgroundStyle = createBackgroundStyle(menuContent.style);
+  const menuTextStyle = createTextStyle(menuContent.style);
+  const menuBodyTextStyle = createBodyTextStyle(menuContent.style);
+  const contactBackgroundStyle = createBackgroundStyle(contact.style);
+  const contactTextStyle = createTextStyle(contact.style);
+  const contactBodyTextStyle = createBodyTextStyle(contact.style);
+  const footerBackgroundStyle = createBackgroundStyle(footer.style);
+  const footerTextStyle = createBodyTextStyle(footer.style);
 
   const [bestSellers, setBestSellers] = useState<Product[]>([]);
   const [orderHistory, setOrderHistory] = useState<Order[]>([]);
@@ -227,40 +249,80 @@ const Login: React.FC = () => {
 
   return (
     <div className="login-page">
-      <header className="login-header">
-        <div className="layout-container login-header__inner">
-          <a href="#accueil" className="login-brand">{navigation.brand}</a>
+      <header className="login-header" style={navigationBackgroundStyle}>
+        <div className="layout-container login-header__inner" style={navigationTextStyle}>
+          <a href="#accueil" className="login-brand" style={navigationTextStyle}>
+            {navigation.brand}
+          </a>
           <nav className="login-nav" aria-label="Navigation principale">
-            <a href="#accueil" className="login-nav__link">{navigation.links.home}</a>
-            <a href="#apropos" className="login-nav__link">{navigation.links.about}</a>
-            <a href="#menu" className="login-nav__link">{navigation.links.menu}</a>
-            <a href="#contact" className="login-nav__link">{navigation.links.contact}</a>
-            <button type="button" onClick={() => setIsModalOpen(true)} className="ui-btn ui-btn-accent login-nav__cta">
+            <a href="#accueil" className="login-nav__link" style={navigationBodyStyle}>
+              {navigation.links.home}
+            </a>
+            <a href="#apropos" className="login-nav__link" style={navigationBodyStyle}>
+              {navigation.links.about}
+            </a>
+            <a href="#menu" className="login-nav__link" style={navigationBodyStyle}>
+              {navigation.links.menu}
+            </a>
+            <a href="#contact" className="login-nav__link" style={navigationBodyStyle}>
+              {navigation.links.contact}
+            </a>
+            <button
+              type="button"
+              onClick={() => setIsModalOpen(true)}
+              className="ui-btn ui-btn-accent login-nav__cta"
+              style={{ fontFamily: navigation.style.fontFamily }}
+            >
               {navigation.links.loginCta}
             </button>
           </nav>
-          <button type="button" onClick={() => setMobileMenuOpen(true)} className="login-header__menu" aria-label="Ouvrir le menu">
+          <button
+            type="button"
+            onClick={() => setMobileMenuOpen(true)}
+            className="login-header__menu"
+            aria-label="Ouvrir le menu"
+          >
             <Menu size={24} />
           </button>
         </div>
       </header>
 
       {isMobileMenuOpen && (
-        <div className="login-menu-overlay" role="dialog" aria-modal="true">
+        <div className="login-menu-overlay" role="dialog" aria-modal="true" style={navigationBackgroundStyle}>
           <button type="button" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__close" aria-label="Fermer le menu">
             <X size={28} />
           </button>
-          <nav className="login-menu-overlay__nav" aria-label="Navigation mobile">
-            <a href="#accueil" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">
+          <nav className="login-menu-overlay__nav" aria-label="Navigation mobile" style={navigationTextStyle}>
+            <a
+              href="#accueil"
+              onClick={() => setMobileMenuOpen(false)}
+              className="login-menu-overlay__link"
+              style={navigationBodyStyle}
+            >
               {navigation.links.home}
             </a>
-            <a href="#apropos" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">
+            <a
+              href="#apropos"
+              onClick={() => setMobileMenuOpen(false)}
+              className="login-menu-overlay__link"
+              style={navigationBodyStyle}
+            >
               {navigation.links.about}
             </a>
-            <a href="#menu" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">
+            <a
+              href="#menu"
+              onClick={() => setMobileMenuOpen(false)}
+              className="login-menu-overlay__link"
+              style={navigationBodyStyle}
+            >
               {navigation.links.menu}
             </a>
-            <a href="#contact" onClick={() => setMobileMenuOpen(false)} className="login-menu-overlay__link">
+            <a
+              href="#contact"
+              onClick={() => setMobileMenuOpen(false)}
+              className="login-menu-overlay__link"
+              style={navigationBodyStyle}
+            >
               {navigation.links.contact}
             </a>
             <button
@@ -270,6 +332,7 @@ const Login: React.FC = () => {
                 setMobileMenuOpen(false);
               }}
               className="ui-btn ui-btn-accent hero-cta"
+              style={{ fontFamily: navigation.style.fontFamily }}
             >
               {navigation.links.loginCta}
             </button>
@@ -278,31 +341,46 @@ const Login: React.FC = () => {
       )}
 
       <main>
-        <section id="accueil" className="section section-hero" style={heroBackgroundStyle}>
+        <section id="accueil" className="section section-hero" style={{ ...heroBackgroundStyle, ...heroTextStyle }}>
           <div className="section-hero__inner">
             {activeOrderId ? (
               <CustomerOrderTracker orderId={activeOrderId} onNewOrderClick={handleNewOrder} variant="hero" />
             ) : (
-                <div className="hero-content">
-                  <h2 className="hero-title">{hero.title}</h2>
-                  <p className="hero-subtitle">{hero.subtitle}</p>
-                  <button onClick={() => navigate('/commande-client')} className="ui-btn ui-btn-accent hero-cta">
-                    {hero.ctaLabel}
-                  </button>
-                  {orderHistory.length > 0 && (
-                    <div className="hero-history">
-                      <p className="hero-history__title">{hero.historyTitle}</p>
+              <div className="hero-content" style={heroTextStyle}>
+                <h2 className="hero-title" style={heroTextStyle}>
+                  {hero.title}
+                </h2>
+                <p className="hero-subtitle" style={heroBodyTextStyle}>
+                  {hero.subtitle}
+                </p>
+                <button
+                  onClick={() => navigate('/commande-client')}
+                  className="ui-btn ui-btn-accent hero-cta"
+                  style={{ fontFamily: hero.style.fontFamily }}
+                >
+                  {hero.ctaLabel}
+                </button>
+                {orderHistory.length > 0 && (
+                  <div className="hero-history">
+                    <p className="hero-history__title" style={heroBodyTextStyle}>
+                      {hero.historyTitle}
+                    </p>
                     <div className="hero-history__list">
                       {orderHistory.slice(0, 3).map(order => (
                         <div key={order.id} className="hero-history__item">
                           <div className="hero-history__meta">
-                            <p className="hero-history__date">Commande du {new Date(order.date_creation).toLocaleDateString()}</p>
-                            <p className="hero-history__details">{order.items.length} article(s) • {formatIntegerAmount(order.total)}€</p>
+                            <p className="hero-history__date" style={heroBodyTextStyle}>
+                              Commande du {new Date(order.date_creation).toLocaleDateString()}
+                            </p>
+                            <p className="hero-history__details" style={heroBodyTextStyle}>
+                              {order.items.length} article(s) • {formatIntegerAmount(order.total)}€
+                            </p>
                           </div>
                           <button
                             type="button"
                             onClick={() => handleQuickReorder(order.id)}
                             className="hero-history__cta"
+                            style={{ fontFamily: hero.style.fontFamily }}
                           >
                             {hero.reorderCtaLabel}
                           </button>
@@ -316,10 +394,18 @@ const Login: React.FC = () => {
           </div>
         </section>
 
-        <section id="apropos" className="section section-surface">
-          <div className="section-inner section-inner--center">
-            <h2 className="section-title">{about.title}</h2>
-            <p className="section-text section-text--muted">{about.description}</p>
+        <section
+          id="apropos"
+          className="section section-surface"
+          style={{ ...aboutBackgroundStyle, ...aboutTextStyle }}
+        >
+          <div className="section-inner section-inner--center" style={aboutTextStyle}>
+            <h2 className="section-title" style={aboutTextStyle}>
+              {about.title}
+            </h2>
+            <p className="section-text section-text--muted" style={aboutBodyTextStyle}>
+              {about.description}
+            </p>
             {about.image && (
               <img
                 src={about.image}
@@ -330,9 +416,15 @@ const Login: React.FC = () => {
           </div>
         </section>
 
-        <section id="menu" className="section section-muted">
-          <div className="section-inner section-inner--wide section-inner--center">
-            <h2 className="section-title">{menuContent.title}</h2>
+        <section
+          id="menu"
+          className="section section-muted"
+          style={{ ...menuBackgroundStyle, ...menuTextStyle }}
+        >
+          <div className="section-inner section-inner--wide section-inner--center" style={menuTextStyle}>
+            <h2 className="section-title" style={menuTextStyle}>
+              {menuContent.title}
+            </h2>
             {menuContent.image && (
               <img
                 src={menuContent.image}
@@ -341,32 +433,50 @@ const Login: React.FC = () => {
               />
             )}
             {menuLoading ? (
-              <p className="section-text section-text--muted">{menuContent.loadingLabel}</p>
+              <p className="section-text section-text--muted" style={menuBodyTextStyle}>
+                {menuContent.loadingLabel}
+              </p>
             ) : (
               <div className={menuGridClassName}>
                 {bestSellersToDisplay.map(product => (
                   <article key={product.id} className={menuCardClassName}>
                     <img src={product.image} alt={product.nom_produit} className="menu-card__media" />
                     <div className="menu-card__body">
-                      <h3 className="menu-card__title">{product.nom_produit}</h3>
-                      <p className="menu-card__description">{product.description}</p>
-                      <p className="menu-card__price">{formatIntegerAmount(product.prix_vente)} €</p>
+                      <h3 className="menu-card__title" style={menuTextStyle}>
+                        {product.nom_produit}
+                      </h3>
+                      <p className="menu-card__description" style={menuBodyTextStyle}>
+                        {product.description}
+                      </p>
+                      <p className="menu-card__price" style={menuBodyTextStyle}>
+                        {formatIntegerAmount(product.prix_vente)} €
+                      </p>
                     </div>
                   </article>
                 ))}
               </div>
             )}
             <div className="section-actions">
-              <button onClick={() => navigate('/commande-client')} className="ui-btn ui-btn-primary hero-cta">
+              <button
+                onClick={() => navigate('/commande-client')}
+                className="ui-btn ui-btn-primary hero-cta"
+                style={{ fontFamily: menuContent.style.fontFamily }}
+              >
                 {menuContent.ctaLabel}
               </button>
             </div>
           </div>
         </section>
 
-        <section id="contact" className="section section-surface">
-          <div className="section-inner section-inner--wide section-inner--center">
-            <h2 className="section-title">{contact.title}</h2>
+        <section
+          id="contact"
+          className="section section-surface"
+          style={{ ...contactBackgroundStyle, ...contactTextStyle }}
+        >
+          <div className="section-inner section-inner--wide section-inner--center" style={contactTextStyle}>
+            <h2 className="section-title" style={contactTextStyle}>
+              {contact.title}
+            </h2>
             {contact.image && (
               <img
                 src={contact.image}
@@ -375,29 +485,41 @@ const Login: React.FC = () => {
               />
             )}
             <div className="contact-grid">
-              <div className="contact-card">
+              <div className="contact-card" style={contactTextStyle}>
                 <MapPin className="contact-card__icon" />
-                <h3 className="contact-card__title">{contact.addressLabel}</h3>
-                <p className="contact-card__text">{contact.address}</p>
+                <h3 className="contact-card__title" style={contactTextStyle}>
+                  {contact.addressLabel}
+                </h3>
+                <p className="contact-card__text" style={contactBodyTextStyle}>
+                  {contact.address}
+                </p>
               </div>
-              <div className="contact-card">
+              <div className="contact-card" style={contactTextStyle}>
                 <Phone className="contact-card__icon" />
-                <h3 className="contact-card__title">{contact.phoneLabel}</h3>
-                <p className="contact-card__text">{contact.phone}</p>
+                <h3 className="contact-card__title" style={contactTextStyle}>
+                  {contact.phoneLabel}
+                </h3>
+                <p className="contact-card__text" style={contactBodyTextStyle}>
+                  {contact.phone}
+                </p>
               </div>
-              <div className="contact-card">
+              <div className="contact-card" style={contactTextStyle}>
                 <Mail className="contact-card__icon" />
-                <h3 className="contact-card__title">{contact.emailLabel}</h3>
-                <p className="contact-card__text">{contact.email}</p>
+                <h3 className="contact-card__title" style={contactTextStyle}>
+                  {contact.emailLabel}
+                </h3>
+                <p className="contact-card__text" style={contactBodyTextStyle}>
+                  {contact.email}
+                </p>
               </div>
             </div>
           </div>
         </section>
       </main>
 
-      <footer className="site-footer">
-        <div className="layout-container site-footer__inner">
-          <p>
+      <footer className="site-footer" style={{ ...footerBackgroundStyle, ...footerTextStyle }}>
+        <div className="layout-container site-footer__inner" style={footerTextStyle}>
+          <p style={footerTextStyle}>
             &copy; {new Date().getFullYear()} {navigation.brand}. {footer.text}
           </p>
         </div>

--- a/pages/SiteCustomization.tsx
+++ b/pages/SiteCustomization.tsx
@@ -1,18 +1,45 @@
 import React, { useEffect, useMemo, useState } from 'react';
-import useSiteContent from '../hooks/useSiteContent';
-import { SiteContent } from '../types';
+import useSiteContent, { DEFAULT_SITE_CONTENT } from '../hooks/useSiteContent';
+import { SectionStyle, SiteContent } from '../types';
 import { normalizeCloudinaryImageUrl, uploadProductImage } from '../services/cloudinary';
-import { resolveSiteContent } from '../utils/siteContent';
+import { ALLOWED_FONT_FAMILIES, ALLOWED_FONT_SIZES, resolveSiteContent } from '../utils/siteContent';
 import SitePreviewCanvas, { EditableZoneKey } from '../components/SitePreviewCanvas';
 import Modal from '../components/Modal';
 
 const imageWarning = "L'URL doit provenir de Cloudinary (https://*.cloudinary.com).";
 
-type ImageFieldKey = 'hero.backgroundImage' | 'about.image' | 'menu.image' | 'contact.image';
+const BACKGROUND_TYPE_OPTIONS: { value: SectionStyle['background']['type']; label: string }[] = [
+  { value: 'color', label: 'Couleur' },
+  { value: 'image', label: 'Image' },
+];
+
+type StyleImageFieldKey =
+  | 'navigation.style.background'
+  | 'hero.style.background'
+  | 'about.style.background'
+  | 'menu.style.background'
+  | 'contact.style.background'
+  | 'footer.style.background';
+
+type ImageFieldKey =
+  | 'hero.backgroundImage'
+  | 'about.image'
+  | 'menu.image'
+  | 'contact.image'
+  | StyleImageFieldKey;
 type HeroFieldKey = Exclude<keyof SiteContent['hero'], 'backgroundImage'>;
 type MenuFieldKey = Exclude<keyof SiteContent['menu'], 'image'>;
 type ContactFieldKey = Exclude<keyof SiteContent['contact'], 'image'>;
 type NavigationFieldKey = keyof SiteContent['navigation']['links'];
+
+const STYLE_BACKGROUND_FIELD_KEYS: Record<EditableZoneKey, StyleImageFieldKey> = {
+  navigation: 'navigation.style.background',
+  hero: 'hero.style.background',
+  about: 'about.style.background',
+  menu: 'menu.style.background',
+  contact: 'contact.style.background',
+  footer: 'footer.style.background',
+};
 
 type NavigationChangeHandler = (key: NavigationFieldKey) => (event: React.ChangeEvent<HTMLInputElement>) => void;
 type HeroChangeHandler = (
@@ -40,6 +67,13 @@ type SiteCustomizationModalsProps = {
   handleImageInputChange: ImageInputHandler;
   handleImageUpload: ImageUploadHandler;
   handleClearImage: ImageClearHandler;
+  handleStyleFontFamilyChange: (zone: EditableZoneKey, value: string) => void;
+  handleStyleFontSizeChange: (zone: EditableZoneKey, value: string) => void;
+  handleStyleTextColorChange: (zone: EditableZoneKey, value: string) => void;
+  handleStyleBackgroundColorChange: (zone: EditableZoneKey, value: string) => void;
+  handleStyleBackgroundTypeChange: (zone: EditableZoneKey, value: SectionStyle['background']['type']) => void;
+  fontOptions: readonly string[];
+  fontSizeOptions: readonly string[];
   imageErrors: Record<ImageFieldKey, string | null>;
   isUploading: (field: ImageFieldKey) => boolean;
 };
@@ -49,6 +83,12 @@ const IMAGE_FIELD_LABELS: Record<ImageFieldKey, string> = {
   'about.image': 'Image de la section À propos',
   'menu.image': 'Image de la section Menu',
   'contact.image': 'Image de la section Contact',
+  'navigation.style.background': 'Fond personnalisé (navigation)',
+  'hero.style.background': 'Fond personnalisé (hero)',
+  'about.style.background': 'Fond personnalisé (À propos)',
+  'menu.style.background': 'Fond personnalisé (menu)',
+  'contact.style.background': 'Fond personnalisé (contact)',
+  'footer.style.background': 'Fond personnalisé (pied de page)',
 };
 
 const INITIAL_IMAGE_ERRORS: Record<ImageFieldKey, string | null> = {
@@ -56,6 +96,12 @@ const INITIAL_IMAGE_ERRORS: Record<ImageFieldKey, string | null> = {
   'about.image': null,
   'menu.image': null,
   'contact.image': null,
+  'navigation.style.background': null,
+  'hero.style.background': null,
+  'about.style.background': null,
+  'menu.style.background': null,
+  'contact.style.background': null,
+  'footer.style.background': null,
 };
 
 const SiteCustomization: React.FC = () => {
@@ -80,12 +126,28 @@ const SiteCustomization: React.FC = () => {
   }, [content]);
 
   const previewContent = useMemo(() => resolveSiteContent(draft), [draft]);
+  const fontOptions = useMemo(() => [...ALLOWED_FONT_FAMILIES], []);
+  const fontSizeOptions = useMemo(() => [...ALLOWED_FONT_SIZES], []);
 
   const mutateDraft = (updater: (prev: SiteContent) => SiteContent) => {
     setDraft(prev => updater(prev));
     setIsDirty(true);
     setStatusMessage(null);
     setFormError(null);
+  };
+
+  const updateZone = <K extends EditableZoneKey>(zone: K, updater: (zoneContent: SiteContent[K]) => SiteContent[K]) => {
+    mutateDraft(prev => ({
+      ...prev,
+      [zone]: updater(prev[zone]),
+    }));
+  };
+
+  const updateZoneStyle = (zone: EditableZoneKey, updater: (style: SectionStyle) => SectionStyle) => {
+    updateZone(zone, zoneContent => ({
+      ...zoneContent,
+      style: updater(zoneContent.style),
+    }));
   };
 
   const handleNavigationChange: NavigationChangeHandler = key => event => {
@@ -179,42 +241,185 @@ const SiteCustomization: React.FC = () => {
     }));
   };
 
+  const handleStyleFontFamilyChange = (zone: EditableZoneKey, value: string) => {
+    updateZoneStyle(zone, style => ({
+      ...style,
+      fontFamily: value,
+    }));
+  };
+
+  const handleStyleFontSizeChange = (zone: EditableZoneKey, value: string) => {
+    updateZoneStyle(zone, style => ({
+      ...style,
+      fontSize: value,
+    }));
+  };
+
+  const handleStyleTextColorChange = (zone: EditableZoneKey, value: string) => {
+    updateZoneStyle(zone, style => ({
+      ...style,
+      textColor: value,
+    }));
+  };
+
+  const handleStyleBackgroundColorChange = (zone: EditableZoneKey, value: string) => {
+    updateZoneStyle(zone, style => ({
+      ...style,
+      background: {
+        ...style.background,
+        color: value,
+      },
+    }));
+  };
+
+  const handleStyleBackgroundTypeChange = (zone: EditableZoneKey, type: SectionStyle['background']['type']) => {
+    const fieldKey = STYLE_BACKGROUND_FIELD_KEYS[zone];
+    const defaultStyle = DEFAULT_SITE_CONTENT[zone].style;
+    updateZoneStyle(zone, style => ({
+      ...style,
+      background: {
+        ...style.background,
+        type,
+        color: style.background.color || defaultStyle.background.color,
+        image: type === 'image' ? style.background.image ?? defaultStyle.background.image : null,
+      },
+    }));
+    if (type === 'color') {
+      setImageErrors(prev => ({
+        ...prev,
+        [fieldKey]: null,
+      }));
+    }
+  };
+
   const setImageField = (field: ImageFieldKey, value: string | null) => {
     mutateDraft(prev => {
-      if (field === 'hero.backgroundImage') {
-        return {
-          ...prev,
-          hero: {
-            ...prev.hero,
-            backgroundImage: value,
-          },
-        };
+      switch (field) {
+        case 'hero.backgroundImage':
+          return {
+            ...prev,
+            hero: {
+              ...prev.hero,
+              backgroundImage: value,
+            },
+          };
+        case 'about.image':
+          return {
+            ...prev,
+            about: {
+              ...prev.about,
+              image: value,
+            },
+          };
+        case 'menu.image':
+          return {
+            ...prev,
+            menu: {
+              ...prev.menu,
+              image: value,
+            },
+          };
+        case 'contact.image':
+          return {
+            ...prev,
+            contact: {
+              ...prev.contact,
+              image: value,
+            },
+          };
+        case 'navigation.style.background':
+          return {
+            ...prev,
+            navigation: {
+              ...prev.navigation,
+              style: {
+                ...prev.navigation.style,
+                background: {
+                  ...prev.navigation.style.background,
+                  type: 'image',
+                  image: value,
+                },
+              },
+            },
+          };
+        case 'hero.style.background':
+          return {
+            ...prev,
+            hero: {
+              ...prev.hero,
+              style: {
+                ...prev.hero.style,
+                background: {
+                  ...prev.hero.style.background,
+                  type: 'image',
+                  image: value,
+                },
+              },
+            },
+          };
+        case 'about.style.background':
+          return {
+            ...prev,
+            about: {
+              ...prev.about,
+              style: {
+                ...prev.about.style,
+                background: {
+                  ...prev.about.style.background,
+                  type: 'image',
+                  image: value,
+                },
+              },
+            },
+          };
+        case 'menu.style.background':
+          return {
+            ...prev,
+            menu: {
+              ...prev.menu,
+              style: {
+                ...prev.menu.style,
+                background: {
+                  ...prev.menu.style.background,
+                  type: 'image',
+                  image: value,
+                },
+              },
+            },
+          };
+        case 'contact.style.background':
+          return {
+            ...prev,
+            contact: {
+              ...prev.contact,
+              style: {
+                ...prev.contact.style,
+                background: {
+                  ...prev.contact.style.background,
+                  type: 'image',
+                  image: value,
+                },
+              },
+            },
+          };
+        case 'footer.style.background':
+          return {
+            ...prev,
+            footer: {
+              ...prev.footer,
+              style: {
+                ...prev.footer.style,
+                background: {
+                  ...prev.footer.style.background,
+                  type: 'image',
+                  image: value,
+                },
+              },
+            },
+          };
+        default:
+          return prev;
       }
-      if (field === 'about.image') {
-        return {
-          ...prev,
-          about: {
-            ...prev.about,
-            image: value,
-          },
-        };
-      }
-      if (field === 'menu.image') {
-        return {
-          ...prev,
-          menu: {
-            ...prev.menu,
-            image: value,
-          },
-        };
-      }
-      return {
-        ...prev,
-        contact: {
-          ...prev.contact,
-          image: value,
-        },
-      };
     });
   };
 
@@ -357,6 +562,13 @@ const SiteCustomization: React.FC = () => {
         handleImageInputChange={handleImageInputChange}
         handleImageUpload={handleImageUpload}
         handleClearImage={handleClearImage}
+        handleStyleFontFamilyChange={handleStyleFontFamilyChange}
+        handleStyleFontSizeChange={handleStyleFontSizeChange}
+        handleStyleTextColorChange={handleStyleTextColorChange}
+        handleStyleBackgroundColorChange={handleStyleBackgroundColorChange}
+        handleStyleBackgroundTypeChange={handleStyleBackgroundTypeChange}
+        fontOptions={fontOptions}
+        fontSizeOptions={fontSizeOptions}
         imageErrors={imageErrors}
         isUploading={isUploading}
       />
@@ -379,444 +591,603 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
   handleImageInputChange,
   handleImageUpload,
   handleClearImage,
+  handleStyleFontFamilyChange,
+  handleStyleFontSizeChange,
+  handleStyleTextColorChange,
+  handleStyleBackgroundColorChange,
+  handleStyleBackgroundTypeChange,
+  fontOptions,
+  fontSizeOptions,
   imageErrors,
   isUploading,
-}) => (
-  <>
-    <Modal isOpen={activeZone === 'navigation'} onClose={onClose} title="Modifier la navigation" size="lg">
-      <div className="space-y-5">
-        <div>
-          <label htmlFor="brand-name" className="block text-sm font-medium text-gray-700">
-            Nom de la marque
-          </label>
-          <input
-            id="brand-name"
-            className="ui-input mt-1"
-            value={draft.navigation.brand}
-            onChange={handleBrandChange}
-          />
+}) => {
+  const renderStyleControls = (zone: EditableZoneKey) => {
+    const style = draft[zone].style;
+    const backgroundField = STYLE_BACKGROUND_FIELD_KEYS[zone];
+    const isBackgroundImage = style.background.type === 'image';
+
+    return (
+      <div className="space-y-4 rounded-lg border border-gray-200 p-4">
+        <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Styles</h3>
+        <div className="grid gap-4 md:grid-cols-2">
+          <div>
+            <label htmlFor={`${zone}-font-family`} className="block text-sm font-medium text-gray-700">
+              Police
+            </label>
+            <select
+              id={`${zone}-font-family`}
+              className="ui-select mt-1"
+              value={style.fontFamily}
+              onChange={event => handleStyleFontFamilyChange(zone, event.target.value)}
+            >
+              {fontOptions.map(font => (
+                <option key={font} value={font}>
+                  {font}
+                </option>
+              ))}
+            </select>
+          </div>
+          <div>
+            <label htmlFor={`${zone}-font-size`} className="block text-sm font-medium text-gray-700">
+              Taille du texte
+            </label>
+            <select
+              id={`${zone}-font-size`}
+              className="ui-select mt-1"
+              value={style.fontSize}
+              onChange={event => handleStyleFontSizeChange(zone, event.target.value)}
+            >
+              {fontSizeOptions.map(size => (
+                <option key={size} value={size}>
+                  {size}
+                </option>
+              ))}
+            </select>
+          </div>
         </div>
         <div className="grid gap-4 md:grid-cols-2">
           <div>
-            <label htmlFor="nav-home" className="block text-sm font-medium text-gray-700">Lien Accueil</label>
+            <label htmlFor={`${zone}-text-color`} className="block text-sm font-medium text-gray-700">
+              Couleur du texte
+            </label>
             <input
-              id="nav-home"
-              className="ui-input mt-1"
-              value={draft.navigation.links.home}
-              onChange={handleNavigationChange('home')}
+              id={`${zone}-text-color`}
+              type="color"
+              className="mt-1 h-10 w-full cursor-pointer rounded-md border border-gray-200 p-1"
+              value={style.textColor}
+              onChange={event => handleStyleTextColorChange(zone, event.target.value)}
             />
+            <p className="mt-1 text-xs text-gray-500">{style.textColor}</p>
           </div>
           <div>
-            <label htmlFor="nav-about" className="block text-sm font-medium text-gray-700">Lien À propos</label>
-            <input
-              id="nav-about"
-              className="ui-input mt-1"
-              value={draft.navigation.links.about}
-              onChange={handleNavigationChange('about')}
-            />
-          </div>
-          <div>
-            <label htmlFor="nav-menu" className="block text-sm font-medium text-gray-700">Lien Menu</label>
-            <input
-              id="nav-menu"
-              className="ui-input mt-1"
-              value={draft.navigation.links.menu}
-              onChange={handleNavigationChange('menu')}
-            />
-          </div>
-          <div>
-            <label htmlFor="nav-contact" className="block text-sm font-medium text-gray-700">Lien Contact</label>
-            <input
-              id="nav-contact"
-              className="ui-input mt-1"
-              value={draft.navigation.links.contact}
-              onChange={handleNavigationChange('contact')}
-            />
+            <label htmlFor={`${zone}-background-type`} className="block text-sm font-medium text-gray-700">
+              Type de fond
+            </label>
+            <select
+              id={`${zone}-background-type`}
+              className="ui-select mt-1"
+              value={style.background.type}
+              onChange={event =>
+                handleStyleBackgroundTypeChange(zone, event.target.value as SectionStyle['background']['type'])
+              }
+            >
+              {BACKGROUND_TYPE_OPTIONS.map(option => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
         <div>
-          <label htmlFor="nav-login" className="block text-sm font-medium text-gray-700">Bouton personnel</label>
-          <input
-            id="nav-login"
-            className="ui-input mt-1"
-            value={draft.navigation.links.loginCta}
-            onChange={handleNavigationChange('loginCta')}
-          />
-        </div>
-      </div>
-    </Modal>
-
-    <Modal isOpen={activeZone === 'hero'} onClose={onClose} title="Modifier la section hero" size="xl">
-      <div className="space-y-5">
-        <div className="grid gap-4 md:grid-cols-2">
-          <div>
-            <label htmlFor="hero-title" className="block text-sm font-medium text-gray-700">Titre</label>
-            <input
-              id="hero-title"
-              className="ui-input mt-1"
-              value={draft.hero.title}
-              onChange={handleHeroFieldChange('title')}
-            />
-          </div>
-          <div>
-            <label htmlFor="hero-cta" className="block text-sm font-medium text-gray-700">Texte du bouton</label>
-            <input
-              id="hero-cta"
-              className="ui-input mt-1"
-              value={draft.hero.ctaLabel}
-              onChange={handleHeroFieldChange('ctaLabel')}
-            />
-          </div>
-        </div>
-        <div>
-          <label htmlFor="hero-subtitle" className="block text-sm font-medium text-gray-700">Sous-titre</label>
-          <textarea
-            id="hero-subtitle"
-            className="ui-textarea mt-1"
-            value={draft.hero.subtitle}
-            rows={3}
-            onChange={handleHeroFieldChange('subtitle')}
-          />
-        </div>
-        <div className="grid gap-4 md:grid-cols-2">
-          <div>
-            <label htmlFor="hero-history" className="block text-sm font-medium text-gray-700">Titre historique</label>
-            <input
-              id="hero-history"
-              className="ui-input mt-1"
-              value={draft.hero.historyTitle}
-              onChange={handleHeroFieldChange('historyTitle')}
-            />
-          </div>
-          <div>
-            <label htmlFor="hero-reorder" className="block text-sm font-medium text-gray-700">Bouton de réassort</label>
-            <input
-              id="hero-reorder"
-              className="ui-input mt-1"
-              value={draft.hero.reorderCtaLabel}
-              onChange={handleHeroFieldChange('reorderCtaLabel')}
-            />
-          </div>
-        </div>
-        <div>
-          <label htmlFor="hero-image" className="block text-sm font-medium text-gray-700">
-            {IMAGE_FIELD_LABELS['hero.backgroundImage']}
+          <label htmlFor={`${zone}-background-color`} className="block text-sm font-medium text-gray-700">
+            Couleur de fond
           </label>
           <input
-            id="hero-image"
-            className="ui-input mt-1"
-            value={draft.hero.backgroundImage ?? ''}
-            onChange={handleImageInputChange('hero.backgroundImage')}
-            placeholder="https://res.cloudinary.com/..."
+            id={`${zone}-background-color`}
+            type="color"
+            className="mt-1 h-10 w-full cursor-pointer rounded-md border border-gray-200 p-1"
+            value={style.background.color}
+            onChange={event => handleStyleBackgroundColorChange(zone, event.target.value)}
           />
-          <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
-          {imageErrors['hero.backgroundImage'] && (
-            <p className="mt-1 text-xs text-red-600">{imageErrors['hero.backgroundImage']}</p>
-          )}
-          <div className="mt-3 flex flex-wrap gap-2">
-            <label className="ui-btn ui-btn-secondary cursor-pointer">
-              Importer une image
-              <input
-                type="file"
-                accept="image/*"
-                className="hidden"
-                onChange={event => {
-                  const file = event.target.files?.[0];
-                  if (file) {
-                    void handleImageUpload('hero.backgroundImage', file);
-                    event.target.value = '';
-                  }
-                }}
-              />
+          <p className="mt-1 text-xs text-gray-500">{style.background.color}</p>
+        </div>
+        {isBackgroundImage && (
+          <div>
+            <label htmlFor={`${zone}-background-image`} className="block text-sm font-medium text-gray-700">
+              {IMAGE_FIELD_LABELS[backgroundField]}
             </label>
-            <button
-              type="button"
-              className="ui-btn ui-btn-ghost"
-              onClick={() => handleClearImage('hero.backgroundImage')}
-              disabled={!draft.hero.backgroundImage || isUploading('hero.backgroundImage')}
-            >
-              Retirer l'image
-            </button>
-            {isUploading('hero.backgroundImage') && (
-              <span className="text-sm text-gray-500">Téléversement en cours…</span>
+            <input
+              id={`${zone}-background-image`}
+              className="ui-input mt-1"
+              value={style.background.image ?? ''}
+              onChange={handleImageInputChange(backgroundField)}
+              placeholder="https://res.cloudinary.com/..."
+            />
+            <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
+            {imageErrors[backgroundField] && (
+              <p className="mt-1 text-xs text-red-600">{imageErrors[backgroundField]}</p>
             )}
+            <div className="mt-3 flex flex-wrap gap-2">
+              <label className="ui-btn ui-btn-secondary cursor-pointer">
+                Importer une image
+                <input
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={event => {
+                    const file = event.target.files?.[0];
+                    if (file) {
+                      void handleImageUpload(backgroundField, file);
+                      event.target.value = '';
+                    }
+                  }}
+                />
+              </label>
+              <button
+                type="button"
+                className="ui-btn ui-btn-ghost"
+                onClick={() => handleClearImage(backgroundField)}
+                disabled={!style.background.image || isUploading(backgroundField)}
+              >
+                Retirer l'image
+              </button>
+              {isUploading(backgroundField) && (
+                <span className="text-sm text-gray-500">Téléversement en cours…</span>
+              )}
+            </div>
           </div>
-        </div>
+        )}
       </div>
-    </Modal>
+    );
+  };
 
-    <Modal isOpen={activeZone === 'about'} onClose={onClose} title="Modifier la section À propos" size="lg">
-      <div className="space-y-5">
-        <div>
-          <label htmlFor="about-title" className="block text-sm font-medium text-gray-700">Titre</label>
-          <input
-            id="about-title"
-            className="ui-input mt-1"
-            value={draft.about.title}
-            onChange={handleAboutTitleChange}
-          />
-        </div>
-        <div>
-          <label htmlFor="about-description" className="block text-sm font-medium text-gray-700">Description</label>
-          <textarea
-            id="about-description"
-            className="ui-textarea mt-1"
-            value={draft.about.description}
-            rows={4}
-            onChange={handleAboutChange}
-          />
-        </div>
-        <div>
-          <label htmlFor="about-image" className="block text-sm font-medium text-gray-700">
-            {IMAGE_FIELD_LABELS['about.image']}
-          </label>
-          <input
-            id="about-image"
-            className="ui-input mt-1"
-            value={draft.about.image ?? ''}
-            onChange={handleImageInputChange('about.image')}
-            placeholder="https://res.cloudinary.com/..."
-          />
-          <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
-          {imageErrors['about.image'] && (
-            <p className="mt-1 text-xs text-red-600">{imageErrors['about.image']}</p>
-          )}
-          <div className="mt-3 flex flex-wrap gap-2">
-            <label className="ui-btn ui-btn-secondary cursor-pointer">
-              Importer une image
-              <input
-                type="file"
-                accept="image/*"
-                className="hidden"
-                onChange={event => {
-                  const file = event.target.files?.[0];
-                  if (file) {
-                    void handleImageUpload('about.image', file);
-                    event.target.value = '';
-                  }
-                }}
-              />
+  return (
+    <>
+      <Modal isOpen={activeZone === 'navigation'} onClose={onClose} title="Modifier la navigation" size="lg">
+        <div className="space-y-5">
+          <div>
+            <label htmlFor="brand-name" className="block text-sm font-medium text-gray-700">
+              Nom de la marque
             </label>
-            <button
-              type="button"
-              className="ui-btn ui-btn-ghost"
-              onClick={() => handleClearImage('about.image')}
-              disabled={!draft.about.image || isUploading('about.image')}
-            >
-              Retirer l'image
-            </button>
-            {isUploading('about.image') && (
-              <span className="text-sm text-gray-500">Téléversement en cours…</span>
-            )}
+            <input
+              id="brand-name"
+              className="ui-input mt-1"
+              value={draft.navigation.brand}
+              onChange={handleBrandChange}
+            />
           </div>
-        </div>
-      </div>
-    </Modal>
-
-    <Modal isOpen={activeZone === 'menu'} onClose={onClose} title="Modifier la section menu" size="lg">
-      <div className="space-y-5">
-        <div>
-          <label htmlFor="menu-title" className="block text-sm font-medium text-gray-700">Titre</label>
-          <input
-            id="menu-title"
-            className="ui-input mt-1"
-            value={draft.menu.title}
-            onChange={handleMenuFieldChange('title')}
-          />
-        </div>
-        <div>
-          <label htmlFor="menu-cta" className="block text-sm font-medium text-gray-700">Texte du bouton</label>
-          <input
-            id="menu-cta"
-            className="ui-input mt-1"
-            value={draft.menu.ctaLabel}
-            onChange={handleMenuFieldChange('ctaLabel')}
-          />
-        </div>
-        <div>
-          <label htmlFor="menu-loading" className="block text-sm font-medium text-gray-700">Texte de chargement</label>
-          <input
-            id="menu-loading"
-            className="ui-input mt-1"
-            value={draft.menu.loadingLabel}
-            onChange={handleMenuFieldChange('loadingLabel')}
-          />
-        </div>
-        <div>
-          <label htmlFor="menu-image" className="block text-sm font-medium text-gray-700">
-            {IMAGE_FIELD_LABELS['menu.image']}
-          </label>
-          <input
-            id="menu-image"
-            className="ui-input mt-1"
-            value={draft.menu.image ?? ''}
-            onChange={handleImageInputChange('menu.image')}
-            placeholder="https://res.cloudinary.com/..."
-          />
-          <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
-          {imageErrors['menu.image'] && (
-            <p className="mt-1 text-xs text-red-600">{imageErrors['menu.image']}</p>
-          )}
-          <div className="mt-3 flex flex-wrap gap-2">
-            <label className="ui-btn ui-btn-secondary cursor-pointer">
-              Importer une image
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label htmlFor="nav-home" className="block text-sm font-medium text-gray-700">Lien Accueil</label>
               <input
-                type="file"
-                accept="image/*"
-                className="hidden"
-                onChange={event => {
-                  const file = event.target.files?.[0];
-                  if (file) {
-                    void handleImageUpload('menu.image', file);
-                    event.target.value = '';
-                  }
-                }}
+                id="nav-home"
+                className="ui-input mt-1"
+                value={draft.navigation.links.home}
+                onChange={handleNavigationChange('home')}
               />
-            </label>
-            <button
-              type="button"
-              className="ui-btn ui-btn-ghost"
-              onClick={() => handleClearImage('menu.image')}
-              disabled={!draft.menu.image || isUploading('menu.image')}
-            >
-              Retirer l'image
-            </button>
-            {isUploading('menu.image') && (
-              <span className="text-sm text-gray-500">Téléversement en cours…</span>
-            )}
-          </div>
-        </div>
-      </div>
-    </Modal>
-
-    <Modal isOpen={activeZone === 'contact'} onClose={onClose} title="Modifier la section contact" size="xl">
-      <div className="space-y-5">
-        <div>
-          <label htmlFor="contact-title" className="block text-sm font-medium text-gray-700">Titre</label>
-          <input
-            id="contact-title"
-            className="ui-input mt-1"
-            value={draft.contact.title}
-            onChange={handleContactFieldChange('title')}
-          />
-        </div>
-        <div className="grid gap-4 md:grid-cols-2">
-          <div>
-            <label htmlFor="contact-address-label" className="block text-sm font-medium text-gray-700">Libellé adresse</label>
-            <input
-              id="contact-address-label"
-              className="ui-input mt-1"
-              value={draft.contact.addressLabel}
-              onChange={handleContactFieldChange('addressLabel')}
-            />
-          </div>
-          <div>
-            <label htmlFor="contact-address" className="block text-sm font-medium text-gray-700">Adresse</label>
-            <input
-              id="contact-address"
-              className="ui-input mt-1"
-              value={draft.contact.address}
-              onChange={handleContactFieldChange('address')}
-            />
-          </div>
-          <div>
-            <label htmlFor="contact-phone-label" className="block text-sm font-medium text-gray-700">Libellé téléphone</label>
-            <input
-              id="contact-phone-label"
-              className="ui-input mt-1"
-              value={draft.contact.phoneLabel}
-              onChange={handleContactFieldChange('phoneLabel')}
-            />
-          </div>
-          <div>
-            <label htmlFor="contact-phone" className="block text-sm font-medium text-gray-700">Téléphone</label>
-            <input
-              id="contact-phone"
-              className="ui-input mt-1"
-              value={draft.contact.phone}
-              onChange={handleContactFieldChange('phone')}
-            />
-          </div>
-          <div>
-            <label htmlFor="contact-email-label" className="block text-sm font-medium text-gray-700">Libellé email</label>
-            <input
-              id="contact-email-label"
-              className="ui-input mt-1"
-              value={draft.contact.emailLabel}
-              onChange={handleContactFieldChange('emailLabel')}
-            />
-          </div>
-          <div>
-            <label htmlFor="contact-email" className="block text-sm font-medium text-gray-700">Email</label>
-            <input
-              id="contact-email"
-              className="ui-input mt-1"
-              value={draft.contact.email}
-              onChange={handleContactFieldChange('email')}
-            />
-          </div>
-        </div>
-        <div>
-          <label htmlFor="contact-image" className="block text-sm font-medium text-gray-700">
-            {IMAGE_FIELD_LABELS['contact.image']}
-          </label>
-          <input
-            id="contact-image"
-            className="ui-input mt-1"
-            value={draft.contact.image ?? ''}
-            onChange={handleImageInputChange('contact.image')}
-            placeholder="https://res.cloudinary.com/..."
-          />
-          <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
-          {imageErrors['contact.image'] && (
-            <p className="mt-1 text-xs text-red-600">{imageErrors['contact.image']}</p>
-          )}
-          <div className="mt-3 flex flex-wrap gap-2">
-            <label className="ui-btn ui-btn-secondary cursor-pointer">
-              Importer une image
+            </div>
+            <div>
+              <label htmlFor="nav-about" className="block text-sm font-medium text-gray-700">Lien À propos</label>
               <input
-                type="file"
-                accept="image/*"
-                className="hidden"
-                onChange={event => {
-                  const file = event.target.files?.[0];
-                  if (file) {
-                    void handleImageUpload('contact.image', file);
-                    event.target.value = '';
-                  }
-                }}
+                id="nav-about"
+                className="ui-input mt-1"
+                value={draft.navigation.links.about}
+                onChange={handleNavigationChange('about')}
               />
-            </label>
-            <button
-              type="button"
-              className="ui-btn ui-btn-ghost"
-              onClick={() => handleClearImage('contact.image')}
-              disabled={!draft.contact.image || isUploading('contact.image')}
-            >
-              Retirer l'image
-            </button>
-            {isUploading('contact.image') && (
-              <span className="text-sm text-gray-500">Téléversement en cours…</span>
-            )}
+            </div>
+            <div>
+              <label htmlFor="nav-menu" className="block text-sm font-medium text-gray-700">Lien Menu</label>
+              <input
+                id="nav-menu"
+                className="ui-input mt-1"
+                value={draft.navigation.links.menu}
+                onChange={handleNavigationChange('menu')}
+              />
+            </div>
+            <div>
+              <label htmlFor="nav-contact" className="block text-sm font-medium text-gray-700">Lien Contact</label>
+              <input
+                id="nav-contact"
+                className="ui-input mt-1"
+                value={draft.navigation.links.contact}
+                onChange={handleNavigationChange('contact')}
+              />
+            </div>
           </div>
+          <div>
+            <label htmlFor="nav-login" className="block text-sm font-medium text-gray-700">Bouton personnel</label>
+            <input
+              id="nav-login"
+              className="ui-input mt-1"
+              value={draft.navigation.links.loginCta}
+              onChange={handleNavigationChange('loginCta')}
+            />
+          </div>
+          {renderStyleControls('navigation')}
         </div>
-      </div>
-    </Modal>
+      </Modal>
 
-    <Modal isOpen={activeZone === 'footer'} onClose={onClose} title="Modifier le pied de page" size="sm">
-      <div className="space-y-4">
-        <div>
-          <label htmlFor="footer-text" className="block text-sm font-medium text-gray-700">Texte du pied de page</label>
-          <input
-            id="footer-text"
-            className="ui-input mt-1"
-            value={draft.footer.text}
-            onChange={handleFooterTextChange}
-          />
+      <Modal isOpen={activeZone === 'hero'} onClose={onClose} title="Modifier la section hero" size="xl">
+        <div className="space-y-5">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label htmlFor="hero-title" className="block text-sm font-medium text-gray-700">Titre</label>
+              <input
+                id="hero-title"
+                className="ui-input mt-1"
+                value={draft.hero.title}
+                onChange={handleHeroFieldChange('title')}
+              />
+            </div>
+            <div>
+              <label htmlFor="hero-cta" className="block text-sm font-medium text-gray-700">Texte du bouton</label>
+              <input
+                id="hero-cta"
+                className="ui-input mt-1"
+                value={draft.hero.ctaLabel}
+                onChange={handleHeroFieldChange('ctaLabel')}
+              />
+            </div>
+          </div>
+          <div>
+            <label htmlFor="hero-subtitle" className="block text-sm font-medium text-gray-700">Sous-titre</label>
+            <textarea
+              id="hero-subtitle"
+              className="ui-textarea mt-1"
+              value={draft.hero.subtitle}
+              rows={3}
+              onChange={handleHeroFieldChange('subtitle')}
+            />
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label htmlFor="hero-history" className="block text-sm font-medium text-gray-700">Titre historique</label>
+              <input
+                id="hero-history"
+                className="ui-input mt-1"
+                value={draft.hero.historyTitle}
+                onChange={handleHeroFieldChange('historyTitle')}
+              />
+            </div>
+            <div>
+              <label htmlFor="hero-reorder" className="block text-sm font-medium text-gray-700">Bouton de réassort</label>
+              <input
+                id="hero-reorder"
+                className="ui-input mt-1"
+                value={draft.hero.reorderCtaLabel}
+                onChange={handleHeroFieldChange('reorderCtaLabel')}
+              />
+            </div>
+          </div>
+          <div>
+            <label htmlFor="hero-image" className="block text-sm font-medium text-gray-700">
+              {IMAGE_FIELD_LABELS['hero.backgroundImage']}
+            </label>
+            <input
+              id="hero-image"
+              className="ui-input mt-1"
+              value={draft.hero.backgroundImage ?? ''}
+              onChange={handleImageInputChange('hero.backgroundImage')}
+              placeholder="https://res.cloudinary.com/..."
+            />
+            <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
+            {imageErrors['hero.backgroundImage'] && (
+              <p className="mt-1 text-xs text-red-600">{imageErrors['hero.backgroundImage']}</p>
+            )}
+            <div className="mt-3 flex flex-wrap gap-2">
+              <label className="ui-btn ui-btn-secondary cursor-pointer">
+                Importer une image
+                <input
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={event => {
+                    const file = event.target.files?.[0];
+                    if (file) {
+                      void handleImageUpload('hero.backgroundImage', file);
+                      event.target.value = '';
+                    }
+                  }}
+                />
+              </label>
+              <button
+                type="button"
+                className="ui-btn ui-btn-ghost"
+                onClick={() => handleClearImage('hero.backgroundImage')}
+                disabled={!draft.hero.backgroundImage || isUploading('hero.backgroundImage')}
+              >
+                Retirer l'image
+              </button>
+              {isUploading('hero.backgroundImage') && (
+                <span className="text-sm text-gray-500">Téléversement en cours…</span>
+              )}
+            </div>
+          </div>
+          {renderStyleControls('hero')}
         </div>
-      </div>
-    </Modal>
-  </>
-);
+      </Modal>
+
+      <Modal isOpen={activeZone === 'about'} onClose={onClose} title="Modifier la section À propos" size="lg">
+        <div className="space-y-5">
+          <div>
+            <label htmlFor="about-title" className="block text-sm font-medium text-gray-700">Titre</label>
+            <input
+              id="about-title"
+              className="ui-input mt-1"
+              value={draft.about.title}
+              onChange={handleAboutTitleChange}
+            />
+          </div>
+          <div>
+            <label htmlFor="about-description" className="block text-sm font-medium text-gray-700">Description</label>
+            <textarea
+              id="about-description"
+              className="ui-textarea mt-1"
+              value={draft.about.description}
+              rows={4}
+              onChange={handleAboutChange}
+            />
+          </div>
+          <div>
+            <label htmlFor="about-image" className="block text-sm font-medium text-gray-700">
+              {IMAGE_FIELD_LABELS['about.image']}
+            </label>
+            <input
+              id="about-image"
+              className="ui-input mt-1"
+              value={draft.about.image ?? ''}
+              onChange={handleImageInputChange('about.image')}
+              placeholder="https://res.cloudinary.com/..."
+            />
+            <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
+            {imageErrors['about.image'] && (
+              <p className="mt-1 text-xs text-red-600">{imageErrors['about.image']}</p>
+            )}
+            <div className="mt-3 flex flex-wrap gap-2">
+              <label className="ui-btn ui-btn-secondary cursor-pointer">
+                Importer une image
+                <input
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={event => {
+                    const file = event.target.files?.[0];
+                    if (file) {
+                      void handleImageUpload('about.image', file);
+                      event.target.value = '';
+                    }
+                  }}
+                />
+              </label>
+              <button
+                type="button"
+                className="ui-btn ui-btn-ghost"
+                onClick={() => handleClearImage('about.image')}
+                disabled={!draft.about.image || isUploading('about.image')}
+              >
+                Retirer l'image
+              </button>
+              {isUploading('about.image') && (
+                <span className="text-sm text-gray-500">Téléversement en cours…</span>
+              )}
+            </div>
+          </div>
+          {renderStyleControls('about')}
+        </div>
+      </Modal>
+
+      <Modal isOpen={activeZone === 'menu'} onClose={onClose} title="Modifier la section menu" size="xl">
+        <div className="space-y-5">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label htmlFor="menu-title" className="block text-sm font-medium text-gray-700">Titre</label>
+              <input
+                id="menu-title"
+                className="ui-input mt-1"
+                value={draft.menu.title}
+                onChange={handleMenuFieldChange('title')}
+              />
+            </div>
+            <div>
+              <label htmlFor="menu-cta" className="block text-sm font-medium text-gray-700">Bouton CTA</label>
+              <input
+                id="menu-cta"
+                className="ui-input mt-1"
+                value={draft.menu.ctaLabel}
+                onChange={handleMenuFieldChange('ctaLabel')}
+              />
+            </div>
+          </div>
+          <div>
+            <label htmlFor="menu-loading" className="block text-sm font-medium text-gray-700">Texte de chargement</label>
+            <input
+              id="menu-loading"
+              className="ui-input mt-1"
+              value={draft.menu.loadingLabel}
+              onChange={handleMenuFieldChange('loadingLabel')}
+            />
+          </div>
+          <div>
+            <label htmlFor="menu-image" className="block text-sm font-medium text-gray-700">
+              {IMAGE_FIELD_LABELS['menu.image']}
+            </label>
+            <input
+              id="menu-image"
+              className="ui-input mt-1"
+              value={draft.menu.image ?? ''}
+              onChange={handleImageInputChange('menu.image')}
+              placeholder="https://res.cloudinary.com/..."
+            />
+            <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
+            {imageErrors['menu.image'] && (
+              <p className="mt-1 text-xs text-red-600">{imageErrors['menu.image']}</p>
+            )}
+            <div className="mt-3 flex flex-wrap gap-2">
+              <label className="ui-btn ui-btn-secondary cursor-pointer">
+                Importer une image
+                <input
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={event => {
+                    const file = event.target.files?.[0];
+                    if (file) {
+                      void handleImageUpload('menu.image', file);
+                      event.target.value = '';
+                    }
+                  }}
+                />
+              </label>
+              <button
+                type="button"
+                className="ui-btn ui-btn-ghost"
+                onClick={() => handleClearImage('menu.image')}
+                disabled={!draft.menu.image || isUploading('menu.image')}
+              >
+                Retirer l'image
+              </button>
+              {isUploading('menu.image') && (
+                <span className="text-sm text-gray-500">Téléversement en cours…</span>
+              )}
+            </div>
+          </div>
+          {renderStyleControls('menu')}
+        </div>
+      </Modal>
+
+      <Modal isOpen={activeZone === 'contact'} onClose={onClose} title="Modifier la section contact" size="xl">
+        <div className="space-y-5">
+          <div>
+            <label htmlFor="contact-title" className="block text-sm font-medium text-gray-700">Titre</label>
+            <input
+              id="contact-title"
+              className="ui-input mt-1"
+              value={draft.contact.title}
+              onChange={handleContactFieldChange('title')}
+            />
+          </div>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label htmlFor="contact-address-label" className="block text-sm font-medium text-gray-700">Libellé adresse</label>
+              <input
+                id="contact-address-label"
+                className="ui-input mt-1"
+                value={draft.contact.addressLabel}
+                onChange={handleContactFieldChange('addressLabel')}
+              />
+            </div>
+            <div>
+              <label htmlFor="contact-address" className="block text-sm font-medium text-gray-700">Adresse</label>
+              <input
+                id="contact-address"
+                className="ui-input mt-1"
+                value={draft.contact.address}
+                onChange={handleContactFieldChange('address')}
+              />
+            </div>
+            <div>
+              <label htmlFor="contact-phone-label" className="block text-sm font-medium text-gray-700">Libellé téléphone</label>
+              <input
+                id="contact-phone-label"
+                className="ui-input mt-1"
+                value={draft.contact.phoneLabel}
+                onChange={handleContactFieldChange('phoneLabel')}
+              />
+            </div>
+            <div>
+              <label htmlFor="contact-phone" className="block text-sm font-medium text-gray-700">Téléphone</label>
+              <input
+                id="contact-phone"
+                className="ui-input mt-1"
+                value={draft.contact.phone}
+                onChange={handleContactFieldChange('phone')}
+              />
+            </div>
+            <div>
+              <label htmlFor="contact-email-label" className="block text-sm font-medium text-gray-700">Libellé email</label>
+              <input
+                id="contact-email-label"
+                className="ui-input mt-1"
+                value={draft.contact.emailLabel}
+                onChange={handleContactFieldChange('emailLabel')}
+              />
+            </div>
+            <div>
+              <label htmlFor="contact-email" className="block text-sm font-medium text-gray-700">Email</label>
+              <input
+                id="contact-email"
+                className="ui-input mt-1"
+                value={draft.contact.email}
+                onChange={handleContactFieldChange('email')}
+              />
+            </div>
+          </div>
+          <div>
+            <label htmlFor="contact-image" className="block text-sm font-medium text-gray-700">
+              {IMAGE_FIELD_LABELS['contact.image']}
+            </label>
+            <input
+              id="contact-image"
+              className="ui-input mt-1"
+              value={draft.contact.image ?? ''}
+              onChange={handleImageInputChange('contact.image')}
+              placeholder="https://res.cloudinary.com/..."
+            />
+            <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
+            {imageErrors['contact.image'] && (
+              <p className="mt-1 text-xs text-red-600">{imageErrors['contact.image']}</p>
+            )}
+            <div className="mt-3 flex flex-wrap gap-2">
+              <label className="ui-btn ui-btn-secondary cursor-pointer">
+                Importer une image
+                <input
+                  type="file"
+                  accept="image/*"
+                  className="hidden"
+                  onChange={event => {
+                    const file = event.target.files?.[0];
+                    if (file) {
+                      void handleImageUpload('contact.image', file);
+                      event.target.value = '';
+                    }
+                  }}
+                />
+              </label>
+              <button
+                type="button"
+                className="ui-btn ui-btn-ghost"
+                onClick={() => handleClearImage('contact.image')}
+                disabled={!draft.contact.image || isUploading('contact.image')}
+              >
+                Retirer l'image
+              </button>
+              {isUploading('contact.image') && (
+                <span className="text-sm text-gray-500">Téléversement en cours…</span>
+              )}
+            </div>
+          </div>
+          {renderStyleControls('contact')}
+        </div>
+      </Modal>
+
+      <Modal isOpen={activeZone === 'footer'} onClose={onClose} title="Modifier le pied de page" size="sm">
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="footer-text" className="block text-sm font-medium text-gray-700">Texte du pied de page</label>
+            <input
+              id="footer-text"
+              className="ui-input mt-1"
+              value={draft.footer.text}
+              onChange={handleFooterTextChange}
+            />
+          </div>
+          {renderStyleControls('footer')}
+        </div>
+      </Modal>
+    </>
+  );
+};
+
 
 export default SiteCustomization;

--- a/types/index.ts
+++ b/types/index.ts
@@ -10,6 +10,19 @@ export interface Role {
   };
 }
 
+export interface SectionBackgroundStyle {
+  type: 'color' | 'image';
+  color: string;
+  image: string | null;
+}
+
+export interface SectionStyle {
+  background: SectionBackgroundStyle;
+  fontFamily: string;
+  fontSize: string;
+  textColor: string;
+}
+
 export interface SiteContent {
   navigation: {
     brand: string;
@@ -20,6 +33,7 @@ export interface SiteContent {
       contact: string;
       loginCta: string;
     };
+    style: SectionStyle;
   };
   hero: {
     title: string;
@@ -28,17 +42,20 @@ export interface SiteContent {
     backgroundImage: string | null;
     historyTitle: string;
     reorderCtaLabel: string;
+    style: SectionStyle;
   };
   about: {
     title: string;
     description: string;
     image: string | null;
+    style: SectionStyle;
   };
   menu: {
     title: string;
     ctaLabel: string;
     loadingLabel: string;
     image: string | null;
+    style: SectionStyle;
   };
   contact: {
     title: string;
@@ -49,9 +66,11 @@ export interface SiteContent {
     emailLabel: string;
     email: string;
     image: string | null;
+    style: SectionStyle;
   };
   footer: {
     text: string;
+    style: SectionStyle;
   };
 }
 

--- a/utils/siteContent.ts
+++ b/utils/siteContent.ts
@@ -1,7 +1,22 @@
-import { SiteContent } from '../types';
+import { SectionStyle, SiteContent } from '../types';
 import { normalizeCloudinaryImageUrl } from '../services/cloudinary';
 
 const trimOrEmpty = (value: string): string => value.trim();
+
+const isValidHexColor = (value: string | null | undefined): value is string =>
+  typeof value === 'string' && /^#(?:[0-9a-fA-F]{3}){1,2}$/.test(value.trim());
+
+export const ALLOWED_FONT_FAMILIES = ['Inter', 'Poppins', 'Playfair Display', 'Roboto', 'Montserrat'] as const;
+export const ALLOWED_FONT_SIZES = ['14px', '16px', '18px', '20px', '24px'] as const;
+
+const resolveFontFamily = (value: string | null | undefined, fallback: string): string =>
+  value && ALLOWED_FONT_FAMILIES.includes(value as (typeof ALLOWED_FONT_FAMILIES)[number]) ? value : fallback;
+
+const resolveFontSize = (value: string | null | undefined, fallback: string): string =>
+  value && ALLOWED_FONT_SIZES.includes(value as (typeof ALLOWED_FONT_SIZES)[number]) ? value : fallback;
+
+const resolveColor = (value: string | null | undefined, fallback: string): string =>
+  isValidHexColor(value) ? value.trim() : fallback;
 
 const resolveString = (value: string | null | undefined, fallback: string): string => {
   if (typeof value !== 'string') {
@@ -30,6 +45,109 @@ const sanitizeImage = (value: string | null | undefined): string | null => {
   return normalized ?? null;
 };
 
+const DEFAULT_NAVIGATION_STYLE: SectionStyle = {
+  background: {
+    type: 'color',
+    color: '#0f172a',
+    image: null,
+  },
+  fontFamily: 'Inter',
+  fontSize: '16px',
+  textColor: '#f1f5f9',
+};
+
+const DEFAULT_HERO_STYLE: SectionStyle = {
+  background: {
+    type: 'image',
+    color: '#0f172a',
+    image: 'https://picsum.photos/seed/tacosbg/1920/1080',
+  },
+  fontFamily: 'Inter',
+  fontSize: '18px',
+  textColor: '#f8fafc',
+};
+
+const DEFAULT_ABOUT_STYLE: SectionStyle = {
+  background: {
+    type: 'color',
+    color: '#ffffff',
+    image: null,
+  },
+  fontFamily: 'Inter',
+  fontSize: '16px',
+  textColor: '#0f172a',
+};
+
+const DEFAULT_MENU_STYLE: SectionStyle = {
+  background: {
+    type: 'color',
+    color: '#f8fafc',
+    image: null,
+  },
+  fontFamily: 'Inter',
+  fontSize: '16px',
+  textColor: '#111827',
+};
+
+const DEFAULT_CONTACT_STYLE: SectionStyle = {
+  background: {
+    type: 'color',
+    color: '#ffffff',
+    image: null,
+  },
+  fontFamily: 'Inter',
+  fontSize: '16px',
+  textColor: '#111827',
+};
+
+const DEFAULT_FOOTER_STYLE: SectionStyle = {
+  background: {
+    type: 'color',
+    color: '#0f172a',
+    image: null,
+  },
+  fontFamily: 'Inter',
+  fontSize: '14px',
+  textColor: '#e2e8f0',
+};
+
+const resolveSectionStyle = (style: Partial<SectionStyle> | undefined, fallback: SectionStyle): SectionStyle => {
+  const backgroundType = style?.background?.type === 'image' ? 'image' : 'color';
+  const backgroundColor = resolveColor(style?.background?.color, fallback.background.color);
+  const backgroundImage =
+    backgroundType === 'image'
+      ? resolveImage(style?.background?.image ?? undefined, fallback.background.image)
+      : null;
+
+  return {
+    background: {
+      type: backgroundType,
+      color: backgroundType === 'color' ? backgroundColor : resolveColor(style?.background?.color, fallback.background.color),
+      image: backgroundType === 'image' ? backgroundImage : null,
+    },
+    fontFamily: resolveFontFamily(style?.fontFamily ?? null, fallback.fontFamily),
+    fontSize: resolveFontSize(style?.fontSize ?? null, fallback.fontSize),
+    textColor: resolveColor(style?.textColor ?? null, fallback.textColor),
+  };
+};
+
+const sanitizeSectionStyle = (style: SectionStyle | undefined, fallback: SectionStyle): SectionStyle => {
+  const backgroundType = style?.background?.type === 'image' ? 'image' : 'color';
+  const sanitizedColor = resolveColor(style?.background?.color ?? null, fallback.background.color);
+  const sanitizedImage = backgroundType === 'image' ? sanitizeImage(style?.background?.image ?? null) : null;
+
+  return {
+    background: {
+      type: backgroundType,
+      color: sanitizedColor,
+      image: backgroundType === 'image' ? sanitizedImage : null,
+    },
+    fontFamily: resolveFontFamily(style?.fontFamily ?? null, fallback.fontFamily),
+    fontSize: resolveFontSize(style?.fontSize ?? null, fallback.fontSize),
+    textColor: resolveColor(style?.textColor ?? null, fallback.textColor),
+  };
+};
+
 export const DEFAULT_SITE_CONTENT: SiteContent = {
   navigation: {
     brand: 'OUIOUITACOS',
@@ -40,6 +158,7 @@ export const DEFAULT_SITE_CONTENT: SiteContent = {
       contact: 'Contact',
       loginCta: 'Staff Login',
     },
+    style: DEFAULT_NAVIGATION_STYLE,
   },
   hero: {
     title: 'Le Goût Authentique du Mexique',
@@ -49,18 +168,21 @@ export const DEFAULT_SITE_CONTENT: SiteContent = {
     backgroundImage: 'https://picsum.photos/seed/tacosbg/1920/1080',
     historyTitle: 'Vos dernières commandes',
     reorderCtaLabel: 'Commander à nouveau',
+    style: DEFAULT_HERO_STYLE,
   },
   about: {
     title: 'Notre Histoire',
     description:
       "Fondé par des passionnés de la cuisine mexicaine, OUIOUITACOS est né d'un désir simple : partager le goût authentique des tacos faits maison. Chaque recette est un héritage familial, chaque ingrédient est choisi avec soin, et chaque plat est préparé avec le cœur. Venez découvrir une explosion de saveurs qui vous transportera directement dans les rues de Mexico.",
     image: null,
+    style: DEFAULT_ABOUT_STYLE,
   },
   menu: {
     title: 'Nos Best-sellers',
     ctaLabel: 'Voir le menu complet & Commander',
     loadingLabel: 'Chargement du menu...',
     image: null,
+    style: DEFAULT_MENU_STYLE,
   },
   contact: {
     title: 'Contactez-nous',
@@ -71,9 +193,11 @@ export const DEFAULT_SITE_CONTENT: SiteContent = {
     emailLabel: 'Email',
     email: 'contact@ouiouitacos.fr',
     image: null,
+    style: DEFAULT_CONTACT_STYLE,
   },
   footer: {
     text: 'Tous droits réservés.',
+    style: DEFAULT_FOOTER_STYLE,
   },
 };
 
@@ -89,6 +213,7 @@ export const resolveSiteContent = (content?: Partial<SiteContent> | null): SiteC
         contact: resolveString(content?.navigation?.links?.contact, base.navigation.links.contact),
         loginCta: resolveString(content?.navigation?.links?.loginCta, base.navigation.links.loginCta),
       },
+      style: resolveSectionStyle(content?.navigation?.style, base.navigation.style),
     },
     hero: {
       title: resolveString(content?.hero?.title, base.hero.title),
@@ -97,17 +222,20 @@ export const resolveSiteContent = (content?: Partial<SiteContent> | null): SiteC
       backgroundImage: resolveImage(content?.hero?.backgroundImage, base.hero.backgroundImage),
       historyTitle: resolveString(content?.hero?.historyTitle, base.hero.historyTitle),
       reorderCtaLabel: resolveString(content?.hero?.reorderCtaLabel, base.hero.reorderCtaLabel),
+      style: resolveSectionStyle(content?.hero?.style, base.hero.style),
     },
     about: {
       title: resolveString(content?.about?.title, base.about.title),
       description: resolveString(content?.about?.description, base.about.description),
       image: resolveImage(content?.about?.image, base.about.image),
+      style: resolveSectionStyle(content?.about?.style, base.about.style),
     },
     menu: {
       title: resolveString(content?.menu?.title, base.menu.title),
       ctaLabel: resolveString(content?.menu?.ctaLabel, base.menu.ctaLabel),
       loadingLabel: resolveString(content?.menu?.loadingLabel, base.menu.loadingLabel),
       image: resolveImage(content?.menu?.image, base.menu.image),
+      style: resolveSectionStyle(content?.menu?.style, base.menu.style),
     },
     contact: {
       title: resolveString(content?.contact?.title, base.contact.title),
@@ -118,9 +246,11 @@ export const resolveSiteContent = (content?: Partial<SiteContent> | null): SiteC
       emailLabel: resolveString(content?.contact?.emailLabel, base.contact.emailLabel),
       email: resolveString(content?.contact?.email, base.contact.email),
       image: resolveImage(content?.contact?.image, base.contact.image),
+      style: resolveSectionStyle(content?.contact?.style, base.contact.style),
     },
     footer: {
       text: resolveString(content?.footer?.text, base.footer.text),
+      style: resolveSectionStyle(content?.footer?.style, base.footer.style),
     },
   };
 };
@@ -135,6 +265,7 @@ export const sanitizeSiteContentInput = (content: SiteContent): SiteContent => (
       contact: trimOrEmpty(content.navigation.links.contact),
       loginCta: trimOrEmpty(content.navigation.links.loginCta),
     },
+    style: sanitizeSectionStyle(content.navigation.style, DEFAULT_NAVIGATION_STYLE),
   },
   hero: {
     title: trimOrEmpty(content.hero.title),
@@ -143,17 +274,20 @@ export const sanitizeSiteContentInput = (content: SiteContent): SiteContent => (
     backgroundImage: sanitizeImage(content.hero.backgroundImage),
     historyTitle: trimOrEmpty(content.hero.historyTitle),
     reorderCtaLabel: trimOrEmpty(content.hero.reorderCtaLabel),
+    style: sanitizeSectionStyle(content.hero.style, DEFAULT_HERO_STYLE),
   },
   about: {
     title: trimOrEmpty(content.about.title),
     description: trimOrEmpty(content.about.description),
     image: sanitizeImage(content.about.image),
+    style: sanitizeSectionStyle(content.about.style, DEFAULT_ABOUT_STYLE),
   },
   menu: {
     title: trimOrEmpty(content.menu.title),
     ctaLabel: trimOrEmpty(content.menu.ctaLabel),
     loadingLabel: trimOrEmpty(content.menu.loadingLabel),
     image: sanitizeImage(content.menu.image),
+    style: sanitizeSectionStyle(content.menu.style, DEFAULT_MENU_STYLE),
   },
   contact: {
     title: trimOrEmpty(content.contact.title),
@@ -164,8 +298,10 @@ export const sanitizeSiteContentInput = (content: SiteContent): SiteContent => (
     emailLabel: trimOrEmpty(content.contact.emailLabel),
     email: trimOrEmpty(content.contact.email),
     image: sanitizeImage(content.contact.image),
+    style: sanitizeSectionStyle(content.contact.style, DEFAULT_CONTACT_STYLE),
   },
   footer: {
     text: trimOrEmpty(content.footer.text),
+    style: sanitizeSectionStyle(content.footer.style, DEFAULT_FOOTER_STYLE),
   },
 });

--- a/utils/siteStyleHelpers.ts
+++ b/utils/siteStyleHelpers.ts
@@ -1,0 +1,59 @@
+import { CSSProperties } from 'react';
+import { SectionStyle } from '../types';
+
+export const createBackgroundStyle = (style: SectionStyle): CSSProperties => {
+  if (style.background.type === 'image' && style.background.image) {
+    return {
+      backgroundImage: `url('${style.background.image}')`,
+      backgroundSize: 'cover',
+      backgroundPosition: 'center',
+      backgroundRepeat: 'no-repeat',
+      backgroundColor: style.background.color,
+    };
+  }
+
+  return { backgroundColor: style.background.color };
+};
+
+export const createHeroBackgroundStyle = (
+  style: SectionStyle,
+  fallbackImage: string | null,
+): CSSProperties => {
+  const base = createBackgroundStyle(style);
+
+  if (style.background.type === 'image') {
+    const image = style.background.image ?? fallbackImage;
+    if (image) {
+      return {
+        ...base,
+        backgroundImage: `url('${image}')`,
+        backgroundSize: 'cover',
+        backgroundPosition: 'center',
+        backgroundRepeat: 'no-repeat',
+      };
+    }
+    return base;
+  }
+
+  if (fallbackImage) {
+    return {
+      ...base,
+      backgroundImage: `url('${fallbackImage}')`,
+      backgroundSize: 'cover',
+      backgroundPosition: 'center',
+      backgroundRepeat: 'no-repeat',
+    };
+  }
+
+  return base;
+};
+
+export const createTextStyle = (style: SectionStyle): CSSProperties => ({
+  color: style.textColor,
+  fontFamily: style.fontFamily,
+});
+
+export const createBodyTextStyle = (style: SectionStyle): CSSProperties => ({
+  ...createTextStyle(style),
+  fontSize: style.fontSize,
+});


### PR DESCRIPTION
## Summary
- extend the site content schema with reusable section style metadata and robust defaults/sanitization for fonts, colors and backgrounds
- expose comprehensive styling controls in the customization modals, including color pickers, font selectors and Cloudinary-backed background management
- render the selected styles across the preview canvas and live login page through shared helpers for backgrounds, typography and section theming

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68db04f8b6e8832a9ab66a243b019062