### PR TITLE
Translate UI strings to Spanish and localize date formats

### DIFF
--- a/components/PaymentModal.tsx
+++ b/components/PaymentModal.tsx
@@ -26,32 +26,32 @@ const PaymentModal: React.FC<PaymentModalProps> = ({ isOpen, onClose, order, onF
   };
 
   return (
-    <Modal isOpen={isOpen} onClose={onClose} title={`Finaliser la commande #${order.id.slice(-4)}`}>
+    <Modal isOpen={isOpen} onClose={onClose} title={`Finalizar el pedido #${order.id.slice(-4)}`}>
       <form onSubmit={handleSubmit} className="space-y-6">
         <div className="text-center">
-          <p className="text-gray-600">Total à payer</p>
+          <p className="text-gray-600">Total a pagar</p>
           <p className="text-4xl font-extrabold text-gray-900">{formatIntegerAmount(order.total)} €</p>
         </div>
 
         <div>
-          <label className="block text-sm font-medium text-gray-700">Méthode de paiement</label>
+          <label className="block text-sm font-medium text-gray-700">Método de pago</label>
           <select
             value={paymentMethod}
             onChange={e => setPaymentMethod(e.target.value as Order['payment_method'])}
             className="mt-1 ui-select"
           >
-            <option value="efectivo">Efectivo (Espèces)</option>
-            <option value="transferencia">Transferencia (Virement)</option>
-            <option value="tarjeta">Tarjeta (Carte)</option>
+            <option value="efectivo">Efectivo</option>
+            <option value="transferencia">Transferencia</option>
+            <option value="tarjeta">Tarjeta</option>
           </select>
         </div>
 
         {paymentMethod === 'transferencia' && (
           <div>
-            <label className="block text-sm font-medium text-gray-700">Justificatif (optionnel)</label>
+            <label className="block text-sm font-medium text-gray-700">Comprobante (opcional)</label>
             <label htmlFor="payment-receipt" className="mt-1 flex w-full cursor-pointer items-center gap-2 rounded-lg border border-gray-300 bg-white p-2 text-gray-500 shadow-sm hover:bg-gray-50">
               <Upload size={18} />
-              <span>{receiptFile ? receiptFile.name : 'Choisir un fichier...'}</span>
+              <span>{receiptFile ? receiptFile.name : 'Selecciona un archivo...'}</span>
             </label>
             <input id="payment-receipt" type="file" accept="image/*,.pdf" onChange={e => setReceiptFile(e.target.files ? e.target.files[0] : null)} className="hidden" />
           </div>
@@ -59,10 +59,10 @@ const PaymentModal: React.FC<PaymentModalProps> = ({ isOpen, onClose, order, onF
 
         <div className="pt-4 flex flex-col sm:flex-row gap-3">
           <button type="button" onClick={onClose} className="w-full ui-btn-secondary py-3">
-            Annuler
+            Cancelar
           </button>
           <button type="submit" disabled={isSubmitting} className="w-full ui-btn-success py-3 disabled:opacity-60">
-            {isSubmitting ? 'Finalisation...' : 'Confirmer Paiement'}
+            {isSubmitting ? 'Finalizando...' : 'Confirmar pago'}
           </button>
         </div>
       </form>

--- a/components/ReportModal.tsx
+++ b/components/ReportModal.tsx
@@ -31,9 +31,9 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
                     const data = await api.generateDailyReport();
                     setReport(data);
                 } catch (error) {
-                    console.error('Échec de la génération du rapport quotidien', error);
+                    console.error('Error al generar el informe diario', error);
                     setReport(null);
-                    setReportError("Impossible de générer le rapport quotidien. Veuillez réessayer plus tard.");
+                    setReportError('No fue posible generar el informe diario. Intenta nuevamente más tarde.');
                 } finally {
                     setLoading(false);
                 }
@@ -45,7 +45,7 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
     const formatLoginsByRole = (logins: RoleLogin[]) => {
         const grouped = new Map<string, string[]>();
         logins.forEach(login => {
-            const time = new Date(login.loginAt).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+            const time = new Date(login.loginAt).toLocaleTimeString('es-CO', { hour: '2-digit', minute: '2-digit' });
             const existing = grouped.get(login.roleName) ?? [];
             existing.push(time);
             grouped.set(login.roleName, existing);
@@ -55,20 +55,20 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
 
     const formatReportForWhatsApp = (reportData: DailyReport): string => {
         const parts: string[] = [];
-        parts.push(`*RAPPORT OUIOUITACOS*`);
-        parts.push(`Généré le: ${new Date(reportData.generatedAt).toLocaleString('fr-FR')}`);
-        parts.push(`Période: depuis le ${new Date(reportData.startDate).toLocaleString('fr-FR')}`);
+        parts.push(`*REPORTE OUIOUITACOS*`);
+        parts.push(`Generado el: ${new Date(reportData.generatedAt).toLocaleString('es-CO')}`);
+        parts.push(`Periodo: desde ${new Date(reportData.startDate).toLocaleString('es-CO')}`);
         parts.push('---');
-    
-        parts.push(`*Statistiques du Jour*`);
-        parts.push(`- Ventes: *${formatIntegerAmount(reportData.ventesDuJour)} €*`);
-        parts.push(`- Clients: *${reportData.clientsDuJour}*`);
-        parts.push(`- Panier Moyen: *${formatIntegerAmount(reportData.panierMoyen)} €*`);
+
+        parts.push(`*Estadísticas del día*`);
+        parts.push(`- Ventas: *${formatIntegerAmount(reportData.ventesDuJour)} €*`);
+        parts.push(`- Clientes: *${reportData.clientsDuJour}*`);
+        parts.push(`- Ticket promedio: *${formatIntegerAmount(reportData.panierMoyen)} €*`);
         parts.push('---');
-    
-        parts.push(`*Produits Vendus*`);
+
+        parts.push(`*Productos vendidos*`);
         if (reportData.soldProducts.length === 0) {
-          parts.push('Aucun produit vendu.');
+          parts.push('Ningún producto vendido.');
         } else {
           reportData.soldProducts.forEach(category => {
             parts.push(`\n_${category.categoryName}_`);
@@ -79,13 +79,13 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
         }
         parts.push('---');
 
-        parts.push(`*Connexions depuis 05h00*`);
+        parts.push(`*Inicios de sesión desde las 05:00*`);
         if (reportData.roleLoginsUnavailable) {
-          parts.push('Connexions indisponibles sur cet appareil.');
+          parts.push('Inicios de sesión no disponibles en este dispositivo.');
         } else {
           const groupedLogins = formatLoginsByRole(reportData.roleLogins);
           if (groupedLogins.size === 0) {
-            parts.push('Aucune connexion enregistrée.');
+            parts.push('No hay inicios de sesión registrados.');
           } else {
             groupedLogins.forEach((times, roleName) => {
               parts.push(`- ${roleName}: ${times.join(', ')}`);
@@ -94,9 +94,9 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
         }
         parts.push('---');
 
-        parts.push(`*Stocks Bas*`);
+        parts.push(`*Inventario bajo*`);
         if (reportData.lowStockIngredients.length === 0) {
-          parts.push('Aucun ingrédient en stock bas.');
+          parts.push('No hay ingredientes con inventario bajo.');
         } else {
           reportData.lowStockIngredients.forEach(ing => {
             parts.push(`- ${ing.nom} (${ing.stock_actuel} / ${ing.stock_minimum} ${ing.unite})`);
@@ -115,17 +115,17 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
     };
 
     return (
-        <Modal isOpen={isOpen} onClose={onClose} title="Rapport Quotidien" size="xl">
+        <Modal isOpen={isOpen} onClose={onClose} title="Reporte diario" size="xl">
             <>
                 <div className="p-6 max-h-[70vh] overflow-y-auto">
-                     {loading && <p>Génération du rapport...</p>}
+                     {loading && <p>Generando el reporte...</p>}
                      {!loading && reportError && (
                         <div className="mb-4 rounded-md border border-red-200 bg-red-50 p-3 text-sm text-red-700">
                             {reportError}
                         </div>
                      )}
                      {!loading && !report && !reportError && (
-                        <p className="text-red-500">Impossible de générer le rapport.</p>
+                        <p className="text-red-500">No fue posible generar el reporte.</p>
                      )}
                      {!loading && report && (
                          <div className="space-y-6">
@@ -133,28 +133,28 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
                                 <div className="rounded-md border border-yellow-200 bg-yellow-50 p-3 text-sm text-yellow-800 flex items-start gap-2">
                                     <AlertTriangle className="mt-0.5 h-4 w-4" />
                                     <span>
-                                        Les connexions des rôles sont indisponibles sur cet appareil (stockage local inaccessible).
+                                        Los inicios de sesión de los roles no están disponibles en este dispositivo (almacenamiento local inaccesible).
                                     </span>
                                 </div>
                             )}
                             <div className="text-center border-b pb-4">
-                                 <h2 className="font-bold text-brand-secondary text-[clamp(1.75rem,4vw,2.75rem)]">Rapport OUIOUITACOS</h2>
+                                 <h2 className="font-bold text-brand-secondary text-[clamp(1.75rem,4vw,2.75rem)]">Reporte OUIOUITACOS</h2>
                                  <p className="text-gray-500">
-                                     Généré le {new Date(report.generatedAt).toLocaleString('fr-FR')}
+                                     Generado el {new Date(report.generatedAt).toLocaleString('es-CO')}
                                  </p>
                                  <p className="text-sm text-gray-500">
-                                     Données depuis le {new Date(report.startDate).toLocaleString('fr-FR')}
+                                     Datos desde {new Date(report.startDate).toLocaleString('es-CO')}
                                  </p>
                             </div>
-                            
+
                             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-                                <ReportStat icon={<DollarSign/>} label="Ventes du Jour" value={`${formatIntegerAmount(report.ventesDuJour)} €`} />
-                                <ReportStat icon={<Users/>} label="Clients du Jour" value={report.clientsDuJour} />
-                                <ReportStat icon={<ShoppingCart/>} label="Panier Moyen" value={`${formatIntegerAmount(report.panierMoyen)} €`} />
+                                <ReportStat icon={<DollarSign/>} label="Ventas del día" value={`${formatIntegerAmount(report.ventesDuJour)} €`} />
+                                <ReportStat icon={<Users/>} label="Clientes del día" value={report.clientsDuJour} />
+                                <ReportStat icon={<ShoppingCart/>} label="Ticket promedio" value={`${formatIntegerAmount(report.panierMoyen)} €`} />
                             </div>
 
                             <div>
-                                <h3 className="text-xl font-semibold mb-3 flex items-center gap-2 text-gray-800"><Package/> Produits Vendus</h3>
+                                <h3 className="text-xl font-semibold mb-3 flex items-center gap-2 text-gray-800"><Package/> Productos vendidos</h3>
                                 <div className="space-y-4">
                                     {report.soldProducts.map(category => (
                                         <div key={category.categoryName}>
@@ -172,14 +172,14 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
                             </div>
 
                             <div>
-                                <h3 className="text-xl font-semibold mb-3 flex items-center gap-2 text-gray-800"><LogIn/> Connexions depuis 05h00</h3>
+                                <h3 className="text-xl font-semibold mb-3 flex items-center gap-2 text-gray-800"><LogIn/> Inicios de sesión desde las 05:00</h3>
                                 {report.roleLoginsUnavailable ? (
-                                    <p className="text-gray-500">Connexions indisponibles : impossible d'accéder au stockage local.</p>
+                                    <p className="text-gray-500">Inicios de sesión no disponibles: no es posible acceder al almacenamiento local.</p>
                                 ) : (
                                     (() => {
                                         const grouped = formatLoginsByRole(report.roleLogins);
                                         if (grouped.size === 0) {
-                                            return <p className="text-gray-500">Aucune connexion enregistrée depuis 05h00.</p>;
+                                            return <p className="text-gray-500">No hay inicios de sesión registrados desde las 05:00.</p>;
                                         }
                                         return (
                                             <ul className="space-y-2">
@@ -196,7 +196,7 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
                             </div>
 
                             <div>
-                                 <h3 className="text-xl font-semibold mb-3 flex items-center gap-2 text-gray-800"><AlertTriangle className="text-orange-500"/> Ingrédients en Stock Bas</h3>
+                                 <h3 className="text-xl font-semibold mb-3 flex items-center gap-2 text-gray-800"><AlertTriangle className="text-orange-500"/> Ingredientes con inventario bajo</h3>
                                  {report.lowStockIngredients.length > 0 ? (
                                     <ul className="space-y-1">
                                         {report.lowStockIngredients.map(ing => (
@@ -207,7 +207,7 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
                                         ))}
                                     </ul>
                                  ) : (
-                                    <p className="text-gray-500">Aucun ingrédient en stock bas.</p>
+                                    <p className="text-gray-500">No hay ingredientes con inventario bajo.</p>
                                  )}
                             </div>
                          </div>
@@ -216,14 +216,14 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
 
                 <div className="flex flex-col sm:flex-row justify-end gap-3 p-4 border-t">
                     <button onClick={onClose} className="w-full sm:w-auto bg-gray-200 text-gray-800 font-bold py-3 px-4 rounded-lg hover:bg-gray-300 transition">
-                        Fermer
+                        Cerrar
                     </button>
-                    <button 
-                        onClick={handleSendToWhatsApp} 
-                        disabled={loading || !report} 
+                    <button
+                        onClick={handleSendToWhatsApp}
+                        disabled={loading || !report}
                         className="w-full sm:w-auto bg-green-500 text-white font-bold py-3 px-4 rounded-lg hover:bg-green-600 transition flex items-center justify-center gap-2 disabled:bg-gray-400"
                     >
-                        <MessageSquare size={20}/> Envoyer sur WhatsApp
+                        <MessageSquare size={20}/> Enviar por WhatsApp
                     </button>
                 </div>
             </>

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -112,11 +112,11 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, notifications, onRep
         className={`app-sidebar fixed inset-y-0 left-0 z-50 flex w-72 flex-col transition-transform duration-300 ease-in-out md:static md:z-auto md:w-64 md:translate-x-0 ${
           isOpen ? 'translate-x-0' : '-translate-x-full md:translate-x-0'
         }`}
-        aria-label="Navigation principale"
+        aria-label="Navegación principal"
       >
         <div className="app-sidebar__header">
           <span className="app-sidebar__brand">OUIOUI</span>
-          <button onClick={onClose} className="app-sidebar__close md:hidden" aria-label="Fermer le menu">
+          <button onClick={onClose} className="app-sidebar__close md:hidden" aria-label="Cerrar el menú">
             <X size={20} />
           </button>
         </div>
@@ -134,7 +134,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, notifications, onRep
                         {notifications.pendingTakeaway > 0 && (
                           <span
                             className="app-sidebar__badge app-sidebar__badge--danger"
-                            title={`${notifications.pendingTakeaway} à valider`}
+                            title={`${notifications.pendingTakeaway} por validar`}
                           >
                             {notifications.pendingTakeaway}
                           </span>
@@ -142,7 +142,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, notifications, onRep
                         {notifications.readyTakeaway > 0 && (
                           <span
                             className="app-sidebar__badge app-sidebar__badge--success"
-                            title={`${notifications.readyTakeaway} prête(s)`}
+                            title={`${notifications.readyTakeaway} listo(s)`}
                           >
                             {notifications.readyTakeaway}
                           </span>
@@ -154,7 +154,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, notifications, onRep
                       <span className="app-sidebar__badge-group">
                         <span
                           className="app-sidebar__badge app-sidebar__badge--danger"
-                          title={`${notifications.readyForService} commande(s) prête(s)`}
+                          title={`${notifications.readyForService} pedido(s) listo(s)`}
                         >
                           {notifications.readyForService}
                         </span>
@@ -216,11 +216,11 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, notifications, onRep
               className="app-sidebar__action"
             >
               <FileText size={22} />
-              <span className="font-semibold">Rapport</span>
+              <span className="font-semibold">Reporte</span>
             </button>
             <button onClick={handleLogout} className="app-sidebar__action app-sidebar__action--logout">
               <LogOut size={22} />
-              <span className="font-semibold">Déconnexion</span>
+              <span className="font-semibold">Cerrar sesión</span>
             </button>
           </div>
         </div>

--- a/pages/CommandeClient.tsx
+++ b/pages/CommandeClient.tsx
@@ -51,7 +51,7 @@ const ItemCustomizationModal: React.FC<ItemCustomizationModalProps> = ({ isOpen,
                 <img src={product.image} alt={product.nom_produit} className="w-full h-48 object-cover rounded-lg" />
                 <p className="text-gray-600">{product.description}</p>
                 <div>
-                    <label className="block text-sm font-medium text-gray-700">Commentaire (allergies, etc.)</label>
+                    <label className="block text-sm font-medium text-gray-700">Comentario (alergias, etc.)</label>
                     <textarea value={comment} onChange={e => setComment(e.target.value)} rows={2} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-700 bg-white" />
                 </div>
                 <div className="flex justify-between items-center">
@@ -61,7 +61,7 @@ const ItemCustomizationModal: React.FC<ItemCustomizationModalProps> = ({ isOpen,
                         <button onClick={() => setQuantity(q => q + 1)} className="p-2 rounded-full bg-gray-200 text-gray-800"><Plus size={18}/></button>
                     </div>
                     <button onClick={handleSave} className="bg-brand-primary text-brand-secondary font-bold py-2 px-6 rounded-lg hover:bg-yellow-400 transition">
-                        Ajouter ({formatIntegerAmount(product.prix_vente * quantity)} €)
+                        Añadir ({formatIntegerAmount(product.prix_vente * quantity)} €)
                     </button>
                 </div>
             </div>
@@ -81,25 +81,25 @@ interface ConfirmationModalProps {
 }
 const ConfirmationModal: React.FC<ConfirmationModalProps> = ({ isOpen, onClose, order, whatsAppMessage }) => {
     return (
-        <Modal isOpen={isOpen} onClose={onClose} title="Commande envoyée !">
+        <Modal isOpen={isOpen} onClose={onClose} title="¡Pedido enviado!">
             <div className="text-center space-y-4">
                 <CheckCircle className="mx-auto text-green-500" size={64}/>
-                <h3 className="text-xl font-bold text-gray-800">Merci pour votre commande !</h3>
+                <h3 className="text-xl font-bold text-gray-800">¡Gracias por tu pedido!</h3>
                 <p className="text-gray-600">
-                    Votre commande #{order.id.slice(-6)} a bien été reçue. 
-                    Elle est en attente de validation. Vous pouvez suivre son statut sur cette page.
+                    Tu pedido #{order.id.slice(-6)} se ha recibido correctamente.
+                    Está en espera de validación. Puedes seguir su estado en esta página.
                 </p>
                 <p className="text-gray-600">
-                    Pour finaliser, veuillez nous envoyer ce récapitulatif sur WhatsApp avec votre justificatif.
+                    Para finalizar, envíanos este resumen por WhatsApp junto con tu comprobante.
                 </p>
-                <a 
+                <a
                     href={`https://wa.me/?text=${whatsAppMessage}`}
-                    target="_blank" 
+                    target="_blank"
                     rel="noopener noreferrer"
                     onClick={onClose}
                     className="inline-flex items-center justify-center gap-2 w-full bg-green-500 text-white font-bold py-3 px-4 rounded-lg hover:bg-green-600 transition"
                 >
-                    <MessageCircle /> Envoyer sur WhatsApp
+                    <MessageCircle /> Enviar por WhatsApp
                 </a>
             </div>
         </Modal>
@@ -151,7 +151,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
             setProducts(productsData);
             setCategories(categoriesData);
         } catch (err) {
-            setError('Impossible de charger le menu. Veuillez réessayer plus tard.');
+            setError('No fue posible cargar el menú. Intenta nuevamente más tarde.');
             console.error(err);
         } finally {
             setLoading(false);
@@ -244,7 +244,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
             setPaymentProof(null);
             storeActiveCustomerOrder(newOrder.id);
         } catch (err) {
-            alert("Une erreur est survenue lors de la soumission ou du téléversement du justificatif.");
+            alert('Ocurrió un error al enviar el pedido o subir el comprobante.');
             console.error(err);
         } finally {
             setSubmitting(false);
@@ -277,7 +277,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
         setCart(updatedItems);
 
         if (missingProducts.length > 0) {
-            alert(`Certains articles ne sont plus disponibles et n'ont pas été ajoutés :\n- ${missingProducts.join('\n- ')}`);
+            alert(`Algunos artículos ya no están disponibles y no se agregaron:\n- ${missingProducts.join('\n- ')}`);
         }
 
         const cartElement = document.getElementById('cart-section');
@@ -287,29 +287,29 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
     };
     
     const generateWhatsAppMessage = (order: Order) => {
-        const header = `*Nouvelle Commande OUIOUITACOS #${order.id.slice(-6)}*`;
+        const header = `*Nuevo pedido OUIOUITACOS #${order.id.slice(-6)}*`;
         const itemLines = (order.items ?? []).map(item => {
             const baseLine = `- ${item.quantite}x ${item.nom_produit} (${formatIntegerAmount(item.prix_unitaire)}€) → ${formatIntegerAmount(item.prix_unitaire * item.quantite)}€`;
             const details: string[] = [];
             if (item.commentaire) {
-                details.push(`Commentaire: ${item.commentaire}`);
+                details.push(`Comentario: ${item.commentaire}`);
             }
             if (item.excluded_ingredients && item.excluded_ingredients.length > 0) {
-                details.push(`Sans: ${item.excluded_ingredients.join(', ')}`);
+                details.push(`Sin: ${item.excluded_ingredients.join(', ')}`);
             }
             return details.length > 0 ? `${baseLine}\n  ${details.join('\n  ')}` : baseLine;
         });
-        const items = itemLines.length > 0 ? itemLines.join('\n') : 'Aucun article';
+        const items = itemLines.length > 0 ? itemLines.join('\n') : 'Sin artículos';
         const totalValue = order.total ?? order.items.reduce((sum, item) => sum + item.prix_unitaire * item.quantite, 0);
         const totalMsg = `*Total: ${formatIntegerAmount(totalValue)}€*`;
-        const paymentMethod = order.payment_method ? `Paiement: ${order.payment_method}` : undefined;
-        const client = `Client: ${order.clientInfo?.nom} (${order.clientInfo?.telephone})\nAdresse: ${order.clientInfo?.adresse}`;
-        const footer = "Justificatif de paiement ci-joint.";
+        const paymentMethod = order.payment_method ? `Pago: ${order.payment_method}` : undefined;
+        const client = `Cliente: ${order.clientInfo?.nom} (${order.clientInfo?.telephone})\nDirección: ${order.clientInfo?.adresse}`;
+        const footer = 'Comprobante de pago adjunto.';
         const messageParts = [header, items, totalMsg, paymentMethod, client, footer].filter(Boolean);
         return encodeURIComponent(messageParts.join('\n\n'));
     };
-    
-    if (loading) return <div className="h-screen flex items-center justify-center">Chargement du menu...</div>;
+
+    if (loading) return <div className="h-screen flex items-center justify-center">Cargando el menú...</div>;
     if (error) return <div className="h-screen flex items-center justify-center text-red-500">{error}</div>;
 
     return (
@@ -319,16 +319,16 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                 <div className="lg:col-span-2">
                     {orderHistory.length > 0 && cart.length === 0 && (
                         <div className="bg-white p-4 rounded-xl shadow-md mb-8">
-                            <h2 className="text-xl font-bold flex items-center gap-2 mb-3 text-gray-700"><History /> Repasser une commande ?</h2>
+                            <h2 className="text-xl font-bold flex items-center gap-2 mb-3 text-gray-700"><History /> ¿Repetir un pedido?</h2>
                             <div className="space-y-2">
                                 {orderHistory.slice(0, 3).map(order => (
                                     <div key={order.id} className="flex justify-between items-center bg-gray-50 p-3 rounded-lg">
                                         <div>
-                                            <p className="font-semibold text-gray-700">Commande du {new Date(order.date_creation).toLocaleDateString()}</p>
-                                            <p className="text-sm text-gray-500">{order.items.length} article(s) - {formatIntegerAmount(order.total)}€</p>
+                                            <p className="font-semibold text-gray-700">Pedido del {new Date(order.date_creation).toLocaleDateString('es-CO')}</p>
+                                            <p className="text-sm text-gray-500">{order.items.length} artículo(s) - {formatIntegerAmount(order.total)}€</p>
                                         </div>
                                         <button onClick={() => handleReorder(order)} className="bg-brand-primary text-brand-secondary font-bold py-1 px-3 rounded-lg text-sm hover:bg-yellow-400">
-                                            Commander à nouveau
+                                            Volver a pedir
                                         </button>
                                     </div>
                                 ))}
@@ -339,7 +339,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                         <div className="flex space-x-2 overflow-x-auto pb-2 mb-4">
                              <button onClick={() => setActiveCategoryId('all')}
                                 className={`px-4 py-2 rounded-full font-semibold whitespace-nowrap transition ${activeCategoryId === 'all' ? 'bg-brand-primary text-brand-secondary' : 'bg-gray-200 text-gray-700'}`}>
-                                Tous
+                                Todos
                             </button>
                             {categories.map(cat => (
                                 <button key={cat.id} onClick={() => setActiveCategoryId(cat.id)}
@@ -356,7 +356,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                                     <p className="font-semibold text-sm flex-grow text-gray-700">{product.nom_produit}</p>
                                     <p className="text-xs text-gray-500 mt-1 px-1 h-10 overflow-hidden">{product.description}</p>
                                     <p className="font-bold text-gray-700 mt-1">{formatIntegerAmount(product.prix_vente)} €</p>
-                                    {product.estado !== 'disponible' && <span className="text-xs text-red-500 font-bold mt-1">Épuisé</span>}
+                                    {product.estado !== 'disponible' && <span className="text-xs text-red-500 font-bold mt-1">Agotado</span>}
                                 </div>
                             ))}
                         </div>
@@ -366,8 +366,8 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                 {/* Cart Section */}
                 <div id="cart-section" className="lg:col-span-1 mt-8 lg:mt-0 lg:sticky top-24 self-start">
                     <div className="bg-white p-4 rounded-xl shadow-md">
-                        <h2 className="text-2xl font-bold flex items-center gap-2 mb-4 text-gray-700"><ShoppingCart/> Mon Panier</h2>
-                        {cart.length === 0 ? <p className="text-gray-500">Votre panier est vide.</p> :
+                        <h2 className="text-2xl font-bold flex items-center gap-2 mb-4 text-gray-700"><ShoppingCart/> Mi carrito</h2>
+                        {cart.length === 0 ? <p className="text-gray-500">Tu carrito está vacío.</p> :
                             <div className="space-y-3 max-h-48 overflow-y-auto pr-2">
                                 {cart.map(item => (
                                     <div key={item.id} className="flex justify-between items-start">
@@ -394,34 +394,34 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                         {cart.length > 0 && (
                             <form onSubmit={handleSubmitOrder} className="mt-6 space-y-4">
                                 <div>
-                                    <label className="text-sm font-medium text-gray-700">Nom Complet</label>
+                                    <label className="text-sm font-medium text-gray-700">Nombre completo</label>
                                     <input type="text" required value={clientInfo.nom} onChange={e => setClientInfo({...clientInfo, nom: e.target.value})} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-700 bg-white"/>
                                 </div>
                                 <div>
-                                    <label className="text-sm font-medium text-gray-700">Adresse de livraison</label>
+                                    <label className="text-sm font-medium text-gray-700">Dirección de entrega</label>
                                     <input type="text" required value={clientInfo.adresse} onChange={e => setClientInfo({...clientInfo, adresse: e.target.value})} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-700 bg-white"/>
                                 </div>
                                 <div>
-                                    <label className="text-sm font-medium text-gray-700">Numéro de Téléphone</label>
+                                    <label className="text-sm font-medium text-gray-700">Número de teléfono</label>
                                     <input type="tel" required value={clientInfo.telephone} onChange={e => setClientInfo({...clientInfo, telephone: e.target.value})} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-700 bg-white"/>
                                 </div>
                                 <div>
-                                    <label className="text-sm font-medium text-gray-700">Méthode de Paiement</label>
+                                    <label className="text-sm font-medium text-gray-700">Método de pago</label>
                                     <select required className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary bg-white text-gray-700">
                                         <option value="transferencia">Transferencia</option>
-                                        <option value="efectivo" disabled>Efectivo - non disponible</option>
+                                        <option value="efectivo" disabled>Efectivo - no disponible</option>
                                     </select>
                                 </div>
                                 <div>
-                                    <label className="block text-sm font-medium text-gray-700">Justificatif de virement</label>
+                                    <label className="block text-sm font-medium text-gray-700">Comprobante de transferencia</label>
                                     <label htmlFor="payment-proof-upload" className="mt-1 w-full border border-gray-300 p-2 rounded-md shadow-sm flex items-center gap-2 cursor-pointer bg-white text-gray-500">
                                         <Upload size={18} />
-                                        <span>{paymentProof ? paymentProof.name : 'Choisir un fichier...'}</span>
+                                        <span>{paymentProof ? paymentProof.name : 'Selecciona un archivo...'}</span>
                                     </label>
                                     <input id="payment-proof-upload" type="file" required accept="image/*,.pdf" onChange={e => setPaymentProof(e.target.files ? e.target.files[0] : null)} className="hidden" />
                                 </div>
                                 <button type="submit" disabled={!clientInfo.nom || !clientInfo.telephone || !clientInfo.adresse || !paymentProof || submitting} className="w-full bg-brand-accent text-white font-bold py-3 rounded-lg text-lg hover:bg-red-700 transition disabled:bg-gray-400">
-                                    {submitting ? 'Envoi...' : `Soumettre la Commande (${formatIntegerAmount(total)} €)`}
+                                    {submitting ? 'Enviando...' : `Enviar el pedido (${formatIntegerAmount(total)} €)`}
                                 </button>
                             </form>
                         )}
@@ -480,7 +480,7 @@ const CommandeClient: React.FC = () => {
                 <div className="container mx-auto flex justify-between items-center">
                     <h1 className="text-2xl font-bold text-brand-primary">OUIOUITACOS</h1>
                     <button onClick={() => navigate('/login')} className="flex items-center gap-2 text-sm text-gray-600 hover:text-brand-primary transition">
-                        <ArrowLeft size={16}/> Retour à l'accueil
+                        <ArrowLeft size={16}/> Volver al inicio
                     </button>
                 </div>
             </header>

--- a/pages/Cuisine.tsx
+++ b/pages/Cuisine.tsx
@@ -54,14 +54,14 @@ const KitchenTicketCard: React.FC<{ order: KitchenTicketOrder; onReady: (orderId
     }, [order.items]);
 
     const sentAt = new Date(order.date_envoi_cuisine || Date.now());
-    const sentAtFormatted = sentAt.toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' });
+    const sentAtFormatted = sentAt.toLocaleTimeString('es-CO', { hour: '2-digit', minute: '2-digit' });
 
     return (
         <div className={`flex h-full flex-col overflow-hidden rounded-xl bg-white text-gray-900 shadow-lg transition-shadow duration-300 hover:shadow-xl ${urgencyStyles.border}`}>
             <header className="border-b border-gray-200 px-5 pt-5 pb-4">
                 <div className="flex w-full flex-col gap-4">
                     <h3 className="w-full text-center text-3xl font-semibold text-gray-900 sm:text-left sm:text-4xl">
-                        {order.table_nom || `À emporter #${order.id.slice(-4)}`}
+                        {order.table_nom || `Para llevar #${order.id.slice(-4)}`}
                     </h3>
                     <OrderTimer
                         startTime={order.date_envoi_cuisine || Date.now()}
@@ -86,7 +86,7 @@ const KitchenTicketCard: React.FC<{ order: KitchenTicketOrder; onReady: (orderId
             <footer className="border-t border-gray-200 px-5 pb-5 pt-4">
                 <div className="flex w-full flex-col gap-3">
                     <p className="text-xs text-gray-500">
-                        Envoyé {sentAtFormatted}
+                        Enviado {sentAtFormatted}
                     </p>
                     {canMarkReady && (
                         <button
@@ -94,7 +94,7 @@ const KitchenTicketCard: React.FC<{ order: KitchenTicketOrder; onReady: (orderId
                             className="group inline-flex w-full items-center justify-center gap-3 rounded-lg border-2 border-transparent bg-black px-4 py-3 text-lg font-semibold uppercase tracking-[0.2em] text-white shadow-sm transition focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/70 focus-visible:ring-offset-2 hover:bg-neutral-900"
                         >
                             <ChefHat size={22} className="shrink-0" />
-                            <span>PRÊT</span>
+                            <span>LISTO</span>
                         </button>
                     )}
                 </div>
@@ -152,12 +152,12 @@ const Cuisine: React.FC = () => {
     };
 
     // FIX: Use the 'loading' state variable that is defined within the component.
-    if (loading) return <div className="text-gray-700">Chargement des commandes pour la cuisine...</div>;
+    if (loading) return <div className="text-gray-700">Cargando pedidos de cocina...</div>;
 
     return (
         <div className="flex h-full flex-col">
             {orders.length === 0 ? (
-                <div className="mt-6 flex flex-1 items-center justify-center text-2xl text-gray-500">Aucune commande en préparation.</div>
+                <div className="mt-6 flex flex-1 items-center justify-center text-2xl text-gray-500">No hay pedidos en preparación.</div>
             ) : (
                 <div className="mt-6 grid flex-1 grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
                     {orders.map(order => (

--- a/pages/Dashboard.tsx
+++ b/pages/Dashboard.tsx
@@ -33,8 +33,8 @@ const OpStatCard: React.FC<{ title: string; value: string | number; icon: React.
 
 
 const PERIOD_CONFIG: Record<DashboardPeriod, { label: string; days: number }> = {
-    week: { label: '7 derniers jours', days: 7 },
-    month: { label: '30 derniers jours', days: 30 },
+    week: { label: 'Últimos 7 días', days: 7 },
+    month: { label: 'Últimos 30 días', days: 30 },
 };
 
 const resolvePeriodBounds = (period: DashboardPeriod) => {
@@ -77,8 +77,8 @@ const Dashboard: React.FC = () => {
         fetchAllStats();
     }, [period]);
 
-    if (loading) return <div className="text-gray-800">Chargement des données du dashboard...</div>;
-    if (!stats) return <div className="text-red-500">Impossible de charger les données.</div>;
+    if (loading) return <div className="text-gray-800">Cargando datos del panel...</div>;
+    if (!stats) return <div className="text-red-500">No fue posible cargar los datos.</div>;
 
     const PIE_COLORS = ['#0088FE', '#00C49F', '#FFBB28', '#FF8042', '#AF19FF', '#FF4560', '#775DD0'];
     const pieData = pieChartMode === 'category' ? stats.ventesParCategorie : salesByProduct;
@@ -107,26 +107,26 @@ const Dashboard: React.FC = () => {
                     className="ui-btn-primary"
                 >
                     <Shield className="mr-2 h-4 w-4" />
-                    Gestion des rôles
+                    Gestión de roles
                 </button>
             </div>
 
             {/* Block 1: Key Indicators */}
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-                <MainStatCard title={`Ventes (${stats.periodLabel})`} value={`${formatIntegerAmount(stats.ventesPeriode)} €`} icon={<DollarSign size={28}/>} />
-                <MainStatCard title={`Bénéfice (${stats.periodLabel})`} value={`${formatIntegerAmount(stats.beneficePeriode)} €`} icon={<DollarSign size={28}/>} />
-                <MainStatCard title={`Clients (${stats.periodLabel})`} value={stats.clientsPeriode.toString()} icon={<Users size={28}/>} />
-                <MainStatCard title="Panier Moyen" value={`${formatIntegerAmount(stats.panierMoyen)} €`} icon={<BarChart2 size={28}/>} />
+                <MainStatCard title={`Ventas (${stats.periodLabel})`} value={`${formatIntegerAmount(stats.ventesPeriode)} €`} icon={<DollarSign size={28}/>} />
+                <MainStatCard title={`Beneficio (${stats.periodLabel})`} value={`${formatIntegerAmount(stats.beneficePeriode)} €`} icon={<DollarSign size={28}/>} />
+                <MainStatCard title={`Clientes (${stats.periodLabel})`} value={stats.clientsPeriode.toString()} icon={<Users size={28}/>} />
+                <MainStatCard title="Ticket promedio" value={`${formatIntegerAmount(stats.panierMoyen)} €`} icon={<BarChart2 size={28}/>} />
             </div>
 
             {/* Block 2: Operational Status */}
              <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-                <OpStatCard title="Tables Occupées" value={stats.tablesOccupees} icon={<Armchair size={24}/>} />
-                <OpStatCard title="Clients Actuels" value={stats.clientsActuels} icon={<Users size={24}/>} />
-                <OpStatCard title="En Cuisine" value={stats.commandesEnCuisine} icon={<Soup size={24}/>} />
+                <OpStatCard title="Mesas ocupadas" value={stats.tablesOccupees} icon={<Armchair size={24}/>} />
+                <OpStatCard title="Clientes actuales" value={stats.clientsActuels} icon={<Users size={24}/>} />
+                <OpStatCard title="En cocina" value={stats.commandesEnCuisine} icon={<Soup size={24}/>} />
                 <OpStatCard
-                    title="Ingrédients Bas" 
-                    value={stats.ingredientsStockBas.length} 
+                    title="Ingredientes bajos"
+                    value={stats.ingredientsStockBas.length}
                     icon={<AlertTriangle size={24} className={stats.ingredientsStockBas.length > 0 ? 'text-red-500' : 'text-gray-600'} />}
                     onClick={() => setLowStockModalOpen(true)}
                 />
@@ -134,7 +134,7 @@ const Dashboard: React.FC = () => {
 
             {/* Block 3: Sales Chart */}
             <div className="ui-card p-6">
-                <h3 className="text-lg font-semibold mb-4 text-gray-900">Ventes sur {stats.periodLabel}</h3>
+                <h3 className="text-lg font-semibold mb-4 text-gray-900">Ventas durante {stats.periodLabel}</h3>
                 <ResponsiveContainer width="100%" height={300}>
                     <BarChart data={stats.ventesPeriodeSeries}>
                         <CartesianGrid strokeDasharray="3 3" />
@@ -143,18 +143,18 @@ const Dashboard: React.FC = () => {
                         <Tooltip />
                         <Legend />
                         <Bar dataKey="ventes" fill="#8884d8" name={`${stats.periodLabel} (€)`} />
-                        <Bar dataKey="ventesPeriodePrecedente" fill="#d8d6f5" name="Période précédente (€)" />
+                        <Bar dataKey="ventesPeriodePrecedente" fill="#d8d6f5" name="Periodo anterior (€)" />
                     </BarChart>
                 </ResponsiveContainer>
             </div>
-            
+
             {/* Block 4: Sales Pie Chart */}
             <div className="ui-card p-6">
                 <div className="flex justify-between items-center mb-4">
-                    <h3 className="text-lg font-semibold text-gray-900">Répartition des Ventes ({stats.periodLabel})</h3>
+                    <h3 className="text-lg font-semibold text-gray-900">Distribución de ventas ({stats.periodLabel})</h3>
                     <div className="flex p-1 bg-gray-200 rounded-lg">
-                        <button onClick={() => setPieChartMode('category')} className={`px-3 py-1 text-sm font-semibold rounded-md ${pieChartMode === 'category' ? 'bg-white shadow' : ''}`}>Par Catégorie</button>
-                        <button onClick={() => setPieChartMode('product')} className={`px-3 py-1 text-sm font-semibold rounded-md ${pieChartMode === 'product' ? 'bg-white shadow' : ''}`}>Par Produit</button>
+                        <button onClick={() => setPieChartMode('category')} className={`px-3 py-1 text-sm font-semibold rounded-md ${pieChartMode === 'category' ? 'bg-white shadow' : ''}`}>Por categoría</button>
+                        <button onClick={() => setPieChartMode('product')} className={`px-3 py-1 text-sm font-semibold rounded-md ${pieChartMode === 'product' ? 'bg-white shadow' : ''}`}>Por producto</button>
                     </div>
                 </div>
                 {hasPieData ? (
@@ -169,12 +169,12 @@ const Dashboard: React.FC = () => {
                     </ResponsiveContainer>
                 ) : (
                     <div style={{ height: 300 }} className="flex items-center justify-center text-gray-500">
-                        Aucune donnée pour la période sélectionnée.
+                        No hay datos para el periodo seleccionado.
                     </div>
                 )}
             </div>
 
-            <Modal isOpen={isLowStockModalOpen} onClose={() => setLowStockModalOpen(false)} title="Ingrédients en Stock Bas">
+            <Modal isOpen={isLowStockModalOpen} onClose={() => setLowStockModalOpen(false)} title="Ingredientes con inventario bajo">
                 {stats.ingredientsStockBas.length > 0 ? (
                     <ul className="space-y-2">
                         {stats.ingredientsStockBas.map(ing => (
@@ -185,7 +185,7 @@ const Dashboard: React.FC = () => {
                         ))}
                     </ul>
                 ) : (
-                    <p className="text-gray-600 text-center">Aucun ingrédient en stock bas pour le moment.</p>
+                    <p className="text-gray-600 text-center">No hay ingredientes con inventario bajo por el momento.</p>
                 )}
             </Modal>
 

--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -11,13 +11,13 @@ import { formatIntegerAmount } from '../utils/formatIntegerAmount';
 const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => void, onDeliver?: (orderId: string) => void, isProcessing?: boolean }> = ({ order, onValidate, onDeliver, isProcessing }) => {
     const [isReceiptModalOpen, setIsReceiptModalOpen] = useState(false);
 
-    const displayName = order.table_nom || `Commande #${order.id.slice(-6)}`;
+    const displayName = order.table_nom || `Pedido #${order.id.slice(-6)}`;
     const timerStart = order.date_envoi_cuisine || order.date_creation;
     const urgencyStyles = getOrderUrgencyStyles(timerStart);
     const urgencyLabelMap: Record<typeof urgencyStyles.level, string> = {
         normal: 'Normal',
-        warning: 'À surveiller',
-        critical: 'Critique',
+        warning: 'En seguimiento',
+        critical: 'Crítico',
     };
 
     return (
@@ -30,7 +30,7 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                             <div className="space-y-1">
                                 <h4 className="text-lg sm:text-xl md:text-2xl font-semibold leading-tight text-gray-900">{displayName}</h4>
                                 <p className="text-xs text-gray-500">
-                                    Commande envoyée {new Date(timerStart).toLocaleTimeString('fr-FR', { hour: '2-digit', minute: '2-digit' })}
+                                    Pedido enviado {new Date(timerStart).toLocaleTimeString('es-CO', { hour: '2-digit', minute: '2-digit' })}
                                 </p>
                             </div>
                             <span className={`inline-flex items-center gap-2 rounded-full px-3 py-1 text-[11px] font-semibold uppercase tracking-[0.18em] ${urgencyStyles.badge}`}>
@@ -61,7 +61,7 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                     )}
 
                     <div className="space-y-3">
-                        <h5 className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Articles</h5>
+                        <h5 className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Artículos</h5>
                         <ul className="space-y-2">
                             {order.items.map((item: OrderItem) => (
                                 <li key={item.id} className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-900 shadow-sm">
@@ -88,7 +88,7 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                                 className="w-full ui-btn ui-btn-secondary"
                                 type="button"
                             >
-                                <Eye size={16} className={urgencyStyles.icon} /> {order.receipt_url ? 'Voir le justificatif' : 'Justificatif indisponible'}
+                                <Eye size={16} className={urgencyStyles.icon} /> {order.receipt_url ? 'Ver comprobante' : 'Comprobante no disponible'}
                             </button>
                             <button
                                 onClick={() => onValidate(order.id)}
@@ -96,7 +96,7 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                                 className="w-full ui-btn ui-btn-info uppercase"
                                 type="button"
                             >
-                                {isProcessing ? 'Validation...' : 'Valider'}
+                                {isProcessing ? 'Validando...' : 'Validar'}
                             </button>
                         </div>
                     )}
@@ -107,16 +107,16 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                             className="w-full ui-btn ui-btn-success uppercase"
                             type="button"
                         >
-                            {isProcessing ? '...' : 'Entregada'}
+                            {isProcessing ? 'Procesando...' : 'Entregar'}
                         </button>
                     )}
                 </footer>
             </div>
-            <Modal isOpen={isReceiptModalOpen} onClose={() => setIsReceiptModalOpen(false)} title="Justificatif de Paiement">
+            <Modal isOpen={isReceiptModalOpen} onClose={() => setIsReceiptModalOpen(false)} title="Comprobante de pago">
                 {order.receipt_url ? (
-                    <img src={order.receipt_url} alt="Justificatif" className="w-full h-auto rounded-md" />
+                    <img src={order.receipt_url} alt="Comprobante" className="w-full h-auto rounded-md" />
                 ) : (
-                    <p>Aucun justificatif fourni.</p>
+                    <p>No se proporcionó comprobante.</p>
                 )}
             </Modal>
         </>
@@ -162,7 +162,7 @@ const ParaLlevar: React.FC = () => {
             await fetchOrders(); // Refresh immediately after action
         } catch (error: any) {
             console.error("Failed to validate order:", error);
-            alert(`Échec de la validation de la commande: ${error.message}`);
+            alert(`No se pudo validar el pedido: ${error.message}`);
         } finally {
             setProcessingOrderId(null);
         }
@@ -176,34 +176,34 @@ const ParaLlevar: React.FC = () => {
             await fetchOrders(); // Refresh immediately after action
         } catch (error) {
             console.error("Failed to mark order as delivered:", error);
-            alert("Une erreur est survenue lors de la finalisation de la commande.");
+            alert('Ocurrió un error al finalizar el pedido.');
         } finally {
             setProcessingOrderId(null);
         }
     };
 
-    if (loading) return <div className="text-gray-700">Chargement des commandes à emporter...</div>;
+    if (loading) return <div className="text-gray-700">Cargando pedidos para llevar...</div>;
 
     return (
         <div className="space-y-6">
             <div className="mt-6 grid grid-cols-1 gap-8 md:grid-cols-2">
                 {/* Column for validation */}
                 <div className="bg-gray-100 p-4 rounded-xl">
-                    <h2 className="text-lg sm:text-xl font-bold mb-4 text-center text-blue-700">En Attente de Validation ({pendingOrders.length})</h2>
+                    <h2 className="text-lg sm:text-xl font-bold mb-4 text-center text-blue-700">Pendientes de validación ({pendingOrders.length})</h2>
                     <div className="space-y-4">
                         {pendingOrders.length > 0 ? pendingOrders.map(order => (
                             <TakeawayCard key={order.id} order={order} onValidate={handleValidate} isProcessing={processingOrderId === order.id} />
-                        )) : <p className="text-center text-gray-500 py-8">Aucune commande à valider.</p>}
+                        )) : <p className="text-center text-gray-500 py-8">No hay pedidos para validar.</p>}
                     </div>
                 </div>
 
                 {/* Column for ready orders */}
                 <div className="bg-gray-100 p-4 rounded-xl">
-                    <h2 className="text-lg sm:text-xl font-bold mb-4 text-center text-green-700">Commandes Prêtes ({readyOrders.length})</h2>
+                    <h2 className="text-lg sm:text-xl font-bold mb-4 text-center text-green-700">Pedidos listos ({readyOrders.length})</h2>
                     <div className="space-y-4">
                         {readyOrders.length > 0 ? readyOrders.map(order => (
                             <TakeawayCard key={order.id} order={order} onDeliver={handleDeliver} isProcessing={processingOrderId === order.id} />
-                        )) : <p className="text-center text-gray-500 py-8">Aucune commande prête.</p>}
+                        )) : <p className="text-center text-gray-500 py-8">No hay pedidos listos.</p>}
                     </div>
                 </div>
             </div>

--- a/pages/ProtectedLayout.tsx
+++ b/pages/ProtectedLayout.tsx
@@ -68,11 +68,11 @@ const ProtectedLayout: React.FC = () => {
               type="button"
               onClick={openSidebar}
               className="app-header__menu-button md:hidden"
-              aria-label="Ouvrir le menu"
+              aria-label="Abrir el menú"
             >
               <Menu size={24} />
             </button>
-            <h1 className="app-header__title">Bienvenue, {role?.name}</h1>
+            <h1 className="app-header__title">Bienvenido, {role?.name}</h1>
             <div className="app-header__spacer md:hidden" aria-hidden="true" />
             {/* Add other header elements like user menu here */}
           </header>

--- a/pages/ResumeVentes.tsx
+++ b/pages/ResumeVentes.tsx
@@ -50,12 +50,12 @@ const ResumeVentes: React.FC = () => {
     };
 
     const exportToCSV = () => {
-        const headers = ['Date', 'Type', 'Table/Client', 'Couverts', 'Total Vente (€)', 'Bénéfice (€)', 'Méthode Paiement'];
+        const headers = ['Fecha', 'Tipo', 'Mesa/Cliente', 'Comensales', 'Venta total (€)', 'Beneficio (€)', 'Método de pago'];
         const csvRows = [
             headers.join(','),
             ...filteredOrders.map(order => [
-                new Date(order.date_creation).toLocaleString('fr-FR'),
-                order.type === 'sur_place' ? 'Sur Place' : 'À Emporter',
+                new Date(order.date_creation).toLocaleString('es-CO'),
+                order.type === 'sur_place' ? 'En el local' : 'Para llevar',
                 `"${order.type === 'sur_place' ? (order.table_nom || 'N/A') : (order.clientInfo?.nom || 'N/A')}"`,
                 order.couverts,
                 formatIntegerAmount(order.total),
@@ -69,7 +69,7 @@ const ResumeVentes: React.FC = () => {
         const url = URL.createObjectURL(blob);
         const a = document.createElement('a');
         a.href = url;
-        a.download = `resume_commandes_${new Date().toISOString().slice(0, 10)}.csv`;
+        a.download = `resumen_pedidos_${new Date().toISOString().slice(0, 10)}.csv`;
         document.body.appendChild(a);
         a.click();
         document.body.removeChild(a);
@@ -84,24 +84,24 @@ const ResumeVentes: React.FC = () => {
         }, { totalSales: 0, totalProfit: 0 });
     }, [filteredOrders]);
 
-    if (loading) return <div className="text-gray-800">Chargement du résumé des ventes...</div>;
+    if (loading) return <div className="text-gray-800">Cargando el resumen de ventas...</div>;
 
     return (
         <div className="space-y-6">
             <div className="mt-6 space-y-4 rounded-xl bg-white p-4 shadow-md">
                  <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 xl:grid-cols-4">
                      <div className="flex flex-col">
-                        <label className="text-sm font-medium text-gray-700">Date de début</label>
+                        <label className="text-sm font-medium text-gray-700">Fecha de inicio</label>
                         <input type="date" name="startDate" value={filters.startDate} onChange={handleFilterChange} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-900"/>
                     </div>
                     <div className="flex flex-col">
-                        <label className="text-sm font-medium text-gray-700">Date de fin</label>
+                        <label className="text-sm font-medium text-gray-700">Fecha de fin</label>
                         <input type="date" name="endDate" value={filters.endDate} onChange={handleFilterChange} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-900"/>
                     </div>
                     <div className="flex flex-col">
-                        <label className="text-sm font-medium text-gray-700">Méthode de paiement</label>
+                        <label className="text-sm font-medium text-gray-700">Método de pago</label>
                         <select name="paymentMethod" value={filters.paymentMethod} onChange={handleFilterChange} className="mt-1 block w-full border border-gray-300 rounded-md shadow-sm py-2 px-3 focus:outline-none focus:ring-brand-primary focus:border-brand-primary text-gray-900">
-                            <option value="all">Toutes</option>
+                            <option value="all">Todas</option>
                             <option value="efectivo">Efectivo</option>
                             <option value="transferencia">Transferencia</option>
                             <option value="tarjeta">Tarjeta</option>
@@ -119,12 +119,12 @@ const ResumeVentes: React.FC = () => {
                         <thead className="border-b">
                             <tr>
                                 <th className="p-3"></th>
-                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Date</th>
-                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Type</th>
-                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Table/Client</th>
-                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider text-right">Ventes</th>
-                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider text-right">Bénéfice</th>
-                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Paiement</th>
+                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
+                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Tipo</th>
+                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Mesa/Cliente</th>
+                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider text-right">Ventas</th>
+                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider text-right">Beneficio</th>
+                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Pago</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -134,12 +134,12 @@ const ResumeVentes: React.FC = () => {
                                         <td className="p-3">
                                             {expandedOrderId === order.id ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
                                         </td>
-                                        <td className="p-3 text-sm text-gray-700 whitespace-nowrap">{new Date(order.date_creation).toLocaleString('fr-FR')}</td>
+                                        <td className="p-3 text-sm text-gray-700 whitespace-nowrap">{new Date(order.date_creation).toLocaleString('es-CO')}</td>
                                         <td className="p-3 text-sm">
                                             {order.type === 'sur_place' ? (
-                                                <span className="inline-flex items-center gap-1.5 py-1 px-2 rounded-full text-xs font-medium bg-blue-100 text-blue-800"><User size={12}/> Sur Place</span>
+                                                <span className="inline-flex items-center gap-1.5 py-1 px-2 rounded-full text-xs font-medium bg-blue-100 text-blue-800"><User size={12}/> En el local</span>
                                             ) : (
-                                                <span className="inline-flex items-center gap-1.5 py-1 px-2 rounded-full text-xs font-medium bg-purple-100 text-purple-800"><ShoppingBag size={12}/> À Emporter</span>
+                                                <span className="inline-flex items-center gap-1.5 py-1 px-2 rounded-full text-xs font-medium bg-purple-100 text-purple-800"><ShoppingBag size={12}/> Para llevar</span>
                                             )}
                                         </td>
                                         <td className="p-3 font-semibold text-gray-900">{order.type === 'sur_place' ? (order.table_nom || 'N/A') : (order.clientInfo?.nom || 'N/A')}</td>
@@ -151,7 +151,7 @@ const ResumeVentes: React.FC = () => {
                                         <tr className="bg-gray-50">
                                             <td colSpan={7} className="p-4">
                                                 <div className="p-2 bg-white rounded-md border">
-                                                    <h4 className="font-semibold mb-2 text-gray-800">Détail des articles :</h4>
+                                                    <h4 className="font-semibold mb-2 text-gray-800">Detalle de artículos:</h4>
                                                     <ul className="list-disc list-inside pl-2 text-gray-700">
                                                     {order.items.map(item => (
                                                         <li key={item.id}>{item.quantite}x {item.nom_produit} - <span className="font-semibold">{formatIntegerAmount(item.prix_unitaire * item.quantite)}€</span></li>
@@ -166,7 +166,7 @@ const ResumeVentes: React.FC = () => {
                         </tbody>
                          <tfoot className="border-t-2 border-gray-300">
                             <tr className="font-bold text-gray-900">
-                                <td colSpan={4} className="p-3 text-right">TOTAUX</td>
+                                <td colSpan={4} className="p-3 text-right">TOTALES</td>
                                 <td className="p-3 text-right">{formatIntegerAmount(totals.totalSales)} €</td>
                                 <td className="p-3 text-right text-green-700">{formatIntegerAmount(totals.totalProfit)} €</td>
                                 <td></td>
@@ -174,7 +174,7 @@ const ResumeVentes: React.FC = () => {
                         </tfoot>
                     </table>
                 </div>
-                 {filteredOrders.length === 0 && <p className="text-center p-8 text-gray-500">Aucune commande finalisée ne correspond à vos filtres.</p>}
+                 {filteredOrders.length === 0 && <p className="text-center p-8 text-gray-500">Ningún pedido finalizado coincide con tus filtros.</p>}
             </div>
         </div>
     );


### PR DESCRIPTION
## Summary
- translate French UI strings in navigation, modals, dashboards, and order flows to Spanish
- update date and time formatting to use the es-CO locale across reports and order views
- align accessibility labels and CTA text with the new Spanish vocabulary

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dba56d90b0832a8357476c25a8a960