### PR TITLE
Switch UI currency to Colombian pesos

### DIFF
--- a/components/CustomerOrderTracker.tsx
+++ b/components/CustomerOrderTracker.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { api } from '../services/api';
 import { Order } from '../types';
 import { CheckCircle, ChefHat, FileText, PackageCheck, User, MapPin, Receipt, Phone } from 'lucide-react';
-import { formatIntegerAmount } from '../utils/formatIntegerAmount';
+import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 import {
     clearActiveCustomerOrder,
     getActiveCustomerOrder,
@@ -183,13 +183,13 @@ const CustomerOrderTracker: React.FC<CustomerOrderTrackerProps> = ({ orderId, on
                         {order.items.map(item => (
                             <div key={item.id} className={`flex justify-between ${variant === 'hero' ? 'text-gray-200' : 'text-gray-600'}`}>
                                 <span>{item.quantite}x {item.nom_produit}</span>
-                                <span>{formatIntegerAmount(item.prix_unitaire * item.quantite)}€</span>
+                                <span>{formatCurrencyCOP(item.prix_unitaire * item.quantite)}</span>
                             </div>
                         ))}
                     </div>
                     <div className={`flex justify-between font-bold text-lg border-t pt-2 ${variant === 'hero' ? 'text-white border-gray-500' : 'text-gray-800'}`}>
-                        <span>Total</span>
-                        <span>{formatIntegerAmount(order.total)}€</span>
+                        <span>Total (pesos colombianos)</span>
+                        <span>{formatCurrencyCOP(order.total)}</span>
                     </div>
 
                     <div className={`border-t pt-4 space-y-2 ${variant === 'hero' ? 'border-gray-500' : ''}`}>

--- a/components/PaymentModal.tsx
+++ b/components/PaymentModal.tsx
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 import { Order } from '../types';
 import Modal from './Modal';
 import { Upload } from 'lucide-react';
-import { formatIntegerAmount } from '../utils/formatIntegerAmount';
+import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 
 interface PaymentModalProps {
   isOpen: boolean;
@@ -29,8 +29,8 @@ const PaymentModal: React.FC<PaymentModalProps> = ({ isOpen, onClose, order, onF
     <Modal isOpen={isOpen} onClose={onClose} title={`Finalizar el pedido #${order.id.slice(-4)}`}>
       <form onSubmit={handleSubmit} className="space-y-6">
         <div className="text-center">
-          <p className="text-gray-600">Total a pagar</p>
-          <p className="text-4xl font-extrabold text-gray-900">{formatIntegerAmount(order.total)} €</p>
+          <p className="text-gray-600">Total a pagar (pesos colombianos)</p>
+          <p className="text-4xl font-extrabold text-gray-900">{formatCurrencyCOP(order.total)}</p>
         </div>
 
         <div>

--- a/components/ReportModal.tsx
+++ b/components/ReportModal.tsx
@@ -3,7 +3,7 @@ import Modal from './Modal';
 import { api } from '../services/api';
 import { DailyReport, RoleLogin } from '../types';
 import { Users, ShoppingCart, DollarSign, Package, AlertTriangle, MessageSquare, LogIn } from 'lucide-react';
-import { formatIntegerAmount } from '../utils/formatIntegerAmount';
+import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 
 const ReportStat: React.FC<{ icon: React.ReactNode, label: string, value: string | number }> = ({ icon, label, value }) => (
     <div className="bg-gray-100 p-3 sm:p-4 rounded-lg flex flex-col sm:flex-row sm:items-center items-start gap-3">
@@ -61,9 +61,9 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
         parts.push('---');
 
         parts.push(`*Estadísticas del día*`);
-        parts.push(`- Ventas: *${formatIntegerAmount(reportData.ventesDuJour)} €*`);
+        parts.push(`- Ventas (pesos colombianos): *${formatCurrencyCOP(reportData.ventesDuJour)}*`);
         parts.push(`- Clientes: *${reportData.clientsDuJour}*`);
-        parts.push(`- Ticket promedio: *${formatIntegerAmount(reportData.panierMoyen)} €*`);
+        parts.push(`- Ticket promedio (pesos colombianos): *${formatCurrencyCOP(reportData.panierMoyen)}*`);
         parts.push('---');
 
         parts.push(`*Productos vendidos*`);
@@ -73,7 +73,7 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
           reportData.soldProducts.forEach(category => {
             parts.push(`\n_${category.categoryName}_`);
             category.products.forEach(product => {
-              parts.push(`  - ${product.quantity}x ${product.name} (${formatIntegerAmount(product.totalSales)} €)`);
+              parts.push(`  - ${product.quantity}x ${product.name} (${formatCurrencyCOP(product.totalSales)} pesos colombianos)`);
             });
           });
         }
@@ -148,9 +148,9 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
                             </div>
 
                             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-                                <ReportStat icon={<DollarSign/>} label="Ventas del día" value={`${formatIntegerAmount(report.ventesDuJour)} €`} />
+                                <ReportStat icon={<DollarSign/>} label="Ventas del día (pesos colombianos)" value={formatCurrencyCOP(report.ventesDuJour)} />
                                 <ReportStat icon={<Users/>} label="Clientes del día" value={report.clientsDuJour} />
-                                <ReportStat icon={<ShoppingCart/>} label="Ticket promedio" value={`${formatIntegerAmount(report.panierMoyen)} €`} />
+                                <ReportStat icon={<ShoppingCart/>} label="Ticket promedio (pesos colombianos)" value={formatCurrencyCOP(report.panierMoyen)} />
                             </div>
 
                             <div>
@@ -162,7 +162,7 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
                                             <ul className="list-disc list-inside pl-2 text-gray-700">
                                                 {category.products.map(product => (
                                                     <li key={product.id}>
-                                                        {product.quantity}x {product.name} - <span className="font-semibold">{formatIntegerAmount(product.totalSales)} €</span>
+                                                        {product.quantity}x {product.name} - <span className="font-semibold">{formatCurrencyCOP(product.totalSales)} (pesos colombianos)</span>
                                                     </li>
                                                 ))}
                                             </ul>

--- a/components/SitePreviewCanvas.tsx
+++ b/components/SitePreviewCanvas.tsx
@@ -7,6 +7,7 @@ import {
   createHeroBackgroundStyle,
   createTextStyle,
 } from '../utils/siteStyleHelpers';
+import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 
 export type EditableZoneKey = 'navigation' | 'hero' | 'about' | 'menu' | 'contact' | 'footer';
 
@@ -64,19 +65,19 @@ const placeholderProducts = [
     id: '1',
     name: 'Taco al Pastor',
     description: 'Porc mariné, ananas rôti et coriandre fraîche.',
-    price: '12,90€',
+    price: formatCurrencyCOP(12900),
   },
   {
     id: '2',
     name: 'Burrito Barbacoa',
     description: 'Bœuf effiloché, haricots noirs et pico de gallo.',
-    price: '14,50€',
+    price: formatCurrencyCOP(14500),
   },
   {
     id: '3',
     name: 'Quesadilla Verde',
     description: 'Fromage fondant, courgettes grillées et salsa verde.',
-    price: '11,40€',
+    price: formatCurrencyCOP(11400),
   },
 ];
 
@@ -163,7 +164,7 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({ content, onEdit }
                           Commande du 12/03/2024
                         </p>
                         <p className="hero-history__details" style={heroBodyTextStyle}>
-                          2 article(s) • 32€
+                          2 article(s) • {formatCurrencyCOP(32000)}
                         </p>
                       </div>
                       <button

--- a/components/commande/ItemCustomizationModal.tsx
+++ b/components/commande/ItemCustomizationModal.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Minus, Plus } from 'lucide-react';
 import Modal from '../Modal';
 import type { Product } from '../../types';
-import { formatIntegerAmount } from '../../utils/formatIntegerAmount';
+import { formatCurrencyCOP } from '../../utils/formatIntegerAmount';
 
 export interface ItemCustomizationResult {
     quantity: number;
@@ -99,7 +99,7 @@ const ItemCustomizationModal: React.FC<ItemCustomizationModalProps> = ({
                         onClick={handleSave}
                         className="rounded-lg bg-brand-primary py-2 px-6 font-semibold text-brand-secondary transition hover:bg-yellow-400"
                     >
-                        Ajouter ({formatIntegerAmount(product.prix_vente * quantity)} €)
+                        Ajouter ({formatCurrencyCOP(product.prix_vente * quantity)})
                     </button>
                 </div>
             </div>

--- a/components/commande/OrderSummary.tsx
+++ b/components/commande/OrderSummary.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Check, DollarSign, MessageSquare, MinusCircle, PlusCircle, Send } from 'lucide-react';
 import type { Order, OrderItem } from '../../types';
-import { formatIntegerAmount } from '../../utils/formatIntegerAmount';
+import { formatCurrencyCOP } from '../../utils/formatIntegerAmount';
 
 export type CategorizedOrderItems = {
     pending: { item: OrderItem; index: number }[];
@@ -66,12 +66,12 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
                                                 {item.quantite}x {item.nom_produit}
                                             </p>
                                             <p className="font-bold text-gray-900">
-                                                {formatIntegerAmount(item.quantite * item.prix_unitaire)}€
+                                                {formatCurrencyCOP(item.quantite * item.prix_unitaire)}
                                             </p>
                                         </div>
                                         <div className="flex justify-between items-center mt-2">
                                             <p className="text-sm text-gray-700">
-                                                {formatIntegerAmount(item.prix_unitaire)} € /u
+                                                {formatCurrencyCOP(item.prix_unitaire)} /u
                                             </p>
                                             <div className="flex items-center space-x-2 text-gray-800">
                                                 <button onClick={() => onQuantityChange(index, -1)} className="p-1">
@@ -119,11 +119,11 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
                                                 {item.quantite}x {item.nom_produit}
                                             </p>
                                             <p className="font-bold text-gray-900">
-                                                {formatIntegerAmount(item.quantite * item.prix_unitaire)}€
+                                                {formatCurrencyCOP(item.quantite * item.prix_unitaire)}
                                             </p>
                                         </div>
                                         <p className="text-sm text-gray-700 mt-2">
-                                            {formatIntegerAmount(item.prix_unitaire)} € /u
+                                            {formatCurrencyCOP(item.prix_unitaire)} /u
                                         </p>
                                         {item.commentaire && (
                                             <p className="mt-2 text-sm italic text-gray-600 pl-2">"{item.commentaire}"</p>
@@ -137,8 +137,8 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
             </div>
             <div className="p-4 border-t space-y-4">
                 <div className="flex justify-between text-2xl font-semibold text-brand-secondary">
-                    <span>Total</span>
-                    <span>{formatIntegerAmount(total)} €</span>
+                    <span>Total (pesos colombianos)</span>
+                    <span>{formatCurrencyCOP(total)}</span>
                 </div>
 
                 {orderStatus === 'listo' && (

--- a/components/commande/ProductGrid.tsx
+++ b/components/commande/ProductGrid.tsx
@@ -1,7 +1,7 @@
 import React, { memo } from 'react';
 import { AlertTriangle } from 'lucide-react';
 import { Product, Category } from '../../types';
-import { formatIntegerAmount } from '../../utils/formatIntegerAmount';
+import { formatCurrencyCOP } from '../../utils/formatIntegerAmount';
 
 export interface ProductGridProps {
     filteredProducts: Product[];
@@ -101,7 +101,7 @@ const ProductGridComponent: React.FC<ProductGridProps> = ({
                                 {product.description}
                             </p>
                             <p className="font-bold text-brand-primary mt-1">
-                                {formatIntegerAmount(product.prix_vente)} €
+                                {formatCurrencyCOP(product.prix_vente)}
                             </p>
                         </button>
                     );

--- a/pages/CommandeClient.tsx
+++ b/pages/CommandeClient.tsx
@@ -7,7 +7,7 @@ import Modal from '../components/Modal';
 import { ArrowLeft, ShoppingCart, Plus, Minus, X, Upload, MessageCircle, CheckCircle, History } from 'lucide-react';
 import CustomerOrderTracker from '../components/CustomerOrderTracker';
 import { clearActiveCustomerOrder, getActiveCustomerOrder, storeActiveCustomerOrder } from '../services/customerOrderStorage';
-import { formatIntegerAmount } from '../utils/formatIntegerAmount';
+import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 
 // ==================================================================================
 // 2. Item Customization Modal
@@ -61,7 +61,7 @@ const ItemCustomizationModal: React.FC<ItemCustomizationModalProps> = ({ isOpen,
                         <button onClick={() => setQuantity(q => q + 1)} className="p-2 rounded-full bg-gray-200 text-gray-800"><Plus size={18}/></button>
                     </div>
                     <button onClick={handleSave} className="bg-brand-primary text-brand-secondary font-bold py-2 px-6 rounded-lg hover:bg-yellow-400 transition">
-                        Añadir ({formatIntegerAmount(product.prix_vente * quantity)} €)
+                        Añadir ({formatCurrencyCOP(product.prix_vente * quantity)})
                     </button>
                 </div>
             </div>
@@ -289,7 +289,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
     const generateWhatsAppMessage = (order: Order) => {
         const header = `*Nuevo pedido OUIOUITACOS #${order.id.slice(-6)}*`;
         const itemLines = (order.items ?? []).map(item => {
-            const baseLine = `- ${item.quantite}x ${item.nom_produit} (${formatIntegerAmount(item.prix_unitaire)}€) → ${formatIntegerAmount(item.prix_unitaire * item.quantite)}€`;
+            const baseLine = `- ${item.quantite}x ${item.nom_produit} (${formatCurrencyCOP(item.prix_unitaire)} pesos colombianos) → ${formatCurrencyCOP(item.prix_unitaire * item.quantite)} pesos colombianos`;
             const details: string[] = [];
             if (item.commentaire) {
                 details.push(`Comentario: ${item.commentaire}`);
@@ -301,7 +301,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
         });
         const items = itemLines.length > 0 ? itemLines.join('\n') : 'Sin artículos';
         const totalValue = order.total ?? order.items.reduce((sum, item) => sum + item.prix_unitaire * item.quantite, 0);
-        const totalMsg = `*Total: ${formatIntegerAmount(totalValue)}€*`;
+        const totalMsg = `*Total (pesos colombianos): ${formatCurrencyCOP(totalValue)}*`;
         const paymentMethod = order.payment_method ? `Pago: ${order.payment_method}` : undefined;
         const client = `Cliente: ${order.clientInfo?.nom} (${order.clientInfo?.telephone})\nDirección: ${order.clientInfo?.adresse}`;
         const footer = 'Comprobante de pago adjunto.';
@@ -325,7 +325,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                                     <div key={order.id} className="flex justify-between items-center bg-gray-50 p-3 rounded-lg">
                                         <div>
                                             <p className="font-semibold text-gray-700">Pedido del {new Date(order.date_creation).toLocaleDateString('es-CO')}</p>
-                                            <p className="text-sm text-gray-500">{order.items.length} artículo(s) - {formatIntegerAmount(order.total)}€</p>
+                                            <p className="text-sm text-gray-500">{order.items.length} artículo(s) - {formatCurrencyCOP(order.total)}</p>
                                         </div>
                                         <button onClick={() => handleReorder(order)} className="bg-brand-primary text-brand-secondary font-bold py-1 px-3 rounded-lg text-sm hover:bg-yellow-400">
                                             Volver a pedir
@@ -355,7 +355,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                                     <img src={product.image} alt={product.nom_produit} className="w-28 h-28 object-cover rounded-md mb-2" />
                                     <p className="font-semibold text-sm flex-grow text-gray-700">{product.nom_produit}</p>
                                     <p className="text-xs text-gray-500 mt-1 px-1 h-10 overflow-hidden">{product.description}</p>
-                                    <p className="font-bold text-gray-700 mt-1">{formatIntegerAmount(product.prix_vente)} €</p>
+                                    <p className="font-bold text-gray-700 mt-1">{formatCurrencyCOP(product.prix_vente)}</p>
                                     {product.estado !== 'disponible' && <span className="text-xs text-red-500 font-bold mt-1">Agotado</span>}
                                 </div>
                             ))}
@@ -374,7 +374,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                                         <div>
                                             <p className="font-semibold text-gray-700">{item.nom_produit}</p>
                                             {item.commentaire && <p className="text-xs text-gray-500 italic">"{item.commentaire}"</p>}
-                                            <p className="text-sm text-gray-600 font-semibold">{formatIntegerAmount(item.prix_unitaire * item.quantite)} €</p>
+                                            <p className="text-sm text-gray-600 font-semibold">{formatCurrencyCOP(item.prix_unitaire * item.quantite)}</p>
                                         </div>
                                         <div className="flex items-center gap-2">
                                             <button onClick={() => handleQuantityChange(item.id, -1)} className="p-1 rounded-full bg-gray-200"><Minus size={14}/></button>
@@ -388,7 +388,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                         <div className="border-t my-4"></div>
                         <div className="flex justify-between text-xl font-bold text-gray-700">
                             <span>Total</span>
-                            <span>{formatIntegerAmount(total)} €</span>
+                            <span>{formatCurrencyCOP(total)}</span>
                         </div>
 
                         {cart.length > 0 && (
@@ -421,7 +421,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                                     <input id="payment-proof-upload" type="file" required accept="image/*,.pdf" onChange={e => setPaymentProof(e.target.files ? e.target.files[0] : null)} className="hidden" />
                                 </div>
                                 <button type="submit" disabled={!clientInfo.nom || !clientInfo.telephone || !clientInfo.adresse || !paymentProof || submitting} className="w-full bg-brand-accent text-white font-bold py-3 rounded-lg text-lg hover:bg-red-700 transition disabled:bg-gray-400">
-                                    {submitting ? 'Enviando...' : `Enviar el pedido (${formatIntegerAmount(total)} €)`}
+                                    {submitting ? 'Enviando...' : `Enviar el pedido (${formatCurrencyCOP(total)})`}
                                 </button>
                             </form>
                         )}

--- a/pages/Dashboard.tsx
+++ b/pages/Dashboard.tsx
@@ -5,7 +5,7 @@ import { api, getBusinessDayStart } from '../services/api';
 import { DashboardStats, SalesDataPoint, DashboardPeriod } from '../types';
 import Modal from '../components/Modal';
 import RoleManager from '../components/role-manager';
-import { formatIntegerAmount } from '../utils/formatIntegerAmount';
+import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 
 const MainStatCard: React.FC<{ title: string; value: string; icon: React.ReactNode }> = ({ title, value, icon }) => (
     <div className="ui-card p-6 flex items-center space-x-4">
@@ -113,10 +113,10 @@ const Dashboard: React.FC = () => {
 
             {/* Block 1: Key Indicators */}
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-                <MainStatCard title={`Ventas (${stats.periodLabel})`} value={`${formatIntegerAmount(stats.ventesPeriode)} €`} icon={<DollarSign size={28}/>} />
-                <MainStatCard title={`Beneficio (${stats.periodLabel})`} value={`${formatIntegerAmount(stats.beneficePeriode)} €`} icon={<DollarSign size={28}/>} />
+                <MainStatCard title={`Ventas (${stats.periodLabel}) · pesos colombianos`} value={formatCurrencyCOP(stats.ventesPeriode)} icon={<DollarSign size={28}/>} />
+                <MainStatCard title={`Beneficio (${stats.periodLabel}) · pesos colombianos`} value={formatCurrencyCOP(stats.beneficePeriode)} icon={<DollarSign size={28}/>} />
                 <MainStatCard title={`Clientes (${stats.periodLabel})`} value={stats.clientsPeriode.toString()} icon={<Users size={28}/>} />
-                <MainStatCard title="Ticket promedio" value={`${formatIntegerAmount(stats.panierMoyen)} €`} icon={<BarChart2 size={28}/>} />
+                <MainStatCard title="Ticket promedio (pesos colombianos)" value={formatCurrencyCOP(stats.panierMoyen)} icon={<BarChart2 size={28}/>} />
             </div>
 
             {/* Block 2: Operational Status */}
@@ -142,8 +142,8 @@ const Dashboard: React.FC = () => {
                         <YAxis />
                         <Tooltip />
                         <Legend />
-                        <Bar dataKey="ventes" fill="#8884d8" name={`${stats.periodLabel} (€)`} />
-                        <Bar dataKey="ventesPeriodePrecedente" fill="#d8d6f5" name="Periodo anterior (€)" />
+                        <Bar dataKey="ventes" fill="#8884d8" name={`${stats.periodLabel} (pesos colombianos)`} />
+                        <Bar dataKey="ventesPeriodePrecedente" fill="#d8d6f5" name="Periodo anterior (pesos colombianos)" />
                     </BarChart>
                 </ResponsiveContainer>
             </div>
@@ -163,7 +163,7 @@ const Dashboard: React.FC = () => {
                             <Pie data={pieData} dataKey="value" nameKey="name" cx="50%" cy="50%" outerRadius={100} fill="#8884d8" label>
                                 {pieData.map((entry, index) => <Cell key={`cell-${index}`} fill={PIE_COLORS[index % PIE_COLORS.length]} />)}
                             </Pie>
-                            <Tooltip formatter={(value: number) => `${formatIntegerAmount(value)} €`} />
+                            <Tooltip formatter={(value: number) => formatCurrencyCOP(value)} />
                             <Legend/>
                         </PieChart>
                     </ResponsiveContainer>

--- a/pages/Ingredients.tsx
+++ b/pages/Ingredients.tsx
@@ -4,7 +4,7 @@ import { api } from '../services/api';
 import { Ingredient } from '../types';
 import Modal from '../components/Modal';
 import { PlusCircle, Edit, Trash2, PackagePlus, Search } from 'lucide-react';
-import { formatIntegerAmount } from '../utils/formatIntegerAmount';
+import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 
 const Ingredients: React.FC = () => {
     const { role } = useAuth();
@@ -87,7 +87,7 @@ const Ingredients: React.FC = () => {
                                 <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Nom</th>
                                 <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Stock Actuel</th>
                                 <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Stock Minimum</th>
-                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Prix Unitaire Moyen</th>
+                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Prix unitaire moyen (pesos colombianos)</th>
                                 {canEdit && <th className="p-3 text-right text-sm font-medium text-gray-500 uppercase tracking-wider">Actions</th>}
                             </tr>
                         </thead>
@@ -104,7 +104,7 @@ const Ingredients: React.FC = () => {
                                         {ing.stock_minimum} {ing.unite}
                                     </td>
                                      <td className={`p-3 ${isLowStock ? 'text-red-800' : 'text-gray-700'}`}>
-                                        {formatIntegerAmount(ing.prix_unitaire)} €
+                                        {formatCurrencyCOP(ing.prix_unitaire)}
                                     </td>
                                     {canEdit && (
                                         <td className="p-3 text-right">
@@ -238,7 +238,7 @@ const ResupplyModal: React.FC<{ isOpen: boolean; onClose: () => void; onSuccess:
                     <input type="number" id="quantity" min="0.01" step="0.01" value={quantity} onChange={e => setQuantity(parseFloat(e.target.value))} required className="mt-1 ui-input"/>
                 </div>
                 <div>
-                    <label htmlFor="unitPrice" className="block text-sm font-medium text-gray-700">Prix par Unité (€/{ingredient.unite})</label>
+                    <label htmlFor="unitPrice" className="block text-sm font-medium text-gray-700">Prix par unité (pesos colombianos/{ingredient.unite})</label>
                     <input type="number" id="unitPrice" min="0" step="0.01" value={unitPrice} onChange={e => setUnitPrice(parseFloat(e.target.value))} required className="mt-1 ui-input"/>
                 </div>
                 <div className="flex flex-col sm:flex-row gap-3 pt-4">

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -7,7 +7,7 @@ import { Product, Order } from '../types';
 import { Mail, MapPin, Phone, Menu, X } from 'lucide-react';
 import CustomerOrderTracker from '../components/CustomerOrderTracker';
 import { clearActiveCustomerOrder, getActiveCustomerOrder } from '../services/customerOrderStorage';
-import { formatIntegerAmount } from '../utils/formatIntegerAmount';
+import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 import useSiteContent from '../hooks/useSiteContent';
 import {
   createBackgroundStyle,
@@ -373,7 +373,7 @@ const Login: React.FC = () => {
                               Commande du {new Date(order.date_creation).toLocaleDateString()}
                             </p>
                             <p className="hero-history__details" style={heroBodyTextStyle}>
-                              {order.items.length} article(s) • {formatIntegerAmount(order.total)}€
+                              {order.items.length} article(s) • {formatCurrencyCOP(order.total)}
                             </p>
                           </div>
                           <button
@@ -449,7 +449,7 @@ const Login: React.FC = () => {
                         {product.description}
                       </p>
                       <p className="menu-card__price" style={menuBodyTextStyle}>
-                        {formatIntegerAmount(product.prix_vente)} €
+                        {formatCurrencyCOP(product.prix_vente)}
                       </p>
                     </div>
                   </article>

--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -5,7 +5,7 @@ import { Eye, User, MapPin } from 'lucide-react';
 import Modal from '../components/Modal';
 import OrderTimer from '../components/OrderTimer';
 import { getOrderUrgencyStyles } from '../utils/orderUrgency';
-import { formatIntegerAmount } from '../utils/formatIntegerAmount';
+import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 
 
 const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => void, onDeliver?: (orderId: string) => void, isProcessing?: boolean }> = ({ order, onValidate, onDeliver, isProcessing }) => {
@@ -75,8 +75,8 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                     </div>
 
                     <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 font-semibold text-gray-900 shadow-sm">
-                        <span>Total</span>
-                        <span className="text-lg sm:text-xl text-gray-900">{formatIntegerAmount(order.total)} €</span>
+                        <span>Total (pesos colombianos)</span>
+                        <span className="text-lg sm:text-xl text-gray-900">{formatCurrencyCOP(order.total)}</span>
                     </div>
                 </div>
 

--- a/pages/Produits.tsx
+++ b/pages/Produits.tsx
@@ -7,7 +7,7 @@ import { uploadProductImage, resolveProductImageUrl } from '../services/cloudina
 import { Product, Category, Ingredient, RecipeItem } from '../types';
 import Modal from '../components/Modal';
 import { PlusCircle, Edit, Trash2, Search, Settings, GripVertical, CheckCircle, Clock, XCircle, MoreVertical, Upload, HelpCircle } from 'lucide-react';
-import { formatIntegerAmount } from '../utils/formatIntegerAmount';
+import { formatCurrencyCOP, formatIntegerAmount } from '../utils/formatIntegerAmount';
 
 const BEST_SELLER_RANKS = [1, 2, 3, 4, 5, 6];
 
@@ -220,7 +220,7 @@ const ProductCard: React.FC<{ product: Product; category?: Category; onEdit: () 
                         <p className="text-xs text-gray-500">{category?.nom || 'Sans catégorie'}</p>
                         <h3 className="font-bold text-lg text-gray-900">{product.nom_produit}</h3>
                     </div>
-                <p className="text-xl font-extrabold text-brand-primary">{formatIntegerAmount(product.prix_vente)}€</p>
+                <p className="text-xl font-extrabold text-brand-primary">{formatCurrencyCOP(product.prix_vente)}</p>
                 </div>
                  <p className="text-xs text-gray-600 mt-1 flex-grow">{product.description}</p>
                 
@@ -431,7 +431,7 @@ const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSu
                             <input type="text" value={formData.nom_produit} onChange={e => setFormData({...formData, nom_produit: e.target.value})} required className="mt-1 ui-input"/>
                         </div>
                         <div>
-                            <label className="block text-sm font-medium text-gray-700">Prix de Vente (€)</label>
+                            <label className="block text-sm font-medium text-gray-700">Prix de vente (pesos colombianos)</label>
                             <input
                                 type="number"
                                 step="0.01"
@@ -509,12 +509,12 @@ const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSu
 
                     <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 bg-gray-50 border border-gray-200 rounded-lg p-4 text-sm text-gray-700">
                         <div>
-                            <p className="text-xs uppercase tracking-wide text-gray-500">Coût de revient</p>
-                            <p className="text-lg font-semibold text-gray-900">{formatIntegerAmount(recipeCost)} €</p>
+                            <p className="text-xs uppercase tracking-wide text-gray-500">Coût de revient (pesos colombianos)</p>
+                            <p className="text-lg font-semibold text-gray-900">{formatCurrencyCOP(recipeCost)}</p>
                         </div>
                         <div>
-                            <p className="text-xs uppercase tracking-wide text-gray-500">Marge</p>
-                            <p className={`text-lg font-semibold ${marginValue >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>{formatIntegerAmount(marginValue)} €</p>
+                            <p className="text-xs uppercase tracking-wide text-gray-500">Marge (pesos colombianos)</p>
+                            <p className={`text-lg font-semibold ${marginValue >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>{formatCurrencyCOP(marginValue)}</p>
                         </div>
                         <div>
                             <p className="text-xs uppercase tracking-wide text-gray-500">Marge %</p>

--- a/pages/ResumeVentes.tsx
+++ b/pages/ResumeVentes.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo } from 'react';
 import { api } from '../services/api';
 import { Order } from '../types';
 import { Download, ChevronDown, ChevronRight, User, ShoppingBag } from 'lucide-react';
-import { formatIntegerAmount } from '../utils/formatIntegerAmount';
+import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 
 const ResumeVentes: React.FC = () => {
     const [orders, setOrders] = useState<Order[]>([]);
@@ -50,7 +50,7 @@ const ResumeVentes: React.FC = () => {
     };
 
     const exportToCSV = () => {
-        const headers = ['Fecha', 'Tipo', 'Mesa/Cliente', 'Comensales', 'Venta total (€)', 'Beneficio (€)', 'Método de pago'];
+        const headers = ['Fecha', 'Tipo', 'Mesa/Cliente', 'Comensales', 'Venta total (pesos colombianos)', 'Beneficio (pesos colombianos)', 'Método de pago'];
         const csvRows = [
             headers.join(','),
             ...filteredOrders.map(order => [
@@ -58,8 +58,8 @@ const ResumeVentes: React.FC = () => {
                 order.type === 'sur_place' ? 'En el local' : 'Para llevar',
                 `"${order.type === 'sur_place' ? (order.table_nom || 'N/A') : (order.clientInfo?.nom || 'N/A')}"`,
                 order.couverts,
-                formatIntegerAmount(order.total),
-                formatIntegerAmount(order.profit || 0),
+                formatCurrencyCOP(order.total),
+                formatCurrencyCOP(order.profit || 0),
                 order.payment_method || 'N/A'
             ].join(','))
         ];
@@ -122,8 +122,8 @@ const ResumeVentes: React.FC = () => {
                                 <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
                                 <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Tipo</th>
                                 <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Mesa/Cliente</th>
-                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider text-right">Ventas</th>
-                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider text-right">Beneficio</th>
+                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider text-right">Ventas (pesos colombianos)</th>
+                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider text-right">Beneficio (pesos colombianos)</th>
                                 <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Pago</th>
                             </tr>
                         </thead>
@@ -143,8 +143,8 @@ const ResumeVentes: React.FC = () => {
                                             )}
                                         </td>
                                         <td className="p-3 font-semibold text-gray-900">{order.type === 'sur_place' ? (order.table_nom || 'N/A') : (order.clientInfo?.nom || 'N/A')}</td>
-                                        <td className="p-3 text-gray-800 font-bold text-right">{formatIntegerAmount(order.total)} €</td>
-                                        <td className="p-3 font-semibold text-green-600 text-right">{formatIntegerAmount(order.profit || 0)} €</td>
+                                        <td className="p-3 text-gray-800 font-bold text-right">{formatCurrencyCOP(order.total)}</td>
+                                        <td className="p-3 font-semibold text-green-600 text-right">{formatCurrencyCOP(order.profit || 0)}</td>
                                         <td className="p-3 text-gray-700 capitalize">{order.payment_method || 'N/A'}</td>
                                     </tr>
                                     {expandedOrderId === order.id && (
@@ -154,7 +154,7 @@ const ResumeVentes: React.FC = () => {
                                                     <h4 className="font-semibold mb-2 text-gray-800">Detalle de artículos:</h4>
                                                     <ul className="list-disc list-inside pl-2 text-gray-700">
                                                     {order.items.map(item => (
-                                                        <li key={item.id}>{item.quantite}x {item.nom_produit} - <span className="font-semibold">{formatIntegerAmount(item.prix_unitaire * item.quantite)}€</span></li>
+                                                        <li key={item.id}>{item.quantite}x {item.nom_produit} - <span className="font-semibold">{formatCurrencyCOP(item.prix_unitaire * item.quantite)} (pesos colombianos)</span></li>
                                                     ))}
                                                     </ul>
                                                 </div>
@@ -167,8 +167,8 @@ const ResumeVentes: React.FC = () => {
                          <tfoot className="border-t-2 border-gray-300">
                             <tr className="font-bold text-gray-900">
                                 <td colSpan={4} className="p-3 text-right">TOTALES</td>
-                                <td className="p-3 text-right">{formatIntegerAmount(totals.totalSales)} €</td>
-                                <td className="p-3 text-right text-green-700">{formatIntegerAmount(totals.totalProfit)} €</td>
+                                <td className="p-3 text-right">{formatCurrencyCOP(totals.totalSales)}</td>
+                                <td className="p-3 text-right text-green-700">{formatCurrencyCOP(totals.totalProfit)}</td>
                                 <td></td>
                             </tr>
                         </tfoot>

--- a/utils/formatIntegerAmount.ts
+++ b/utils/formatIntegerAmount.ts
@@ -1,11 +1,21 @@
-const integerAmountFormatter = new Intl.NumberFormat('fr-FR', {
+const integerAmountFormatter = new Intl.NumberFormat('es-CO', {
   maximumFractionDigits: 0,
 });
 
-export function formatIntegerAmount(value: number): string {
-  if (!Number.isFinite(value)) {
-    return '0';
-  }
+const copCurrencyFormatter = new Intl.NumberFormat('es-CO', {
+  style: 'currency',
+  currency: 'COP',
+  maximumFractionDigits: 0,
+});
 
-  return integerAmountFormatter.format(Math.round(value));
+function ensureFinite(value: number): number {
+  return Number.isFinite(value) ? Math.round(value) : 0;
+}
+
+export function formatIntegerAmount(value: number): string {
+  return integerAmountFormatter.format(ensureFinite(value));
+}
+
+export function formatCurrencyCOP(value: number): string {
+  return copCurrencyFormatter.format(ensureFinite(value));
 }


### PR DESCRIPTION
## Summary
- add a dedicated Colombian peso formatter alongside the integer formatter
- replace hard-coded euro symbols with the COP formatter across order flows, dashboards, and previews
- update reports, exports, and shareable messages to reference pesos colombianos explicitly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dba7124050832a8cb7afe34fc5261f