### PR TITLE
feat: integrate brand and staff logos into login interface

### DIFF
--- a/components/SitePreviewCanvas.tsx
+++ b/components/SitePreviewCanvas.tsx
@@ -9,6 +9,9 @@ import {
 } from '../utils/siteStyleHelpers';
 import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 
+const brandLogo = '/logo-brand.svg';
+const staffLogo = '/logo-staff.svg';
+
 export type EditableZoneKey = 'navigation' | 'hero' | 'about' | 'menu' | 'contact' | 'footer';
 
 interface SitePreviewCanvasProps {
@@ -105,9 +108,14 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({ content, onEdit }
       <EditableZoneFrame zone="navigation" label="Navigation" onEdit={onEdit} contentClassName="pt-16">
         <header className="login-header" style={navigationBackgroundStyle}>
           <div className="layout-container login-header__inner" style={navigationTextStyle}>
-            <span className="login-brand" style={navigationTextStyle}>
-              {content.navigation.brand}
-            </span>
+            <div className="login-brand" style={navigationTextStyle}>
+              <img
+                src={brandLogo}
+                alt={`Logo ${content.navigation.brand}`}
+                className="login-brand__logo"
+              />
+              <span className="login-brand__name">{content.navigation.brand}</span>
+            </div>
             <nav className="login-nav" aria-label="Navigation principale">
               <span className="login-nav__link" style={navigationBodyStyle}>
                 {content.navigation.links.home}
@@ -123,11 +131,12 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({ content, onEdit }
               </span>
               <button
                 type="button"
-                className="ui-btn ui-btn-accent login-nav__cta"
+                className="login-nav__staff-btn"
                 style={{ fontFamily: content.navigation.style.fontFamily }}
+                aria-label="Connexion staff"
                 disabled
               >
-                {content.navigation.links.loginCta}
+                <img src={staffLogo} alt="" className="login-nav__staff-logo" aria-hidden="true" />
               </button>
             </nav>
           </div>

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -16,6 +16,9 @@ import {
   createTextStyle,
 } from '../utils/siteStyleHelpers';
 
+const brandLogo = '/logo-brand.svg';
+const staffLogo = '/logo-staff.svg';
+
 type PinInputProps = {
   pin: string;
   onPinChange: (pin: string) => void;
@@ -251,9 +254,14 @@ const Login: React.FC = () => {
     <div className="login-page">
       <header className="login-header" style={navigationBackgroundStyle}>
         <div className="layout-container login-header__inner" style={navigationTextStyle}>
-          <a href="#accueil" className="login-brand" style={navigationTextStyle}>
-            {navigation.brand}
-          </a>
+          <div className="login-brand" style={navigationTextStyle}>
+            <img
+              src={brandLogo}
+              alt={`Logo ${navigation.brand}`}
+              className="login-brand__logo"
+            />
+            <span className="login-brand__name">{navigation.brand}</span>
+          </div>
           <nav className="login-nav" aria-label="Navigation principale">
             <a href="#accueil" className="login-nav__link" style={navigationBodyStyle}>
               {navigation.links.home}
@@ -270,10 +278,11 @@ const Login: React.FC = () => {
             <button
               type="button"
               onClick={() => setIsModalOpen(true)}
-              className="ui-btn ui-btn-accent login-nav__cta"
+              className="login-nav__staff-btn"
+              aria-label="Connexion staff"
               style={{ fontFamily: navigation.style.fontFamily }}
             >
-              {navigation.links.loginCta}
+              <img src={staffLogo} alt="" className="login-nav__staff-logo" aria-hidden="true" />
             </button>
           </nav>
           <button
@@ -331,10 +340,11 @@ const Login: React.FC = () => {
                 setIsModalOpen(true);
                 setMobileMenuOpen(false);
               }}
-              className="ui-btn ui-btn-accent hero-cta"
+              className="login-nav__staff-btn login-menu-overlay__staff-btn"
+              aria-label="Connexion staff"
               style={{ fontFamily: navigation.style.fontFamily }}
             >
-              {navigation.links.loginCta}
+              <img src={staffLogo} alt="" className="login-nav__staff-logo" aria-hidden="true" />
             </button>
           </nav>
         </div>

--- a/public/logo-brand.svg
+++ b/public/logo-brand.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 120 120" role="img" aria-labelledby="title desc">
+  <title>Restaurant Brand Logo</title>
+  <desc>Stylised plate with cutlery to represent the restaurant brand.</desc>
+  <circle cx="60" cy="60" r="55" fill="#F97316" opacity="0.15" />
+  <circle cx="60" cy="60" r="40" fill="#F97316" />
+  <path d="M60 30c-5 10-5 50 0 60" stroke="#FFFFFF" stroke-width="6" stroke-linecap="round" fill="none" />
+  <path d="M45 45h6v30h-6zM69 45l18 15-18 15z" fill="#FFFFFF" />
+</svg>

--- a/public/logo-staff.svg
+++ b/public/logo-staff.svg
@@ -1,0 +1,8 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 64 64" role="img" aria-labelledby="title desc">
+  <title>Staff Login Logo</title>
+  <desc>Key icon enclosed in a rounded square.</desc>
+  <rect x="4" y="4" width="56" height="56" rx="14" fill="#1F2937" />
+  <circle cx="26" cy="30" r="10" fill="#FACC15" />
+  <path d="M35 30h13l-3 4h-4v4h-5z" fill="#FACC15" />
+  <circle cx="24" cy="28" r="3" fill="#1F2937" />
+</svg>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -483,10 +483,26 @@ body {
 }
 
 .login-brand {
+  display: inline-flex;
+  align-items: center;
+  gap: clamp(0.6rem, 1.5vw, 0.9rem);
   font-size: clamp(1.75rem, 4vw, 2.25rem);
   font-weight: 800;
   letter-spacing: -0.01em;
   color: var(--color-accent);
+}
+
+.login-brand__logo {
+  width: clamp(2.5rem, 5vw, 3rem);
+  height: clamp(2.5rem, 5vw, 3rem);
+  flex: 0 0 auto;
+  display: block;
+  object-fit: contain;
+  filter: drop-shadow(0 4px 12px color-mix(in srgb, var(--color-heading) 25%, transparent));
+}
+
+.login-brand__name {
+  line-height: 1.1;
 }
 
 .login-nav {
@@ -512,12 +528,42 @@ body {
 }
 
 .login-nav__cta {
-  font-size: var(--font-size-sm);
-  padding-inline: clamp(1.15rem, 3vw, 1.75rem);
-  padding-block: 0.65rem;
+  display: none;
+}
+
+.login-nav__staff-btn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: clamp(2.75rem, 4vw, 3.15rem);
+  height: clamp(2.75rem, 4vw, 3.15rem);
   border-radius: 999px;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
+  border: 1px solid color-mix(in srgb, var(--color-surface) 24%, transparent);
+  background: color-mix(in srgb, var(--color-heading) 72%, transparent);
+  padding: clamp(0.35rem, 1vw, 0.55rem);
+  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.login-nav__staff-btn:hover,
+.login-nav__staff-btn:focus-visible {
+  transform: translateY(-1px);
+  border-color: color-mix(in srgb, var(--color-surface) 35%, transparent);
+  box-shadow: 0 6px 16px color-mix(in srgb, var(--color-heading) 22%, transparent);
+  outline: none;
+}
+
+.login-nav__staff-btn:disabled {
+  cursor: default;
+  opacity: 0.65;
+  transform: none;
+  box-shadow: none;
+}
+
+.login-nav__staff-logo {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  display: block;
 }
 
 .login-header__menu {
@@ -578,6 +624,36 @@ body {
   font-size: clamp(1.5rem, 5vw, 2rem);
   text-transform: uppercase;
   letter-spacing: 0.08em;
+}
+
+.login-menu-overlay__staff-btn {
+  width: clamp(3rem, 12vw, 3.75rem);
+  height: clamp(3rem, 12vw, 3.75rem);
+  background: color-mix(in srgb, var(--color-surface) 10%, transparent);
+  border-color: color-mix(in srgb, var(--color-surface) 40%, transparent);
+}
+
+.login-menu-overlay__staff-btn:hover,
+.login-menu-overlay__staff-btn:focus-visible {
+  background: color-mix(in srgb, var(--color-surface) 20%, transparent);
+}
+
+@media (max-width: 640px) {
+  .login-brand {
+    gap: 0.5rem;
+  }
+
+  .login-brand__logo {
+    width: 2.25rem;
+    height: 2.25rem;
+    filter: drop-shadow(0 2px 6px color-mix(in srgb, var(--color-heading) 20%, transparent));
+  }
+
+  .login-nav__staff-btn {
+    width: 2.5rem;
+    height: 2.5rem;
+    padding: 0.3rem;
+  }
 }
 
 .login-menu-overlay__link {


### PR DESCRIPTION
## Summary
- add reusable brand and staff logo assets and surface them on the login page and site preview
- swap the staff CTA buttons for icon buttons and ensure the mobile overlay reuses the staff trigger
- extend global styles to handle the new logo elements and responsive behaviour

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dba9fa785c832a986b8b1e7361e87c