### PR TITLE
Refonte de l'onglet personnalisation avec médiathèque Cloudinary

### DIFF
--- a/pages/SiteCustomization.tsx
+++ b/pages/SiteCustomization.tsx
@@ -1,10 +1,35 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import useSiteContent, { DEFAULT_SITE_CONTENT } from '../hooks/useSiteContent';
-import { SectionStyle, SiteContent } from '../types';
-import { normalizeCloudinaryImageUrl, uploadProductImage } from '../services/cloudinary';
+import {
+  CustomizationAsset,
+  CustomizationAssetType,
+  SectionStyle,
+  SiteContent,
+} from '../types';
+import { normalizeCloudinaryImageUrl, uploadCustomizationAsset } from '../services/cloudinary';
 import { resolveSiteContent } from '../utils/siteContent';
-import SitePreviewCanvas, { EditableElementKey, EditableZoneKey } from '../components/SitePreviewCanvas';
-import Modal from '../components/Modal';
+import SitePreviewCanvas, {
+  EditableElementKey,
+  EditableZoneKey,
+} from '../components/SitePreviewCanvas';
+import {
+  Archive,
+  Copy,
+  Image as ImageIcon,
+  Link as LinkIcon,
+  Loader2,
+  Music,
+  Trash2,
+  Type as TypeIcon,
+  Upload,
+  Video,
+} from 'lucide-react';
 
 const imageWarning = "L'URL doit provenir de Cloudinary (https://*.cloudinary.com).";
 
@@ -60,10 +85,105 @@ type ImageFieldKey =
   | 'menu.image'
   | 'contact.image'
   | StyleImageFieldKey;
-type HeroFieldKey = Exclude<keyof SiteContent['hero'], 'backgroundImage'>;
-type MenuFieldKey = Exclude<keyof SiteContent['menu'], 'image'>;
-type ContactFieldKey = Exclude<keyof SiteContent['contact'], 'image'>;
+
+type HeroFieldKey = Exclude<keyof SiteContent['hero'], 'backgroundImage' | 'style'>;
+type MenuFieldKey = Exclude<keyof SiteContent['menu'], 'image' | 'style'>;
+type ContactFieldKey = Exclude<keyof SiteContent['contact'], 'image' | 'style'>;
 type NavigationFieldKey = keyof SiteContent['navigation']['links'];
+
+type PanelSectionKey = EditableZoneKey | 'assets';
+
+type NavigationChangeHandler = (
+  key: NavigationFieldKey,
+) => (event: React.ChangeEvent<HTMLInputElement>) => void;
+type HeroChangeHandler = (
+  key: HeroFieldKey,
+) => (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
+type MenuChangeHandler = (
+  key: MenuFieldKey,
+) => (event: React.ChangeEvent<HTMLInputElement>) => void;
+type ContactChangeHandler = (
+  key: ContactFieldKey,
+) => (event: React.ChangeEvent<HTMLInputElement>) => void;
+type ImageInputHandler = (
+  field: ImageFieldKey,
+) => (event: React.ChangeEvent<HTMLInputElement>) => void;
+
+type ImageUploadHandler = (field: ImageFieldKey, file: File) => Promise<void>;
+type ImageClearHandler = (field: ImageFieldKey) => void;
+
+type AssetUploadHandler = (files: FileList | null) => Promise<void>;
+type AssetRemoveHandler = (id: string) => void;
+type AssetRenameHandler = (id: string, name: string) => void;
+type AssetApplyHandler = (field: ImageFieldKey, asset: CustomizationAsset) => void;
+
+type CustomizationPanelProps = {
+  draft: SiteContent;
+  activeElement: EditableElementKey | null;
+  imageErrors: Record<ImageFieldKey, string | null>;
+  isUploading: (field: ImageFieldKey) => boolean;
+  handleBrandChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleNavigationChange: NavigationChangeHandler;
+  handleHeroFieldChange: HeroChangeHandler;
+  handleAboutChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
+  handleAboutTitleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleMenuFieldChange: MenuChangeHandler;
+  handleContactFieldChange: ContactChangeHandler;
+  handleFooterTextChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
+  handleImageInputChange: ImageInputHandler;
+  handleImageUpload: ImageUploadHandler;
+  handleClearImage: ImageClearHandler;
+  handleStyleFontFamilyChange: (zone: EditableZoneKey, value: string) => void;
+  handleStyleFontSizeChange: (zone: EditableZoneKey, value: string) => void;
+  handleStyleTextColorChange: (zone: EditableZoneKey, value: string) => void;
+  handleStyleBackgroundColorChange: (zone: EditableZoneKey, value: string) => void;
+  handleStyleBackgroundTypeChange: (
+    zone: EditableZoneKey,
+    value: SectionStyle['background']['type'],
+  ) => void;
+  fontOptions: readonly string[];
+  fontSizeOptions: readonly string[];
+  assetState: {
+    uploading: boolean;
+    error: string | null;
+    assets: CustomizationAsset[];
+    onUpload: AssetUploadHandler;
+    onRemove: AssetRemoveHandler;
+    onRename: AssetRenameHandler;
+    onApply: AssetApplyHandler;
+  };
+};
+
+type ImageFieldEditorProps = {
+  field: ImageFieldKey;
+  label: string;
+  value: string | null;
+  imageErrors: Record<ImageFieldKey, string | null>;
+  handleImageInputChange: ImageInputHandler;
+  handleImageUpload: ImageUploadHandler;
+  handleClearImage: ImageClearHandler;
+  isUploading: (field: ImageFieldKey) => boolean;
+};
+
+type StyleControlsProps = {
+  zone: EditableZoneKey;
+  style: SectionStyle;
+  fontOptions: readonly string[];
+  fontSizeOptions: readonly string[];
+  handleStyleFontFamilyChange: (zone: EditableZoneKey, value: string) => void;
+  handleStyleFontSizeChange: (zone: EditableZoneKey, value: string) => void;
+  handleStyleTextColorChange: (zone: EditableZoneKey, value: string) => void;
+  handleStyleBackgroundColorChange: (zone: EditableZoneKey, value: string) => void;
+  handleStyleBackgroundTypeChange: (
+    zone: EditableZoneKey,
+    value: SectionStyle['background']['type'],
+  ) => void;
+  handleImageInputChange: ImageInputHandler;
+  handleImageUpload: ImageUploadHandler;
+  handleClearImage: ImageClearHandler;
+  imageErrors: Record<ImageFieldKey, string | null>;
+  isUploading: (field: ImageFieldKey) => boolean;
+};
 
 const STYLE_BACKGROUND_FIELD_KEYS: Record<EditableZoneKey, StyleImageFieldKey> = {
   navigation: 'navigation.style.background',
@@ -95,43 +215,6 @@ const resolveZoneFromElement = (element: EditableElementKey): EditableZoneKey =>
   }
 
   throw new Error(`Zone introuvable pour l'élément modifiable "${element}"`);
-};
-
-type NavigationChangeHandler = (key: NavigationFieldKey) => (event: React.ChangeEvent<HTMLInputElement>) => void;
-type HeroChangeHandler = (
-  key: HeroFieldKey,
-) => (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
-type MenuChangeHandler = (key: MenuFieldKey) => (event: React.ChangeEvent<HTMLInputElement>) => void;
-type ContactChangeHandler = (key: ContactFieldKey) => (event: React.ChangeEvent<HTMLInputElement>) => void;
-type ImageInputHandler = (field: ImageFieldKey) => (event: React.ChangeEvent<HTMLInputElement>) => void;
-
-type ImageUploadHandler = (field: ImageFieldKey, file: File) => Promise<void>;
-type ImageClearHandler = (field: ImageFieldKey) => void;
-
-type SiteCustomizationModalsProps = {
-  activeElement: EditableElementKey | null;
-  onClose: () => void;
-  draft: SiteContent;
-  handleBrandChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  handleNavigationChange: NavigationChangeHandler;
-  handleHeroFieldChange: HeroChangeHandler;
-  handleAboutTitleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  handleAboutChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
-  handleMenuFieldChange: MenuChangeHandler;
-  handleContactFieldChange: ContactChangeHandler;
-  handleFooterTextChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  handleImageInputChange: ImageInputHandler;
-  handleImageUpload: ImageUploadHandler;
-  handleClearImage: ImageClearHandler;
-  handleStyleFontFamilyChange: (zone: EditableZoneKey, value: string) => void;
-  handleStyleFontSizeChange: (zone: EditableZoneKey, value: string) => void;
-  handleStyleTextColorChange: (zone: EditableZoneKey, value: string) => void;
-  handleStyleBackgroundColorChange: (zone: EditableZoneKey, value: string) => void;
-  handleStyleBackgroundTypeChange: (zone: EditableZoneKey, value: SectionStyle['background']['type']) => void;
-  fontOptions: readonly string[];
-  fontSizeOptions: readonly string[];
-  imageErrors: Record<ImageFieldKey, string | null>;
-  isUploading: (field: ImageFieldKey) => boolean;
 };
 
 const IMAGE_FIELD_LABELS: Record<ImageFieldKey, string> = {
@@ -196,6 +279,65 @@ const EDITABLE_ELEMENT_INPUT_IDS: Partial<Record<EditableElementKey, string>> = 
   'footer.style.background': 'footer-background-type',
 };
 
+const ASSET_TYPE_LABELS: Record<CustomizationAssetType, string> = {
+  image: 'Image',
+  video: 'Vidéo',
+  audio: 'Audio',
+  font: 'Police',
+  raw: 'Fichier',
+};
+
+const guessAssetType = (file: File): CustomizationAssetType => {
+  const { type, name } = file;
+  if (type.startsWith('image/')) {
+    return 'image';
+  }
+  if (type.startsWith('video/')) {
+    return 'video';
+  }
+  if (type.startsWith('audio/')) {
+    return 'audio';
+  }
+  if (type.includes('font')) {
+    return 'font';
+  }
+  const extension = name.split('.').pop()?.toLowerCase();
+  if (extension && ['ttf', 'otf', 'woff', 'woff2'].includes(extension)) {
+    return 'font';
+  }
+  return 'raw';
+};
+
+const createAssetId = (): string =>
+  typeof crypto !== 'undefined' && 'randomUUID' in crypto
+    ? crypto.randomUUID()
+    : `asset-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+const formatBytes = (bytes: number): string => {
+  if (!Number.isFinite(bytes) || bytes <= 0) {
+    return '—';
+  }
+  const units = ['o', 'Ko', 'Mo', 'Go'];
+  const exponent = Math.min(Math.floor(Math.log(bytes) / Math.log(1024)), units.length - 1);
+  const value = bytes / Math.pow(1024, exponent);
+  return `${value.toFixed(value >= 10 || exponent === 0 ? 0 : 1)} ${units[exponent]}`;
+};
+
+const AssetTypeIcon: React.FC<{ type: CustomizationAssetType }> = ({ type }) => {
+  switch (type) {
+    case 'image':
+      return <ImageIcon className="h-4 w-4" aria-hidden="true" />;
+    case 'video':
+      return <Video className="h-4 w-4" aria-hidden="true" />;
+    case 'audio':
+      return <Music className="h-4 w-4" aria-hidden="true" />;
+    case 'font':
+      return <TypeIcon className="h-4 w-4" aria-hidden="true" />;
+    default:
+      return <Archive className="h-4 w-4" aria-hidden="true" />;
+  }
+};
+
 const SiteCustomization: React.FC = () => {
   const { content, loading, error, updateContent } = useSiteContent();
   const [draft, setDraft] = useState<SiteContent>(content);
@@ -208,6 +350,8 @@ const SiteCustomization: React.FC = () => {
   });
   const [uploadingField, setUploadingField] = useState<ImageFieldKey | null>(null);
   const [activeElement, setActiveElement] = useState<EditableElementKey | null>(null);
+  const [assetUploading, setAssetUploading] = useState(false);
+  const [assetError, setAssetError] = useState<string | null>(null);
 
   useEffect(() => {
     setDraft(content);
@@ -215,10 +359,33 @@ const SiteCustomization: React.FC = () => {
     setStatusMessage(null);
     setFormError(null);
     setImageErrors({ ...INITIAL_IMAGE_ERRORS });
+    setAssetError(null);
   }, [content]);
 
+  useEffect(() => {
+    if (!activeElement) {
+      return;
+    }
+    const targetId = EDITABLE_ELEMENT_INPUT_IDS[activeElement];
+    if (!targetId) {
+      return;
+    }
+    const element = document.getElementById(targetId);
+    if (element instanceof HTMLElement) {
+      element.focus({ preventScroll: true });
+    }
+  }, [activeElement]);
+
   const previewContent = useMemo(() => resolveSiteContent(draft), [draft]);
-  const fontOptions = useMemo(() => [...FONT_FAMILY_SUGGESTIONS], []);
+
+  const fontOptions = useMemo(() => {
+    const customFonts = draft.assets.library
+      .filter(asset => asset.type === 'font')
+      .map(asset => `"${asset.name}"`)
+      .filter((value, index, list) => list.indexOf(value) === index);
+    return [...FONT_FAMILY_SUGGESTIONS, ...customFonts];
+  }, [draft.assets.library]);
+
   const fontSizeOptions = useMemo(() => [...FONT_SIZE_SUGGESTIONS], []);
 
   const mutateDraft = (updater: (prev: SiteContent) => SiteContent) => {
@@ -228,14 +395,20 @@ const SiteCustomization: React.FC = () => {
     setFormError(null);
   };
 
-  const updateZone = <K extends EditableZoneKey>(zone: K, updater: (zoneContent: SiteContent[K]) => SiteContent[K]) => {
+  const updateZone = <K extends EditableZoneKey>(
+    zone: K,
+    updater: (zoneContent: SiteContent[K]) => SiteContent[K],
+  ) => {
     mutateDraft(prev => ({
       ...prev,
       [zone]: updater(prev[zone]),
     }));
   };
 
-  const updateZoneStyle = (zone: EditableZoneKey, updater: (style: SectionStyle) => SectionStyle) => {
+  const updateZoneStyle = (
+    zone: EditableZoneKey,
+    updater: (style: SectionStyle) => SectionStyle,
+  ) => {
     updateZone(zone, zoneContent => ({
       ...zoneContent,
       style: updater(zoneContent.style),
@@ -364,7 +537,10 @@ const SiteCustomization: React.FC = () => {
     }));
   };
 
-  const handleStyleBackgroundTypeChange = (zone: EditableZoneKey, type: SectionStyle['background']['type']) => {
+  const handleStyleBackgroundTypeChange = (
+    zone: EditableZoneKey,
+    type: SectionStyle['background']['type'],
+  ) => {
     const fieldKey = STYLE_BACKGROUND_FIELD_KEYS[zone];
     const defaultStyle = DEFAULT_SITE_CONTENT[zone].style;
     updateZoneStyle(zone, style => ({
@@ -532,16 +708,19 @@ const SiteCustomization: React.FC = () => {
     setFormError(null);
     setStatusMessage(null);
     try {
-      const label = IMAGE_FIELD_LABELS[field];
-      const uploadedUrl = await uploadProductImage(file, label);
+      const uploadedUrl = await uploadCustomizationAsset(file, {
+        tags: ['customization', field.replace(/\./g, '_')],
+      });
       setImageField(field, uploadedUrl);
       setImageErrors(prev => ({
         ...prev,
         [field]: null,
       }));
     } catch (uploadError) {
-      console.error('Failed to upload site image', uploadError);
-      setFormError("Impossible de téléverser l'image. Vérifiez votre connexion ou la configuration Cloudinary.");
+      console.error('Failed to upload customization asset', uploadError);
+      setFormError(
+        "Impossible de téléverser l'image. Vérifiez votre connexion ou la configuration Cloudinary.",
+      );
     } finally {
       setUploadingField(null);
     }
@@ -553,6 +732,90 @@ const SiteCustomization: React.FC = () => {
       ...prev,
       [field]: null,
     }));
+  };
+
+  const handleAssetUpload: AssetUploadHandler = async files => {
+    if (!files || files.length === 0) {
+      return;
+    }
+
+    setAssetUploading(true);
+    setAssetError(null);
+    try {
+      const uploadedAssets: CustomizationAsset[] = [];
+      for (const file of Array.from(files)) {
+        const url = await uploadCustomizationAsset(file, {
+          tags: ['customization', guessAssetType(file)],
+        });
+        uploadedAssets.push({
+          id: createAssetId(),
+          name: file.name.replace(/\.[^/.]+$/, '') || file.name,
+          url,
+          format: file.type || 'application/octet-stream',
+          bytes: file.size,
+          type: guessAssetType(file),
+          createdAt: new Date().toISOString(),
+        });
+      }
+
+      if (uploadedAssets.length > 0) {
+        mutateDraft(prev => ({
+          ...prev,
+          assets: {
+            ...prev.assets,
+            library: [...prev.assets.library, ...uploadedAssets],
+          },
+        }));
+        setStatusMessage(
+          uploadedAssets.length === 1
+            ? 'Nouvelle ressource ajoutée à la médiathèque personnalisée.'
+            : `${uploadedAssets.length} ressources ajoutées à la médiathèque personnalisée.`,
+        );
+      }
+    } catch (assetUploadError) {
+      console.error('Failed to upload customization asset', assetUploadError);
+      setAssetError("Téléversement impossible. Vérifiez vos presets Cloudinary ou réessayez.");
+    } finally {
+      setAssetUploading(false);
+    }
+  };
+
+  const handleAssetRemove: AssetRemoveHandler = id => {
+    mutateDraft(prev => ({
+      ...prev,
+      assets: {
+        ...prev.assets,
+        library: prev.assets.library.filter(asset => asset.id !== id),
+      },
+    }));
+  };
+
+  const handleAssetRename: AssetRenameHandler = (id, name) => {
+    const trimmed = name.trim();
+    mutateDraft(prev => ({
+      ...prev,
+      assets: {
+        ...prev.assets,
+        library: prev.assets.library.map(asset =>
+          asset.id === id
+            ? {
+                ...asset,
+                name: trimmed.length > 0 ? trimmed : asset.name,
+              }
+            : asset,
+        ),
+      },
+    }));
+  };
+
+  const handleAssetApply: AssetApplyHandler = (field, asset) => {
+    setImageField(field, asset.url);
+    setImageErrors(prev => ({
+      ...prev,
+      [field]: null,
+    }));
+    setActiveElement(field as EditableElementKey);
+    setStatusMessage('Ressource appliquée à la section sélectionnée.');
   };
 
   const handleSave = async () => {
@@ -578,14 +841,15 @@ const SiteCustomization: React.FC = () => {
     }
   };
 
-    const handleReset = () => {
-      setDraft(content);
-      setIsDirty(false);
-      setStatusMessage(null);
-      setFormError(null);
-      setImageErrors({ ...INITIAL_IMAGE_ERRORS });
-      setActiveElement(null);
-    };
+  const handleReset = () => {
+    setDraft(content);
+    setIsDirty(false);
+    setStatusMessage(null);
+    setFormError(null);
+    setImageErrors({ ...INITIAL_IMAGE_ERRORS });
+    setActiveElement(null);
+    setAssetError(null);
+  };
 
   const isUploading = (field: ImageFieldKey) => uploadingField === field;
 
@@ -594,8 +858,10 @@ const SiteCustomization: React.FC = () => {
       <div className="flex flex-col gap-3 md:flex-row md:items-center md:justify-between">
         <div>
           <h1 className="text-2xl font-semibold text-gray-900">Personnalisation du site</h1>
-          <p className="text-sm text-gray-500">
-            Ajustez les textes, visuels et coordonnées visibles sur la vitrine publique.
+          <p className="max-w-2xl text-sm text-gray-500">
+            Composez une vitrine sur mesure : contenu, styles, ressources médias et polices sont entièrement modulables. Toutes
+            vos créations sont centralisées dans le dossier Cloudinary <code className="rounded bg-slate-100 px-1">Custom</code>
+            , prêtes à être réutilisées ou téléchargées.
           </p>
         </div>
         <div className="flex flex-wrap gap-2">
@@ -631,47 +897,78 @@ const SiteCustomization: React.FC = () => {
         </div>
       )}
 
-      {loading ? (
-        <div className="flex justify-center py-12">
-          <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-brand-primary" />
+      <div className="grid gap-6 xl:grid-cols-[420px,1fr]">
+        <CustomizationPanel
+          draft={draft}
+          activeElement={activeElement}
+          imageErrors={imageErrors}
+          isUploading={isUploading}
+          handleBrandChange={handleBrandChange}
+          handleNavigationChange={handleNavigationChange}
+          handleHeroFieldChange={handleHeroFieldChange}
+          handleAboutChange={handleAboutChange}
+          handleAboutTitleChange={handleAboutTitleChange}
+          handleMenuFieldChange={handleMenuFieldChange}
+          handleContactFieldChange={handleContactFieldChange}
+          handleFooterTextChange={handleFooterTextChange}
+          handleImageInputChange={handleImageInputChange}
+          handleImageUpload={handleImageUpload}
+          handleClearImage={handleClearImage}
+          handleStyleFontFamilyChange={handleStyleFontFamilyChange}
+          handleStyleFontSizeChange={handleStyleFontSizeChange}
+          handleStyleTextColorChange={handleStyleTextColorChange}
+          handleStyleBackgroundColorChange={handleStyleBackgroundColorChange}
+          handleStyleBackgroundTypeChange={handleStyleBackgroundTypeChange}
+          fontOptions={fontOptions}
+          fontSizeOptions={fontSizeOptions}
+          assetState={{
+            uploading: assetUploading,
+            error: assetError,
+            assets: draft.assets.library,
+            onUpload: handleAssetUpload,
+            onRemove: handleAssetRemove,
+            onRename: handleAssetRename,
+            onApply: handleAssetApply,
+          }}
+        />
+        <div className="space-y-6">
+          {loading ? (
+            <div className="flex justify-center py-12">
+              <div className="h-12 w-12 animate-spin rounded-full border-b-2 border-brand-primary" />
+            </div>
+          ) : (
+            <SitePreviewCanvas content={previewContent} onEdit={element => setActiveElement(element)} />
+          )}
+          <div className="rounded-3xl border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-sm font-semibold uppercase tracking-wide text-slate-500">
+              Astuces de personnalisation avancée
+            </h2>
+            <ul className="mt-3 space-y-2 text-sm text-slate-600">
+              <li>
+                Utilisez des valeurs CSS complètes dans les champs de styles pour bénéficier de la pleine puissance du moteur (ex :
+                <code className="mx-1 rounded bg-slate-100 px-1">clamp()</code>,<code className="mx-1 rounded bg-slate-100 px-1">rgba()</code>...).
+              </li>
+              <li>
+                Les polices téléversées dans la médiathèque peuvent être intégrées via <code className="rounded bg-slate-100 px-1">@font-face</code>
+                dans votre feuille de styles publique ou à l'aide d'un service d'injection externe.
+              </li>
+              <li>
+                Chaque ressource envoyée est stockée dans <strong>Cloudinary / Custom</strong>. Vous pouvez les retoucher, les
+                renommer ou les remplacer directement depuis votre console Cloudinary sans casser les liens.
+              </li>
+            </ul>
+          </div>
         </div>
-      ) : (
-        <SitePreviewCanvas content={previewContent} onEdit={element => setActiveElement(element)} />
-      )}
-
-      <SiteCustomizationModals
-        activeElement={activeElement}
-        onClose={() => setActiveElement(null)}
-        draft={draft}
-        handleBrandChange={handleBrandChange}
-        handleNavigationChange={handleNavigationChange}
-        handleHeroFieldChange={handleHeroFieldChange}
-        handleAboutChange={handleAboutChange}
-        handleAboutTitleChange={handleAboutTitleChange}
-        handleMenuFieldChange={handleMenuFieldChange}
-        handleContactFieldChange={handleContactFieldChange}
-        handleFooterTextChange={handleFooterTextChange}
-        handleImageInputChange={handleImageInputChange}
-        handleImageUpload={handleImageUpload}
-        handleClearImage={handleClearImage}
-        handleStyleFontFamilyChange={handleStyleFontFamilyChange}
-        handleStyleFontSizeChange={handleStyleFontSizeChange}
-        handleStyleTextColorChange={handleStyleTextColorChange}
-        handleStyleBackgroundColorChange={handleStyleBackgroundColorChange}
-        handleStyleBackgroundTypeChange={handleStyleBackgroundTypeChange}
-        fontOptions={fontOptions}
-        fontSizeOptions={fontSizeOptions}
-        imageErrors={imageErrors}
-        isUploading={isUploading}
-      />
+      </div>
     </div>
   );
 };
 
-const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
-  activeElement,
-  onClose,
+const CustomizationPanel: React.FC<CustomizationPanelProps> = ({
   draft,
+  activeElement,
+  imageErrors,
+  isUploading,
   handleBrandChange,
   handleNavigationChange,
   handleHeroFieldChange,
@@ -690,263 +987,89 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
   handleStyleBackgroundTypeChange,
   fontOptions,
   fontSizeOptions,
-  imageErrors,
-  isUploading,
+  assetState,
 }) => {
-  const activeZone = activeElement ? resolveZoneFromElement(activeElement) : null;
+  const sectionRefs = useRef<Record<PanelSectionKey, HTMLDivElement | null>>({
+    navigation: null,
+    hero: null,
+    about: null,
+    menu: null,
+    contact: null,
+    footer: null,
+    assets: null,
+  });
 
-  const validateCssValue = useCallback(
-    (property: string, value: string): { valid: boolean; message: string | null } => {
-      const trimmed = value.trim();
-      if (!trimmed) {
-        return { valid: true, message: null };
-      }
+  const [openSections, setOpenSections] = useState<Record<PanelSectionKey, boolean>>({
+    navigation: true,
+    hero: true,
+    about: false,
+    menu: false,
+    contact: false,
+    footer: false,
+    assets: true,
+  });
 
-      if (typeof window === 'undefined' || typeof window.CSS === 'undefined' || typeof window.CSS.supports !== 'function') {
-        return { valid: true, message: null };
-      }
-
-      return window.CSS.supports(property, trimmed)
-        ? { valid: true, message: null }
-        : { valid: false, message: 'Cette valeur ne semble pas être reconnue comme une valeur CSS valide.' };
-    },
-    [],
-  );
+  const [highlightedZone, setHighlightedZone] = useState<EditableZoneKey | null>(null);
 
   useEffect(() => {
     if (!activeElement) {
       return;
     }
+    const zone = resolveZoneFromElement(activeElement);
+    setOpenSections(prev => ({
+      ...prev,
+      [zone]: true,
+    }));
+    setHighlightedZone(zone);
 
-    const targetId = EDITABLE_ELEMENT_INPUT_IDS[activeElement];
-    if (!targetId) {
-      return;
+    const node = sectionRefs.current[zone];
+    if (node) {
+      node.scrollIntoView({ behavior: 'smooth', block: 'start' });
     }
 
-    if (typeof window === 'undefined') {
-      return;
-    }
-
-    const timeout = window.setTimeout(() => {
-      const input = document.getElementById(targetId);
-      if (input instanceof HTMLElement) {
-        input.focus();
-      }
-    }, 120);
-
+    const timeout = window.setTimeout(() => setHighlightedZone(null), 2400);
     return () => window.clearTimeout(timeout);
   }, [activeElement]);
 
-  const renderStyleControls = (zone: EditableZoneKey) => {
-    const style = draft[zone].style;
-    const backgroundField = STYLE_BACKGROUND_FIELD_KEYS[zone];
-    const isBackgroundImage = style.background.type === 'image';
-    const fontFamilyValidation = validateCssValue('font-family', style.fontFamily);
-    const fontSizeValidation = validateCssValue('font-size', style.fontSize);
-    const textColorValidation = validateCssValue('color', style.textColor);
-    const backgroundColorValidation =
-      style.background.type === 'color'
-        ? validateCssValue('background-color', style.background.color)
-        : { valid: true, message: null };
-
-    return (
-      <div className="space-y-4 rounded-lg border border-gray-200 p-4">
-        <h3 className="text-sm font-semibold uppercase tracking-wide text-gray-500">Styles</h3>
-        <div className="grid gap-4 md:grid-cols-2">
-          <div>
-            <label htmlFor={`${zone}-font-family`} className="block text-sm font-medium text-gray-700">
-              Police
-            </label>
-            <input
-              id={`${zone}-font-family`}
-              className={`ui-input mt-1 ${
-                fontFamilyValidation.valid ? '' : 'border-red-300 focus:border-red-500 focus:ring-red-500'
-              }`}
-              value={style.fontFamily}
-              onChange={event => handleStyleFontFamilyChange(zone, event.target.value)}
-              list={`${zone}-font-family-options`}
-              placeholder="Ex: 'Open Sans', sans-serif"
-            />
-            <datalist id={`${zone}-font-family-options`}>
-              {fontOptions.map(font => (
-                <option key={font} value={font} />
-              ))}
-            </datalist>
-            {!fontFamilyValidation.valid && (
-              <p className="mt-1 text-xs text-red-600">{fontFamilyValidation.message}</p>
-            )}
-            <p className="mt-1 text-xs text-gray-500">
-              Utilisez le nom exact de la police ou une pile de polices CSS.
-            </p>
-          </div>
-          <div>
-            <label htmlFor={`${zone}-font-size`} className="block text-sm font-medium text-gray-700">
-              Taille du texte
-            </label>
-            <input
-              id={`${zone}-font-size`}
-              className={`ui-input mt-1 ${
-                fontSizeValidation.valid ? '' : 'border-red-300 focus:border-red-500 focus:ring-red-500'
-              }`}
-              value={style.fontSize}
-              onChange={event => handleStyleFontSizeChange(zone, event.target.value)}
-              list={`${zone}-font-size-options`}
-              placeholder="Ex: 1rem ou clamp(1rem, 2vw, 1.5rem)"
-            />
-            <datalist id={`${zone}-font-size-options`}>
-              {fontSizeOptions.map(size => (
-                <option key={size} value={size} />
-              ))}
-            </datalist>
-            {!fontSizeValidation.valid && (
-              <p className="mt-1 text-xs text-red-600">{fontSizeValidation.message}</p>
-            )}
-            <p className="mt-1 text-xs text-gray-500">Toutes les valeurs CSS valides sont acceptées.</p>
-          </div>
-        </div>
-        <div className="grid gap-4 md:grid-cols-2">
-          <div>
-            <label htmlFor={`${zone}-text-color`} className="block text-sm font-medium text-gray-700">
-              Couleur du texte
-            </label>
-            <div className="mt-1 flex items-center gap-3">
-              <span
-                aria-hidden="true"
-                className="h-10 w-10 rounded-md border border-gray-200"
-                style={{ backgroundColor: textColorValidation.valid ? style.textColor : 'transparent' }}
-              />
-              <input
-                id={`${zone}-text-color`}
-                className={`ui-input ${
-                  textColorValidation.valid ? '' : 'border-red-300 focus:border-red-500 focus:ring-red-500'
-                }`}
-                value={style.textColor}
-                onChange={event => handleStyleTextColorChange(zone, event.target.value)}
-                list={`${zone}-text-color-options`}
-                placeholder="Ex: #0f172a ou rgba(15, 23, 42, 0.8)"
-              />
-            </div>
-            <datalist id={`${zone}-text-color-options`}>
-              {COLOR_SUGGESTIONS.map(color => (
-                <option key={color} value={color} />
-              ))}
-            </datalist>
-            {!textColorValidation.valid && (
-              <p className="mt-1 text-xs text-red-600">{textColorValidation.message}</p>
-            )}
-            <p className="mt-1 text-xs text-gray-500">
-              Entrez une valeur hexadécimale, rgba(), hsl() ou un nom de couleur CSS.
-            </p>
-          </div>
-          <div>
-            <label htmlFor={`${zone}-background-type`} className="block text-sm font-medium text-gray-700">
-              Type de fond
-            </label>
-            <select
-              id={`${zone}-background-type`}
-              className="ui-select mt-1"
-              value={style.background.type}
-              onChange={event =>
-                handleStyleBackgroundTypeChange(zone, event.target.value as SectionStyle['background']['type'])
-              }
-            >
-              {BACKGROUND_TYPE_OPTIONS.map(option => (
-                <option key={option.value} value={option.value}>
-                  {option.label}
-                </option>
-              ))}
-            </select>
-          </div>
-        </div>
-        {style.background.type === 'color' && (
-          <div>
-            <label htmlFor={`${zone}-background-color`} className="block text-sm font-medium text-gray-700">
-              Couleur du fond
-            </label>
-            <div className="mt-1 flex items-center gap-3">
-              <span
-                aria-hidden="true"
-                className="h-10 w-10 rounded-md border border-gray-200"
-                style={{
-                  backgroundColor: backgroundColorValidation.valid ? style.background.color : 'transparent',
-                }}
-              />
-              <input
-                id={`${zone}-background-color`}
-                className={`ui-input ${
-                  backgroundColorValidation.valid ? '' : 'border-red-300 focus:border-red-500 focus:ring-red-500'
-                }`}
-                value={style.background.color}
-                onChange={event => handleStyleBackgroundColorChange(zone, event.target.value)}
-                list={`${zone}-background-color-options`}
-                placeholder="Ex: #ffffff ou rgba(255, 255, 255, 0.75)"
-              />
-            </div>
-            <datalist id={`${zone}-background-color-options`}>
-              {COLOR_SUGGESTIONS.map(color => (
-                <option key={color} value={color} />
-              ))}
-            </datalist>
-            {!backgroundColorValidation.valid && (
-              <p className="mt-1 text-xs text-red-600">{backgroundColorValidation.message}</p>
-            )}
-            <p className="mt-1 text-xs text-gray-500">Accepte toutes les valeurs de couleur CSS valides.</p>
-          </div>
-        )}
-        {isBackgroundImage && (
-          <div>
-            <label htmlFor={`${zone}-background-image`} className="block text-sm font-medium text-gray-700">
-              {IMAGE_FIELD_LABELS[backgroundField]}
-            </label>
-            <input
-              id={`${zone}-background-image`}
-              className="ui-input mt-1"
-              value={style.background.image ?? ''}
-              onChange={handleImageInputChange(backgroundField)}
-              placeholder="https://res.cloudinary.com/..."
-            />
-            <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
-            {imageErrors[backgroundField] && (
-              <p className="mt-1 text-xs text-red-600">{imageErrors[backgroundField]}</p>
-            )}
-            <div className="mt-3 flex flex-wrap gap-2">
-              <label className="ui-btn ui-btn-secondary cursor-pointer">
-                Importer une image
-                <input
-                  type="file"
-                  accept="image/*"
-                  className="hidden"
-                  onChange={event => {
-                    const file = event.target.files?.[0];
-                    if (file) {
-                      void handleImageUpload(backgroundField, file);
-                      event.target.value = '';
-                    }
-                  }}
-                />
-              </label>
-              <button
-                type="button"
-                className="ui-btn ui-btn-ghost"
-                onClick={() => handleClearImage(backgroundField)}
-                disabled={!style.background.image || isUploading(backgroundField)}
-              >
-                Retirer l'image
-              </button>
-              {isUploading(backgroundField) && (
-                <span className="text-sm text-gray-500">Téléversement en cours…</span>
-              )}
-            </div>
-          </div>
-        )}
-      </div>
-    );
+  const toggleSection = (key: PanelSectionKey) => {
+    setOpenSections(prev => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
   };
 
+  const renderStyleControls = (zone: EditableZoneKey) => (
+    <StyleControls
+      zone={zone}
+      style={draft[zone].style}
+      fontOptions={fontOptions}
+      fontSizeOptions={fontSizeOptions}
+      handleStyleFontFamilyChange={handleStyleFontFamilyChange}
+      handleStyleFontSizeChange={handleStyleFontSizeChange}
+      handleStyleTextColorChange={handleStyleTextColorChange}
+      handleStyleBackgroundColorChange={handleStyleBackgroundColorChange}
+      handleStyleBackgroundTypeChange={handleStyleBackgroundTypeChange}
+      handleImageInputChange={handleImageInputChange}
+      handleImageUpload={handleImageUpload}
+      handleClearImage={handleClearImage}
+      imageErrors={imageErrors}
+      isUploading={isUploading}
+    />
+  );
+
   return (
-    <>
-      <Modal isOpen={activeZone === 'navigation'} onClose={onClose} title="Modifier la navigation" size="lg">
-        <div className="space-y-5">
+    <div className="flex flex-col gap-4">
+      <SectionCard
+        ref={element => {
+          sectionRefs.current.navigation = element;
+        }}
+        title="Navigation & identité"
+        description="Lien direct entre votre marque et le parcours utilisateur."
+        open={openSections.navigation}
+        onToggle={() => toggleSection('navigation')}
+        highlighted={highlightedZone === 'navigation'}
+      >
+        <div className="space-y-4">
           <div>
             <label htmlFor="brand-name" className="block text-sm font-medium text-gray-700">
               Nom de la marque
@@ -960,7 +1083,9 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
           </div>
           <div className="grid gap-4 md:grid-cols-2">
             <div>
-              <label htmlFor="nav-home" className="block text-sm font-medium text-gray-700">Lien Accueil</label>
+              <label htmlFor="nav-home" className="block text-sm font-medium text-gray-700">
+                Lien Accueil
+              </label>
               <input
                 id="nav-home"
                 className="ui-input mt-1"
@@ -969,7 +1094,9 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
               />
             </div>
             <div>
-              <label htmlFor="nav-about" className="block text-sm font-medium text-gray-700">Lien À propos</label>
+              <label htmlFor="nav-about" className="block text-sm font-medium text-gray-700">
+                Lien À propos
+              </label>
               <input
                 id="nav-about"
                 className="ui-input mt-1"
@@ -978,7 +1105,9 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
               />
             </div>
             <div>
-              <label htmlFor="nav-menu" className="block text-sm font-medium text-gray-700">Lien Menu</label>
+              <label htmlFor="nav-menu" className="block text-sm font-medium text-gray-700">
+                Lien Menu
+              </label>
               <input
                 id="nav-menu"
                 className="ui-input mt-1"
@@ -987,7 +1116,9 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
               />
             </div>
             <div>
-              <label htmlFor="nav-contact" className="block text-sm font-medium text-gray-700">Lien Contact</label>
+              <label htmlFor="nav-contact" className="block text-sm font-medium text-gray-700">
+                Lien Contact
+              </label>
               <input
                 id="nav-contact"
                 className="ui-input mt-1"
@@ -995,44 +1126,48 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
                 onChange={handleNavigationChange('contact')}
               />
             </div>
-          </div>
-          <div>
-            <label htmlFor="nav-login" className="block text-sm font-medium text-gray-700">Bouton personnel</label>
-            <input
-              id="nav-login"
-              className="ui-input mt-1"
-              value={draft.navigation.links.loginCta}
-              onChange={handleNavigationChange('loginCta')}
-            />
+            <div>
+              <label htmlFor="nav-login" className="block text-sm font-medium text-gray-700">
+                Lien Staff / CTA
+              </label>
+              <input
+                id="nav-login"
+                className="ui-input mt-1"
+                value={draft.navigation.links.loginCta}
+                onChange={handleNavigationChange('loginCta')}
+              />
+            </div>
           </div>
           {renderStyleControls('navigation')}
         </div>
-      </Modal>
+      </SectionCard>
 
-      <Modal isOpen={activeZone === 'hero'} onClose={onClose} title="Modifier la section hero" size="xl">
-        <div className="space-y-5">
-          <div className="grid gap-4 md:grid-cols-2">
-            <div>
-              <label htmlFor="hero-title" className="block text-sm font-medium text-gray-700">Titre</label>
-              <input
-                id="hero-title"
-                className="ui-input mt-1"
-                value={draft.hero.title}
-                onChange={handleHeroFieldChange('title')}
-              />
-            </div>
-            <div>
-              <label htmlFor="hero-cta" className="block text-sm font-medium text-gray-700">Texte du bouton</label>
-              <input
-                id="hero-cta"
-                className="ui-input mt-1"
-                value={draft.hero.ctaLabel}
-                onChange={handleHeroFieldChange('ctaLabel')}
-              />
-            </div>
+      <SectionCard
+        ref={element => {
+          sectionRefs.current.hero = element;
+        }}
+        title="Hero & Accroche"
+        description="Structurez votre message principal, son visuel et ses appels à l'action."
+        open={openSections.hero}
+        onToggle={() => toggleSection('hero')}
+        highlighted={highlightedZone === 'hero'}
+      >
+        <div className="space-y-4">
+          <div>
+            <label htmlFor="hero-title" className="block text-sm font-medium text-gray-700">
+              Titre principal
+            </label>
+            <input
+              id="hero-title"
+              className="ui-input mt-1"
+              value={draft.hero.title}
+              onChange={handleHeroFieldChange('title')}
+            />
           </div>
           <div>
-            <label htmlFor="hero-subtitle" className="block text-sm font-medium text-gray-700">Sous-titre</label>
+            <label htmlFor="hero-subtitle" className="block text-sm font-medium text-gray-700">
+              Sous-titre
+            </label>
             <textarea
               id="hero-subtitle"
               className="ui-textarea mt-1"
@@ -1043,16 +1178,20 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
           </div>
           <div className="grid gap-4 md:grid-cols-2">
             <div>
-              <label htmlFor="hero-history" className="block text-sm font-medium text-gray-700">Titre historique</label>
+              <label htmlFor="hero-cta" className="block text-sm font-medium text-gray-700">
+                Label CTA principal
+              </label>
               <input
-                id="hero-history"
+                id="hero-cta"
                 className="ui-input mt-1"
-                value={draft.hero.historyTitle}
-                onChange={handleHeroFieldChange('historyTitle')}
+                value={draft.hero.ctaLabel}
+                onChange={handleHeroFieldChange('ctaLabel')}
               />
             </div>
             <div>
-              <label htmlFor="hero-reorder" className="block text-sm font-medium text-gray-700">Bouton de réassort</label>
+              <label htmlFor="hero-reorder" className="block text-sm font-medium text-gray-700">
+                Label CTA historique
+              </label>
               <input
                 id="hero-reorder"
                 className="ui-input mt-1"
@@ -1060,59 +1199,47 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
                 onChange={handleHeroFieldChange('reorderCtaLabel')}
               />
             </div>
-          </div>
-          <div>
-            <label htmlFor="hero-image" className="block text-sm font-medium text-gray-700">
-              {IMAGE_FIELD_LABELS['hero.backgroundImage']}
-            </label>
-            <input
-              id="hero-image"
-              className="ui-input mt-1"
-              value={draft.hero.backgroundImage ?? ''}
-              onChange={handleImageInputChange('hero.backgroundImage')}
-              placeholder="https://res.cloudinary.com/..."
-            />
-            <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
-            {imageErrors['hero.backgroundImage'] && (
-              <p className="mt-1 text-xs text-red-600">{imageErrors['hero.backgroundImage']}</p>
-            )}
-            <div className="mt-3 flex flex-wrap gap-2">
-              <label className="ui-btn ui-btn-secondary cursor-pointer">
-                Importer une image
-                <input
-                  type="file"
-                  accept="image/*"
-                  className="hidden"
-                  onChange={event => {
-                    const file = event.target.files?.[0];
-                    if (file) {
-                      void handleImageUpload('hero.backgroundImage', file);
-                      event.target.value = '';
-                    }
-                  }}
-                />
+            <div>
+              <label htmlFor="hero-history" className="block text-sm font-medium text-gray-700">
+                Titre historique
               </label>
-              <button
-                type="button"
-                className="ui-btn ui-btn-ghost"
-                onClick={() => handleClearImage('hero.backgroundImage')}
-                disabled={!draft.hero.backgroundImage || isUploading('hero.backgroundImage')}
-              >
-                Retirer l'image
-              </button>
-              {isUploading('hero.backgroundImage') && (
-                <span className="text-sm text-gray-500">Téléversement en cours…</span>
-              )}
+              <input
+                id="hero-history"
+                className="ui-input mt-1"
+                value={draft.hero.historyTitle}
+                onChange={handleHeroFieldChange('historyTitle')}
+              />
             </div>
           </div>
+          <ImageFieldEditor
+            field="hero.backgroundImage"
+            label={IMAGE_FIELD_LABELS['hero.backgroundImage']}
+            value={draft.hero.backgroundImage}
+            imageErrors={imageErrors}
+            handleImageInputChange={handleImageInputChange}
+            handleImageUpload={handleImageUpload}
+            handleClearImage={handleClearImage}
+            isUploading={isUploading}
+          />
           {renderStyleControls('hero')}
         </div>
-      </Modal>
+      </SectionCard>
 
-      <Modal isOpen={activeZone === 'about'} onClose={onClose} title="Modifier la section À propos" size="lg">
-        <div className="space-y-5">
+      <SectionCard
+        ref={element => {
+          sectionRefs.current.about = element;
+        }}
+        title="Section À propos"
+        description="Racontez votre histoire et accompagnez-la de visuels immersifs."
+        open={openSections.about}
+        onToggle={() => toggleSection('about')}
+        highlighted={highlightedZone === 'about'}
+      >
+        <div className="space-y-4">
           <div>
-            <label htmlFor="about-title" className="block text-sm font-medium text-gray-700">Titre</label>
+            <label htmlFor="about-title" className="block text-sm font-medium text-gray-700">
+              Titre
+            </label>
             <input
               id="about-title"
               className="ui-input mt-1"
@@ -1121,7 +1248,9 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
             />
           </div>
           <div>
-            <label htmlFor="about-description" className="block text-sm font-medium text-gray-700">Description</label>
+            <label htmlFor="about-description" className="block text-sm font-medium text-gray-700">
+              Description
+            </label>
             <textarea
               id="about-description"
               className="ui-textarea mt-1"
@@ -1130,59 +1259,36 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
               onChange={handleAboutChange}
             />
           </div>
-          <div>
-            <label htmlFor="about-image" className="block text-sm font-medium text-gray-700">
-              {IMAGE_FIELD_LABELS['about.image']}
-            </label>
-            <input
-              id="about-image"
-              className="ui-input mt-1"
-              value={draft.about.image ?? ''}
-              onChange={handleImageInputChange('about.image')}
-              placeholder="https://res.cloudinary.com/..."
-            />
-            <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
-            {imageErrors['about.image'] && (
-              <p className="mt-1 text-xs text-red-600">{imageErrors['about.image']}</p>
-            )}
-            <div className="mt-3 flex flex-wrap gap-2">
-              <label className="ui-btn ui-btn-secondary cursor-pointer">
-                Importer une image
-                <input
-                  type="file"
-                  accept="image/*"
-                  className="hidden"
-                  onChange={event => {
-                    const file = event.target.files?.[0];
-                    if (file) {
-                      void handleImageUpload('about.image', file);
-                      event.target.value = '';
-                    }
-                  }}
-                />
-              </label>
-              <button
-                type="button"
-                className="ui-btn ui-btn-ghost"
-                onClick={() => handleClearImage('about.image')}
-                disabled={!draft.about.image || isUploading('about.image')}
-              >
-                Retirer l'image
-              </button>
-              {isUploading('about.image') && (
-                <span className="text-sm text-gray-500">Téléversement en cours…</span>
-              )}
-            </div>
-          </div>
+          <ImageFieldEditor
+            field="about.image"
+            label={IMAGE_FIELD_LABELS['about.image']}
+            value={draft.about.image}
+            imageErrors={imageErrors}
+            handleImageInputChange={handleImageInputChange}
+            handleImageUpload={handleImageUpload}
+            handleClearImage={handleClearImage}
+            isUploading={isUploading}
+          />
           {renderStyleControls('about')}
         </div>
-      </Modal>
+      </SectionCard>
 
-      <Modal isOpen={activeZone === 'menu'} onClose={onClose} title="Modifier la section menu" size="xl">
-        <div className="space-y-5">
+      <SectionCard
+        ref={element => {
+          sectionRefs.current.menu = element;
+        }}
+        title="Section Menu"
+        description="Exposez vos produits phares et adaptez leur mise en avant."
+        open={openSections.menu}
+        onToggle={() => toggleSection('menu')}
+        highlighted={highlightedZone === 'menu'}
+      >
+        <div className="space-y-4">
           <div className="grid gap-4 md:grid-cols-2">
             <div>
-              <label htmlFor="menu-title" className="block text-sm font-medium text-gray-700">Titre</label>
+              <label htmlFor="menu-title" className="block text-sm font-medium text-gray-700">
+                Titre
+              </label>
               <input
                 id="menu-title"
                 className="ui-input mt-1"
@@ -1191,7 +1297,9 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
               />
             </div>
             <div>
-              <label htmlFor="menu-cta" className="block text-sm font-medium text-gray-700">Bouton CTA</label>
+              <label htmlFor="menu-cta" className="block text-sm font-medium text-gray-700">
+                Label CTA
+              </label>
               <input
                 id="menu-cta"
                 className="ui-input mt-1"
@@ -1199,68 +1307,47 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
                 onChange={handleMenuFieldChange('ctaLabel')}
               />
             </div>
-          </div>
-          <div>
-            <label htmlFor="menu-loading" className="block text-sm font-medium text-gray-700">Texte de chargement</label>
-            <input
-              id="menu-loading"
-              className="ui-input mt-1"
-              value={draft.menu.loadingLabel}
-              onChange={handleMenuFieldChange('loadingLabel')}
-            />
-          </div>
-          <div>
-            <label htmlFor="menu-image" className="block text-sm font-medium text-gray-700">
-              {IMAGE_FIELD_LABELS['menu.image']}
-            </label>
-            <input
-              id="menu-image"
-              className="ui-input mt-1"
-              value={draft.menu.image ?? ''}
-              onChange={handleImageInputChange('menu.image')}
-              placeholder="https://res.cloudinary.com/..."
-            />
-            <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
-            {imageErrors['menu.image'] && (
-              <p className="mt-1 text-xs text-red-600">{imageErrors['menu.image']}</p>
-            )}
-            <div className="mt-3 flex flex-wrap gap-2">
-              <label className="ui-btn ui-btn-secondary cursor-pointer">
-                Importer une image
-                <input
-                  type="file"
-                  accept="image/*"
-                  className="hidden"
-                  onChange={event => {
-                    const file = event.target.files?.[0];
-                    if (file) {
-                      void handleImageUpload('menu.image', file);
-                      event.target.value = '';
-                    }
-                  }}
-                />
+            <div>
+              <label htmlFor="menu-loading" className="block text-sm font-medium text-gray-700">
+                Label de chargement
               </label>
-              <button
-                type="button"
-                className="ui-btn ui-btn-ghost"
-                onClick={() => handleClearImage('menu.image')}
-                disabled={!draft.menu.image || isUploading('menu.image')}
-              >
-                Retirer l'image
-              </button>
-              {isUploading('menu.image') && (
-                <span className="text-sm text-gray-500">Téléversement en cours…</span>
-              )}
+              <input
+                id="menu-loading"
+                className="ui-input mt-1"
+                value={draft.menu.loadingLabel}
+                onChange={handleMenuFieldChange('loadingLabel')}
+              />
             </div>
           </div>
+          <ImageFieldEditor
+            field="menu.image"
+            label={IMAGE_FIELD_LABELS['menu.image']}
+            value={draft.menu.image}
+            imageErrors={imageErrors}
+            handleImageInputChange={handleImageInputChange}
+            handleImageUpload={handleImageUpload}
+            handleClearImage={handleClearImage}
+            isUploading={isUploading}
+          />
           {renderStyleControls('menu')}
         </div>
-      </Modal>
+      </SectionCard>
 
-      <Modal isOpen={activeZone === 'contact'} onClose={onClose} title="Modifier la section contact" size="xl">
-        <div className="space-y-5">
+      <SectionCard
+        ref={element => {
+          sectionRefs.current.contact = element;
+        }}
+        title="Section Contact"
+        description="Ouvrez tous vos canaux de communication avec un design à votre image."
+        open={openSections.contact}
+        onToggle={() => toggleSection('contact')}
+        highlighted={highlightedZone === 'contact'}
+      >
+        <div className="space-y-4">
           <div>
-            <label htmlFor="contact-title" className="block text-sm font-medium text-gray-700">Titre</label>
+            <label htmlFor="contact-title" className="block text-sm font-medium text-gray-700">
+              Titre
+            </label>
             <input
               id="contact-title"
               className="ui-input mt-1"
@@ -1270,7 +1357,9 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
           </div>
           <div className="grid gap-4 md:grid-cols-2">
             <div>
-              <label htmlFor="contact-address-label" className="block text-sm font-medium text-gray-700">Libellé adresse</label>
+              <label htmlFor="contact-address-label" className="block text-sm font-medium text-gray-700">
+                Label adresse
+              </label>
               <input
                 id="contact-address-label"
                 className="ui-input mt-1"
@@ -1279,7 +1368,9 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
               />
             </div>
             <div>
-              <label htmlFor="contact-address" className="block text-sm font-medium text-gray-700">Adresse</label>
+              <label htmlFor="contact-address" className="block text-sm font-medium text-gray-700">
+                Adresse
+              </label>
               <input
                 id="contact-address"
                 className="ui-input mt-1"
@@ -1288,7 +1379,9 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
               />
             </div>
             <div>
-              <label htmlFor="contact-phone-label" className="block text-sm font-medium text-gray-700">Libellé téléphone</label>
+              <label htmlFor="contact-phone-label" className="block text-sm font-medium text-gray-700">
+                Label téléphone
+              </label>
               <input
                 id="contact-phone-label"
                 className="ui-input mt-1"
@@ -1297,7 +1390,9 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
               />
             </div>
             <div>
-              <label htmlFor="contact-phone" className="block text-sm font-medium text-gray-700">Téléphone</label>
+              <label htmlFor="contact-phone" className="block text-sm font-medium text-gray-700">
+                Téléphone
+              </label>
               <input
                 id="contact-phone"
                 className="ui-input mt-1"
@@ -1306,7 +1401,9 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
               />
             </div>
             <div>
-              <label htmlFor="contact-email-label" className="block text-sm font-medium text-gray-700">Libellé email</label>
+              <label htmlFor="contact-email-label" className="block text-sm font-medium text-gray-700">
+                Label e-mail
+              </label>
               <input
                 id="contact-email-label"
                 className="ui-input mt-1"
@@ -1315,7 +1412,9 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
               />
             </div>
             <div>
-              <label htmlFor="contact-email" className="block text-sm font-medium text-gray-700">Email</label>
+              <label htmlFor="contact-email" className="block text-sm font-medium text-gray-700">
+                E-mail
+              </label>
               <input
                 id="contact-email"
                 className="ui-input mt-1"
@@ -1324,58 +1423,35 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
               />
             </div>
           </div>
-          <div>
-            <label htmlFor="contact-image" className="block text-sm font-medium text-gray-700">
-              {IMAGE_FIELD_LABELS['contact.image']}
-            </label>
-            <input
-              id="contact-image"
-              className="ui-input mt-1"
-              value={draft.contact.image ?? ''}
-              onChange={handleImageInputChange('contact.image')}
-              placeholder="https://res.cloudinary.com/..."
-            />
-            <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
-            {imageErrors['contact.image'] && (
-              <p className="mt-1 text-xs text-red-600">{imageErrors['contact.image']}</p>
-            )}
-            <div className="mt-3 flex flex-wrap gap-2">
-              <label className="ui-btn ui-btn-secondary cursor-pointer">
-                Importer une image
-                <input
-                  type="file"
-                  accept="image/*"
-                  className="hidden"
-                  onChange={event => {
-                    const file = event.target.files?.[0];
-                    if (file) {
-                      void handleImageUpload('contact.image', file);
-                      event.target.value = '';
-                    }
-                  }}
-                />
-              </label>
-              <button
-                type="button"
-                className="ui-btn ui-btn-ghost"
-                onClick={() => handleClearImage('contact.image')}
-                disabled={!draft.contact.image || isUploading('contact.image')}
-              >
-                Retirer l'image
-              </button>
-              {isUploading('contact.image') && (
-                <span className="text-sm text-gray-500">Téléversement en cours…</span>
-              )}
-            </div>
-          </div>
+          <ImageFieldEditor
+            field="contact.image"
+            label={IMAGE_FIELD_LABELS['contact.image']}
+            value={draft.contact.image}
+            imageErrors={imageErrors}
+            handleImageInputChange={handleImageInputChange}
+            handleImageUpload={handleImageUpload}
+            handleClearImage={handleClearImage}
+            isUploading={isUploading}
+          />
           {renderStyleControls('contact')}
         </div>
-      </Modal>
+      </SectionCard>
 
-      <Modal isOpen={activeZone === 'footer'} onClose={onClose} title="Modifier le pied de page" size="sm">
+      <SectionCard
+        ref={element => {
+          sectionRefs.current.footer = element;
+        }}
+        title="Pied de page & mentions"
+        description="Finalisez votre identité avec un message de bas de page sur-mesure."
+        open={openSections.footer}
+        onToggle={() => toggleSection('footer')}
+        highlighted={highlightedZone === 'footer'}
+      >
         <div className="space-y-4">
           <div>
-            <label htmlFor="footer-text" className="block text-sm font-medium text-gray-700">Texte du pied de page</label>
+            <label htmlFor="footer-text" className="block text-sm font-medium text-gray-700">
+              Texte du pied de page
+            </label>
             <input
               id="footer-text"
               className="ui-input mt-1"
@@ -1385,10 +1461,494 @@ const SiteCustomizationModals: React.FC<SiteCustomizationModalsProps> = ({
           </div>
           {renderStyleControls('footer')}
         </div>
-      </Modal>
-    </>
+      </SectionCard>
+
+      <SectionCard
+        ref={element => {
+          sectionRefs.current.assets = element;
+        }}
+        title="Médiathèque Cloudinary"
+        description="Centralisez vos images, polices, vidéos ou assets bruts pour les appliquer instantanément."
+        open={openSections.assets}
+        onToggle={() => toggleSection('assets')}
+        highlighted={false}
+      >
+        <AssetLibrary
+          assets={assetState.assets}
+          uploading={assetState.uploading}
+          error={assetState.error}
+          onUpload={assetState.onUpload}
+          onRemove={assetState.onRemove}
+          onRename={assetState.onRename}
+          onApply={assetState.onApply}
+        />
+      </SectionCard>
+    </div>
   );
 };
 
+const SectionCard = React.forwardRef<HTMLDivElement, {
+  title: string;
+  description?: string;
+  open: boolean;
+  onToggle: () => void;
+  highlighted?: boolean;
+  children: React.ReactNode;
+}>(({ title, description, open, onToggle, highlighted = false, children }, ref) => (
+  <div
+    ref={ref}
+    className={`rounded-3xl border bg-white shadow-sm transition-shadow ${
+      highlighted ? 'border-brand-primary shadow-brand-primary/20 ring-2 ring-brand-primary/10' : 'border-slate-200'
+    }`}
+  >
+    <button
+      type="button"
+      onClick={onToggle}
+      className="flex w-full items-start justify-between gap-4 rounded-3xl px-5 py-4 text-left"
+      aria-expanded={open}
+    >
+      <div>
+        <h2 className="text-base font-semibold text-slate-900">{title}</h2>
+        {description && <p className="mt-1 text-sm text-slate-500">{description}</p>}
+      </div>
+      <span
+        aria-hidden="true"
+        className={`mt-1 inline-flex h-6 w-6 items-center justify-center rounded-full border text-xs font-medium ${
+          open ? 'border-brand-primary text-brand-primary' : 'border-slate-300 text-slate-400'
+        }`}
+      >
+        {open ? '–' : '+'}
+      </span>
+    </button>
+    {open && <div className="border-t border-slate-100 px-5 py-5 text-sm text-slate-700">{children}</div>}
+  </div>
+));
+SectionCard.displayName = 'SectionCard';
+
+const StyleControls: React.FC<StyleControlsProps> = ({
+  zone,
+  style,
+  fontOptions,
+  fontSizeOptions,
+  handleStyleFontFamilyChange,
+  handleStyleFontSizeChange,
+  handleStyleTextColorChange,
+  handleStyleBackgroundColorChange,
+  handleStyleBackgroundTypeChange,
+  handleImageInputChange,
+  handleImageUpload,
+  handleClearImage,
+  imageErrors,
+  isUploading,
+}) => {
+  const backgroundField = STYLE_BACKGROUND_FIELD_KEYS[zone];
+  const isBackgroundImage = style.background.type === 'image';
+
+  const validateCssValue = useCallback((property: string, value: string) => {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return { valid: true, message: null } as const;
+    }
+
+    if (typeof window === 'undefined' || typeof window.CSS === 'undefined') {
+      return { valid: true, message: null } as const;
+    }
+
+    return window.CSS.supports(property, trimmed)
+      ? { valid: true, message: null }
+      : {
+          valid: false,
+          message: 'Cette valeur ne semble pas être reconnue comme une valeur CSS valide.',
+        };
+  }, []);
+
+  const fontFamilyValidation = validateCssValue('font-family', style.fontFamily);
+  const fontSizeValidation = validateCssValue('font-size', style.fontSize);
+  const textColorValidation = validateCssValue('color', style.textColor);
+  const backgroundColorValidation =
+    style.background.type === 'color'
+      ? validateCssValue('background-color', style.background.color)
+      : { valid: true, message: null };
+
+  return (
+    <div className="space-y-4 rounded-2xl border border-slate-200 p-4">
+      <h3 className="text-sm font-semibold uppercase tracking-wide text-slate-500">Styles</h3>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <label htmlFor={`${zone}-font-family`} className="block text-sm font-medium text-gray-700">
+            Police
+          </label>
+          <input
+            id={`${zone}-font-family`}
+            className={`ui-input mt-1 ${
+              fontFamilyValidation.valid ? '' : 'border-red-300 focus:border-red-500 focus:ring-red-500'
+            }`}
+            value={style.fontFamily}
+            onChange={event => handleStyleFontFamilyChange(zone, event.target.value)}
+            list={`${zone}-font-family-options`}
+            placeholder="Ex: 'Open Sans', sans-serif"
+          />
+          <datalist id={`${zone}-font-family-options`}>
+            {fontOptions.map(font => (
+              <option key={font} value={font} />
+            ))}
+          </datalist>
+          {!fontFamilyValidation.valid && (
+            <p className="mt-1 text-xs text-red-600">{fontFamilyValidation.message}</p>
+          )}
+          <p className="mt-1 text-xs text-gray-500">Utilisez le nom exact de la police ou une pile CSS.</p>
+        </div>
+        <div>
+          <label htmlFor={`${zone}-font-size`} className="block text-sm font-medium text-gray-700">
+            Taille du texte
+          </label>
+          <input
+            id={`${zone}-font-size`}
+            className={`ui-input mt-1 ${
+              fontSizeValidation.valid ? '' : 'border-red-300 focus:border-red-500 focus:ring-red-500'
+            }`}
+            value={style.fontSize}
+            onChange={event => handleStyleFontSizeChange(zone, event.target.value)}
+            list={`${zone}-font-size-options`}
+            placeholder="Ex: clamp(1rem, 2vw, 1.5rem)"
+          />
+          <datalist id={`${zone}-font-size-options`}>
+            {fontSizeOptions.map(size => (
+              <option key={size} value={size} />
+            ))}
+          </datalist>
+          {!fontSizeValidation.valid && (
+            <p className="mt-1 text-xs text-red-600">{fontSizeValidation.message}</p>
+          )}
+          <p className="mt-1 text-xs text-gray-500">Toutes les valeurs CSS valides sont acceptées.</p>
+        </div>
+      </div>
+      <div className="grid gap-4 md:grid-cols-2">
+        <div>
+          <label htmlFor={`${zone}-text-color`} className="block text-sm font-medium text-gray-700">
+            Couleur du texte
+          </label>
+          <div className="mt-1 flex items-center gap-3">
+            <span
+              aria-hidden="true"
+              className="h-10 w-10 rounded-md border border-gray-200"
+              style={{ backgroundColor: textColorValidation.valid ? style.textColor : 'transparent' }}
+            />
+            <input
+              id={`${zone}-text-color`}
+              className={`ui-input ${
+                textColorValidation.valid ? '' : 'border-red-300 focus:border-red-500 focus:ring-red-500'
+              }`}
+              value={style.textColor}
+              onChange={event => handleStyleTextColorChange(zone, event.target.value)}
+              list={`${zone}-text-color-options`}
+              placeholder="Ex: #0f172a ou rgba(15, 23, 42, 0.8)"
+            />
+          </div>
+          <datalist id={`${zone}-text-color-options`}>
+            {COLOR_SUGGESTIONS.map(color => (
+              <option key={color} value={color} />
+            ))}
+          </datalist>
+          {!textColorValidation.valid && (
+            <p className="mt-1 text-xs text-red-600">{textColorValidation.message}</p>
+          )}
+          <p className="mt-1 text-xs text-gray-500">Entrez une valeur hexadécimale, rgba(), hsl() ou un nom CSS.</p>
+        </div>
+        <div>
+          <label htmlFor={`${zone}-background-type`} className="block text-sm font-medium text-gray-700">
+            Type de fond
+          </label>
+          <select
+            id={`${zone}-background-type`}
+            className="ui-select mt-1"
+            value={style.background.type}
+            onChange={event =>
+              handleStyleBackgroundTypeChange(zone, event.target.value as SectionStyle['background']['type'])
+            }
+          >
+            {BACKGROUND_TYPE_OPTIONS.map(option => (
+              <option key={option.value} value={option.value}>
+                {option.label}
+              </option>
+            ))}
+          </select>
+        </div>
+      </div>
+      {style.background.type === 'color' && (
+        <div>
+          <label htmlFor={`${zone}-background-color`} className="block text-sm font-medium text-gray-700">
+            Couleur du fond
+          </label>
+          <div className="mt-1 flex items-center gap-3">
+            <span
+              aria-hidden="true"
+              className="h-10 w-10 rounded-md border border-gray-200"
+              style={{ backgroundColor: backgroundColorValidation.valid ? style.background.color : 'transparent' }}
+            />
+            <input
+              id={`${zone}-background-color`}
+              className={`ui-input ${
+                backgroundColorValidation.valid
+                  ? ''
+                  : 'border-red-300 focus:border-red-500 focus:ring-red-500'
+              }`}
+              value={style.background.color}
+              onChange={event => handleStyleBackgroundColorChange(zone, event.target.value)}
+              list={`${zone}-background-color-options`}
+              placeholder="Ex: rgba(255, 255, 255, 0.75)"
+            />
+          </div>
+          <datalist id={`${zone}-background-color-options`}>
+            {COLOR_SUGGESTIONS.map(color => (
+              <option key={color} value={color} />
+            ))}
+          </datalist>
+          {!backgroundColorValidation.valid && (
+            <p className="mt-1 text-xs text-red-600">{backgroundColorValidation.message}</p>
+          )}
+          <p className="mt-1 text-xs text-gray-500">Accepte toutes les valeurs de couleur CSS valides.</p>
+        </div>
+      )}
+      {isBackgroundImage && (
+        <ImageFieldEditor
+          field={backgroundField}
+          label={IMAGE_FIELD_LABELS[backgroundField]}
+          value={style.background.image}
+          imageErrors={imageErrors}
+          handleImageInputChange={handleImageInputChange}
+          handleImageUpload={handleImageUpload}
+          handleClearImage={handleClearImage}
+          isUploading={isUploading}
+        />
+      )}
+    </div>
+  );
+};
+
+const ImageFieldEditor: React.FC<ImageFieldEditorProps> = ({
+  field,
+  label,
+  value,
+  imageErrors,
+  handleImageInputChange,
+  handleImageUpload,
+  handleClearImage,
+  isUploading,
+}) => (
+  <div>
+    <label htmlFor={`${field}-input`} className="block text-sm font-medium text-gray-700">
+      {label}
+    </label>
+    <input
+      id={`${field}-input`}
+      className="ui-input mt-1"
+      value={value ?? ''}
+      onChange={handleImageInputChange(field)}
+      placeholder="https://res.cloudinary.com/..."
+    />
+    <p className="mt-1 text-xs text-gray-500">{imageWarning}</p>
+    {imageErrors[field] && <p className="mt-1 text-xs text-red-600">{imageErrors[field]}</p>}
+    <div className="mt-3 flex flex-wrap gap-2">
+      <label className="ui-btn ui-btn-secondary cursor-pointer">
+        Importer une ressource
+        <input
+          type="file"
+          accept="image/*,video/*,audio/*,.ttf,.otf,.woff,.woff2,.svg"
+          className="hidden"
+          onChange={event => {
+            const file = event.target.files?.[0];
+            if (file) {
+              void handleImageUpload(field, file);
+              event.target.value = '';
+            }
+          }}
+        />
+      </label>
+      <button
+        type="button"
+        className="ui-btn ui-btn-ghost"
+        onClick={() => handleClearImage(field)}
+        disabled={!value || isUploading(field)}
+      >
+        Retirer
+      </button>
+      {isUploading(field) && <span className="text-sm text-gray-500">Téléversement en cours…</span>}
+    </div>
+  </div>
+);
+
+const AssetLibrary: React.FC<{
+  assets: CustomizationAsset[];
+  uploading: boolean;
+  error: string | null;
+  onUpload: AssetUploadHandler;
+  onRemove: AssetRemoveHandler;
+  onRename: AssetRenameHandler;
+  onApply: AssetApplyHandler;
+}> = ({ assets, uploading, error, onUpload, onRemove, onRename, onApply }) => {
+  const [copiedAssetId, setCopiedAssetId] = useState<string | null>(null);
+  const [selectedField, setSelectedField] = useState<Record<string, ImageFieldKey>>({});
+
+  useEffect(() => {
+    if (!copiedAssetId) {
+      return;
+    }
+    const timeout = window.setTimeout(() => setCopiedAssetId(null), 1800);
+    return () => window.clearTimeout(timeout);
+  }, [copiedAssetId]);
+
+  const imageFieldEntries = useMemo(
+    () =>
+      (Object.entries(IMAGE_FIELD_LABELS) as [ImageFieldKey, string][]).map(([key, label]) => ({
+        key,
+        label,
+      })),
+    [],
+  );
+
+  const handleCopy = async (asset: CustomizationAsset) => {
+    try {
+      if (navigator?.clipboard?.writeText) {
+        await navigator.clipboard.writeText(asset.url);
+        setCopiedAssetId(asset.id);
+      }
+    } catch (clipboardError) {
+      console.warn('Clipboard copy failed', clipboardError);
+    }
+  };
+
+  return (
+    <div className="space-y-4">
+      <div className="rounded-2xl border border-dashed border-slate-300 bg-slate-50 p-4">
+        <p className="text-sm text-slate-600">
+          Téléversez vos fichiers directement dans le dossier <strong>Custom</strong> de Cloudinary. Images HD, textures, polices,
+          vidéos d'ambiance… utilisez la ressource de votre choix.
+        </p>
+        <label className="mt-3 inline-flex items-center gap-2 rounded-full bg-brand-primary/10 px-4 py-2 text-sm font-medium text-brand-primary">
+          <Upload className="h-4 w-4" aria-hidden="true" />
+          Importer depuis mon ordinateur
+          <input
+            type="file"
+            accept="image/*,video/*,audio/*,.ttf,.otf,.woff,.woff2,.zip,.svg,.json,.pdf"
+            multiple
+            className="hidden"
+            onChange={event => {
+              void onUpload(event.target.files);
+              event.target.value = '';
+            }}
+          />
+        </label>
+        {uploading && (
+          <div className="mt-2 flex items-center gap-2 text-sm text-slate-500">
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+            Téléversement en cours…
+          </div>
+        )}
+        {error && <p className="mt-2 text-sm text-red-600">{error}</p>}
+      </div>
+
+      {assets.length === 0 ? (
+        <p className="text-sm text-slate-500">
+          Aucun asset personnalisé pour le moment. Téléversez vos premiers fichiers pour les réutiliser partout dans la vitrine.
+        </p>
+      ) : (
+        <div className="space-y-4">
+          {assets.map(asset => (
+            <div
+              key={asset.id}
+              className="flex flex-col gap-3 rounded-2xl border border-slate-200 p-4 md:flex-row md:items-start md:justify-between"
+            >
+              <div className="flex flex-1 flex-col gap-2">
+                <div className="flex items-center gap-2">
+                  <span className="inline-flex h-8 w-8 items-center justify-center rounded-full bg-slate-100 text-slate-600">
+                    <AssetTypeIcon type={asset.type} />
+                  </span>
+                  <div className="min-w-0 flex-1">
+                    <input
+                      className="w-full truncate rounded-md border border-transparent px-0 text-base font-semibold text-slate-900 focus:border-slate-300 focus:px-2 focus:outline-none focus:ring-1 focus:ring-brand-primary"
+                      value={asset.name}
+                      onChange={event => onRename(asset.id, event.target.value)}
+                    />
+                    <p className="text-xs text-slate-500">
+                      {ASSET_TYPE_LABELS[asset.type]} · {formatBytes(asset.bytes)} ·{' '}
+                      {new Date(asset.createdAt).toLocaleString()}
+                    </p>
+                  </div>
+                </div>
+                <div className="flex flex-wrap items-center gap-2 text-xs text-slate-500">
+                  <LinkIcon className="h-3.5 w-3.5" aria-hidden="true" />
+                  <span className="truncate" title={asset.url}>
+                    {asset.url}
+                  </span>
+                </div>
+              </div>
+              <div className="flex flex-col gap-2 md:w-60">
+                <div className="flex items-center gap-2">
+                  <button
+                    type="button"
+                    className="ui-btn ui-btn-secondary flex-1"
+                    onClick={() => void handleCopy(asset)}
+                  >
+                    <Copy className="h-4 w-4" aria-hidden="true" />
+                    {copiedAssetId === asset.id ? 'Lien copié !' : 'Copier le lien'}
+                  </button>
+                  <button
+                    type="button"
+                    className="ui-btn ui-btn-ghost"
+                    onClick={() => onRemove(asset.id)}
+                  >
+                    <Trash2 className="h-4 w-4" aria-hidden="true" />
+                  </button>
+                </div>
+                <div className="flex flex-col gap-2">
+                  <label className="text-xs font-medium text-slate-500" htmlFor={`asset-field-${asset.id}`}>
+                    Appliquer à une section
+                  </label>
+                  <div className="flex items-center gap-2">
+                    <select
+                      id={`asset-field-${asset.id}`}
+                      className="ui-select flex-1"
+                      value={selectedField[asset.id] ?? ''}
+                      onChange={event =>
+                        setSelectedField(prev => ({
+                          ...prev,
+                          [asset.id]: event.target.value as ImageFieldKey,
+                        }))
+                      }
+                    >
+                      <option value="" disabled>
+                        Choisir…
+                      </option>
+                      {imageFieldEntries.map(({ key, label: optionLabel }) => (
+                        <option key={key} value={key}>
+                          {optionLabel}
+                        </option>
+                      ))}
+                    </select>
+                    <button
+                      type="button"
+                      className="ui-btn ui-btn-primary"
+                      disabled={!selectedField[asset.id]}
+                      onClick={() => {
+                        const field = selectedField[asset.id];
+                        if (field) {
+                          onApply(field, asset);
+                        }
+                      }}
+                    >
+                      Appliquer
+                    </button>
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+};
 
 export default SiteCustomization;
+

--- a/services/cloudinary.ts
+++ b/services/cloudinary.ts
@@ -167,6 +167,33 @@ export const uploadProductImage = async (
   });
 };
 
+const resolveCustomizationFolder = (): string =>
+  sanitizeSegment(getEnv('VITE_CLOUDINARY_CUSTOM_FOLDER') ?? 'Custom', 'Custom');
+
+type CustomizationAssetOptions = {
+  tags?: string[];
+  publicId?: string;
+};
+
+export const uploadCustomizationAsset = async (
+  file: File | Blob,
+  options?: CustomizationAssetOptions,
+): Promise<string> => {
+  const folder = resolveCustomizationFolder();
+  const preset = getEnv('VITE_CLOUDINARY_UPLOAD_PRESET_CUSTOM') ?? getEnv('VITE_CLOUDINARY_UPLOAD_PRESET');
+  const baseName =
+    options?.publicId ?? (file instanceof File && file.name ? slugify(file.name.replace(/\.[^/.]+$/, '')) : undefined);
+  const publicId = baseName ? `${baseName}-${generateSuffix()}` : undefined;
+  const tags = Array.from(new Set(['customization', 'custom-folder', ...(options?.tags ?? [])]));
+
+  return uploadToCloudinary(file, {
+    folder,
+    uploadPreset: preset,
+    publicId,
+    tags,
+  });
+};
+
 export type ReceiptUploadOptions = {
   orderId?: string;
   customerReference?: string;

--- a/types/index.ts
+++ b/types/index.ts
@@ -23,6 +23,22 @@ export interface SectionStyle {
   textColor: string;
 }
 
+export type CustomizationAssetType = 'image' | 'video' | 'audio' | 'font' | 'raw';
+
+export interface CustomizationAsset {
+  id: string;
+  name: string;
+  url: string;
+  format: string;
+  bytes: number;
+  type: CustomizationAssetType;
+  createdAt: string;
+}
+
+export interface SiteAssets {
+  library: CustomizationAsset[];
+}
+
 export interface SiteContent {
   navigation: {
     brand: string;
@@ -72,6 +88,7 @@ export interface SiteContent {
     text: string;
     style: SectionStyle;
   };
+  assets: SiteAssets;
 }
 
 export interface Ingredient {

--- a/utils/siteContent.ts
+++ b/utils/siteContent.ts
@@ -1,4 +1,10 @@
-import { SectionStyle, SiteContent } from '../types';
+import {
+  CustomizationAsset,
+  CustomizationAssetType,
+  SectionStyle,
+  SiteAssets,
+  SiteContent,
+} from '../types';
 import { normalizeCloudinaryImageUrl } from '../services/cloudinary';
 
 const trimOrEmpty = (value: string): string => value.trim();
@@ -40,6 +46,88 @@ const resolveImage = (value: string | null | undefined, fallback: string | null)
 const sanitizeImage = (value: string | null | undefined): string | null => {
   const normalized = normalizeCloudinaryImageUrl(value);
   return normalized ?? null;
+};
+
+const ASSET_TYPES: CustomizationAssetType[] = ['image', 'video', 'audio', 'font', 'raw'];
+
+const generateAssetId = (): string => `asset-${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;
+
+const resolveAssetType = (type: unknown): CustomizationAssetType =>
+  ASSET_TYPES.includes(type as CustomizationAssetType) ? (type as CustomizationAssetType) : 'raw';
+
+const resolveAssetTimestamp = (value: unknown): string => {
+  if (typeof value === 'string') {
+    const timestamp = Date.parse(value);
+    if (!Number.isNaN(timestamp)) {
+      return new Date(timestamp).toISOString();
+    }
+  }
+  return new Date().toISOString();
+};
+
+const resolveAssetBytes = (value: unknown): number => {
+  const numeric = typeof value === 'number' ? value : Number(value);
+  if (!Number.isFinite(numeric) || numeric < 0) {
+    return 0;
+  }
+  return Math.round(numeric);
+};
+
+const sanitizeCustomizationAsset = (asset: Partial<CustomizationAsset> | null | undefined): CustomizationAsset | null => {
+  if (!asset) {
+    return null;
+  }
+
+  const normalizedUrl = normalizeCloudinaryImageUrl(asset.url ?? undefined);
+  if (!normalizedUrl) {
+    return null;
+  }
+
+  const id = typeof asset.id === 'string' && asset.id.trim().length > 0 ? asset.id.trim() : generateAssetId();
+  const name = typeof asset.name === 'string' && asset.name.trim().length > 0 ? asset.name.trim() : id;
+  const format = typeof asset.format === 'string' && asset.format.trim().length > 0 ? asset.format.trim() : 'application/octet-stream';
+  const type = resolveAssetType(asset.type);
+  const bytes = resolveAssetBytes(asset.bytes);
+  const createdAt = resolveAssetTimestamp(asset.createdAt);
+
+  return {
+    id,
+    name,
+    url: normalizedUrl,
+    format,
+    bytes,
+    type,
+    createdAt,
+  };
+};
+
+const resolveSiteAssets = (assets: Partial<SiteAssets> | null | undefined, fallback: SiteAssets): SiteAssets => {
+  if (!assets) {
+    return fallback;
+  }
+
+  const library = Array.isArray(assets.library)
+    ? (assets.library
+        .map(entry => sanitizeCustomizationAsset(entry))
+        .filter(Boolean) as CustomizationAsset[])
+    : fallback.library;
+
+  return {
+    library,
+  };
+};
+
+const sanitizeSiteAssets = (assets: SiteAssets | undefined, fallback: SiteAssets): SiteAssets => {
+  const source = assets ?? fallback;
+  const library = Array.isArray(source.library)
+    ? (source.library
+        .map(entry => sanitizeCustomizationAsset(entry))
+        .filter(Boolean) as CustomizationAsset[])
+    : fallback.library;
+
+  return {
+    library,
+  };
 };
 
 const DEFAULT_NAVIGATION_STYLE: SectionStyle = {
@@ -106,6 +194,10 @@ const DEFAULT_FOOTER_STYLE: SectionStyle = {
   fontFamily: 'Inter',
   fontSize: '14px',
   textColor: '#e2e8f0',
+};
+
+const DEFAULT_SITE_ASSETS: SiteAssets = {
+  library: [],
 };
 
 const resolveSectionStyle = (style: Partial<SectionStyle> | undefined, fallback: SectionStyle): SectionStyle => {
@@ -196,6 +288,7 @@ export const DEFAULT_SITE_CONTENT: SiteContent = {
     text: 'Tous droits réservés.',
     style: DEFAULT_FOOTER_STYLE,
   },
+  assets: DEFAULT_SITE_ASSETS,
 };
 
 export const resolveSiteContent = (content?: Partial<SiteContent> | null): SiteContent => {
@@ -249,6 +342,7 @@ export const resolveSiteContent = (content?: Partial<SiteContent> | null): SiteC
       text: resolveString(content?.footer?.text, base.footer.text),
       style: resolveSectionStyle(content?.footer?.style, base.footer.style),
     },
+    assets: resolveSiteAssets(content?.assets ?? null, DEFAULT_SITE_ASSETS),
   };
 };
 
@@ -301,4 +395,5 @@ export const sanitizeSiteContentInput = (content: SiteContent): SiteContent => (
     text: trimOrEmpty(content.footer.text),
     style: sanitizeSectionStyle(content.footer.style, DEFAULT_FOOTER_STYLE),
   },
+  assets: sanitizeSiteAssets(content.assets, DEFAULT_SITE_ASSETS),
 });


### PR DESCRIPTION
## Summary
- Repenser l'onglet de personnalisation en un espace de travail à panneaux avec prévisualisation instantanée et médiathèque intégrée.
- Étendre le modèle `SiteContent` pour stocker une bibliothèque d'actifs personnalisés et relier chaque section à ces ressources.
- Ajouter un helper Cloudinary dédié au dossier `Custom` afin de gérer l'upload et la réutilisation des assets utilisateurs.

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dbc59297a8832a920a4ecdfe227e94