### PR TITLE
Update UI text and order tracking experience

### DIFF
--- a/components/CustomerOrderTracker.tsx
+++ b/components/CustomerOrderTracker.tsx
@@ -42,27 +42,36 @@ const CustomerOrderTracker: React.FC<CustomerOrderTrackerProps> = ({ orderId, on
     const [isReceiptModalOpen, setReceiptModalOpen] = useState(false);
 
     const steps = [
-        { name: 'En attente', icon: FileText },
-        { name: 'En préparation', icon: ChefHat },
-        { name: 'Prête', icon: PackageCheck },
-        { name: 'Terminée', icon: CheckCircle }
+        { name: 'Enviado', icon: FileText },
+        { name: 'Validado', icon: CheckCircle },
+        { name: 'En preparacion', icon: ChefHat },
+        { name: 'Listo', icon: PackageCheck }
     ];
 
     const getCurrentStepIndex = useCallback((order: Order | null): number => {
         if (!order) return -1;
 
-        const isDelivered =
+        if (
             order.statut === 'finalisee' ||
             order.estado_cocina === 'servido' ||
-            order.estado_cocina === 'entregada';
-
-        if (isDelivered) {
+            order.estado_cocina === 'entregada' ||
+            order.estado_cocina === 'listo'
+        ) {
             return 3;
         }
 
-        if (order.estado_cocina === 'listo') return 2;
-        if (order.estado_cocina === 'recibido') return 1;
-        if (order.statut === 'pendiente_validacion') return 0;
+        if (order.estado_cocina === 'recibido') {
+            return 2;
+        }
+
+        if (order.statut === 'en_cours') {
+            return 1;
+        }
+
+        if (order.statut === 'pendiente_validacion' || order.estado_cocina === 'no_enviado') {
+            return 0;
+        }
+
         return -1;
     }, []);
 
@@ -113,7 +122,8 @@ const CustomerOrderTracker: React.FC<CustomerOrderTrackerProps> = ({ orderId, on
     const isOrderCompleted =
         order?.statut === 'finalisee' ||
         order?.estado_cocina === 'servido' ||
-        order?.estado_cocina === 'entregada';
+        order?.estado_cocina === 'entregada' ||
+        order?.estado_cocina === 'listo';
 
     const containerClasses = variant === 'page'
       ? "container mx-auto p-4 lg:p-8"
@@ -188,7 +198,7 @@ const CustomerOrderTracker: React.FC<CustomerOrderTrackerProps> = ({ orderId, on
                         ))}
                     </div>
                     <div className={`flex justify-between font-bold text-lg border-t pt-2 ${variant === 'hero' ? 'text-white border-gray-500' : 'text-gray-800'}`}>
-                        <span>Total (pesos colombianos)</span>
+                        <span>Total</span>
                         <span>{formatCurrencyCOP(order.total)}</span>
                     </div>
 
@@ -206,7 +216,7 @@ const CustomerOrderTracker: React.FC<CustomerOrderTrackerProps> = ({ orderId, on
                     {isOrderCompleted && (
                         <div className="flex justify-center">
                             <span className="inline-flex items-center gap-2 rounded-full bg-green-100 px-4 py-2 text-sm font-semibold text-green-700">
-                                <CheckCircle size={16} /> Terminée
+                                <CheckCircle size={16} /> Pedido listo
                             </span>
                         </div>
                     )}

--- a/components/PaymentModal.tsx
+++ b/components/PaymentModal.tsx
@@ -29,7 +29,7 @@ const PaymentModal: React.FC<PaymentModalProps> = ({ isOpen, onClose, order, onF
     <Modal isOpen={isOpen} onClose={onClose} title={`Finalizar el pedido #${order.id.slice(-4)}`}>
       <form onSubmit={handleSubmit} className="space-y-6">
         <div className="text-center">
-          <p className="text-gray-600">Total a pagar (pesos colombianos)</p>
+          <p className="text-gray-600">Total a pagar</p>
           <p className="text-4xl font-extrabold text-gray-900">{formatCurrencyCOP(order.total)}</p>
         </div>
 

--- a/components/ReportModal.tsx
+++ b/components/ReportModal.tsx
@@ -61,9 +61,9 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
         parts.push('---');
 
         parts.push(`*Estadísticas del día*`);
-        parts.push(`- Ventas (pesos colombianos): *${formatCurrencyCOP(reportData.ventesDuJour)}*`);
+        parts.push(`- Ventas: *${formatCurrencyCOP(reportData.ventesDuJour)}*`);
         parts.push(`- Clientes: *${reportData.clientsDuJour}*`);
-        parts.push(`- Ticket promedio (pesos colombianos): *${formatCurrencyCOP(reportData.panierMoyen)}*`);
+        parts.push(`- Ticket promedio: *${formatCurrencyCOP(reportData.panierMoyen)}*`);
         parts.push('---');
 
         parts.push(`*Productos vendidos*`);
@@ -73,7 +73,7 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
           reportData.soldProducts.forEach(category => {
             parts.push(`\n_${category.categoryName}_`);
             category.products.forEach(product => {
-              parts.push(`  - ${product.quantity}x ${product.name} (${formatCurrencyCOP(product.totalSales)} pesos colombianos)`);
+              parts.push(`  - ${product.quantity}x ${product.name} (${formatCurrencyCOP(product.totalSales)})`);
             });
           });
         }
@@ -148,9 +148,9 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
                             </div>
 
                             <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 gap-4">
-                                <ReportStat icon={<DollarSign/>} label="Ventas del día (pesos colombianos)" value={formatCurrencyCOP(report.ventesDuJour)} />
+                                <ReportStat icon={<DollarSign/>} label="Ventas del día" value={formatCurrencyCOP(report.ventesDuJour)} />
                                 <ReportStat icon={<Users/>} label="Clientes del día" value={report.clientsDuJour} />
-                                <ReportStat icon={<ShoppingCart/>} label="Ticket promedio (pesos colombianos)" value={formatCurrencyCOP(report.panierMoyen)} />
+                                <ReportStat icon={<ShoppingCart/>} label="Ticket promedio" value={formatCurrencyCOP(report.panierMoyen)} />
                             </div>
 
                             <div>
@@ -162,7 +162,7 @@ const ReportModal: React.FC<{ isOpen: boolean; onClose: () => void }> = ({ isOpe
                                             <ul className="list-disc list-inside pl-2 text-gray-700">
                                                 {category.products.map(product => (
                                                     <li key={product.id}>
-                                                        {product.quantity}x {product.name} - <span className="font-semibold">{formatCurrencyCOP(product.totalSales)} (pesos colombianos)</span>
+                                                        {product.quantity}x {product.name} - <span className="font-semibold">{formatCurrencyCOP(product.totalSales)}</span>
                                                     </li>
                                                 ))}
                                             </ul>

--- a/components/commande/OrderSummary.tsx
+++ b/components/commande/OrderSummary.tsx
@@ -137,7 +137,7 @@ const OrderSummary: React.FC<OrderSummaryProps> = ({
             </div>
             <div className="p-4 border-t space-y-4">
                 <div className="flex justify-between text-2xl font-semibold text-brand-secondary">
-                    <span>Total (pesos colombianos)</span>
+                    <span>Total</span>
                     <span>{formatCurrencyCOP(total)}</span>
                 </div>
 

--- a/constants/index.ts
+++ b/constants/index.ts
@@ -7,7 +7,6 @@ export const NAV_LINKS = [
   { name: 'À Emporter', href: '/para-llevar', icon: ShoppingBag, permissionKey: '/para-llevar' },
   { name: 'Plan de Salle', href: '/ventes', icon: Armchair, permissionKey: '/ventes' },
   { name: 'Cuisine', href: '/cocina', icon: Soup, permissionKey: '/cocina' },
-  { name: 'Résumé Ventes', href: '/resume-ventes', icon: AreaChart, permissionKey: '/resume-ventes' },
   {
     name: 'Personnalisation',
     href: SITE_CUSTOMIZER_PERMISSION_KEY,
@@ -16,6 +15,7 @@ export const NAV_LINKS = [
   },
   { name: 'Produits', href: '/produits', icon: UtensilsCrossed, permissionKey: '/produits' },
   { name: 'Ingrédients', href: '/ingredients', icon: Package, permissionKey: '/ingredients' },
+  { name: 'Résumé Ventes', href: '/resume-ventes', icon: AreaChart, permissionKey: '/resume-ventes' },
 ];
 
 export const ROLES = {

--- a/pages/Commande.tsx
+++ b/pages/Commande.tsx
@@ -654,16 +654,12 @@ const Commande: React.FC = () => {
             {/* Menu Section */}
             <div className="lg:col-span-2 ui-card flex flex-col">
                 <div className="p-4">
-                    <div className="flex flex-col gap-4">
-                        <div className="flex items-center gap-4">
-                            <button onClick={handleExitAttempt} className="ui-btn-dark" title="Retour au plan de salle">
-                                <ArrowLeft size={20} />
-                                <span className="hidden sm:inline">Plan de Salle</span>
-                            </button>
-                        </div>
-                        <div className="flex flex-col gap-2">
-                            <h2 className="text-2xl font-semibold text-white">Table {order.table_nom}</h2>
-                        </div>
+                    <div className="flex flex-wrap items-center justify-between gap-4">
+                        <button onClick={handleExitAttempt} className="ui-btn-dark" title="Retour au plan de salle">
+                            <ArrowLeft size={20} />
+                            <span>Retour plan de salle</span>
+                        </button>
+                        <h2 className="text-2xl font-semibold text-gray-900">Table {order.table_nom}</h2>
                     </div>
                 </div>
                 <ProductGrid

--- a/pages/CommandeClient.tsx
+++ b/pages/CommandeClient.tsx
@@ -289,7 +289,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
     const generateWhatsAppMessage = (order: Order) => {
         const header = `*Nuevo pedido OUIOUITACOS #${order.id.slice(-6)}*`;
         const itemLines = (order.items ?? []).map(item => {
-            const baseLine = `- ${item.quantite}x ${item.nom_produit} (${formatCurrencyCOP(item.prix_unitaire)} pesos colombianos) → ${formatCurrencyCOP(item.prix_unitaire * item.quantite)} pesos colombianos`;
+            const baseLine = `- ${item.quantite}x ${item.nom_produit} (${formatCurrencyCOP(item.prix_unitaire)}) → ${formatCurrencyCOP(item.prix_unitaire * item.quantite)}`;
             const details: string[] = [];
             if (item.commentaire) {
                 details.push(`Comentario: ${item.commentaire}`);
@@ -301,7 +301,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
         });
         const items = itemLines.length > 0 ? itemLines.join('\n') : 'Sin artículos';
         const totalValue = order.total ?? order.items.reduce((sum, item) => sum + item.prix_unitaire * item.quantite, 0);
-        const totalMsg = `*Total (pesos colombianos): ${formatCurrencyCOP(totalValue)}*`;
+        const totalMsg = `*Total: ${formatCurrencyCOP(totalValue)}*`;
         const paymentMethod = order.payment_method ? `Pago: ${order.payment_method}` : undefined;
         const client = `Cliente: ${order.clientInfo?.nom} (${order.clientInfo?.telephone})\nDirección: ${order.clientInfo?.adresse}`;
         const footer = 'Comprobante de pago adjunto.';

--- a/pages/Dashboard.tsx
+++ b/pages/Dashboard.tsx
@@ -8,25 +8,25 @@ import RoleManager from '../components/role-manager';
 import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 
 const MainStatCard: React.FC<{ title: string; value: string; icon: React.ReactNode }> = ({ title, value, icon }) => (
-    <div className="ui-card p-6 flex items-center space-x-4">
+    <div className="ui-card p-6 flex items-center space-x-4 min-w-0">
         <div className="p-4 bg-brand-primary/20 text-brand-primary rounded-full">
             {icon}
         </div>
-        <div>
+        <div className="flex-1 min-w-0">
             <p className="text-sm font-semibold text-gray-500">{title}</p>
-            <p className="text-2xl md:text-3xl xl:text-4xl font-bold text-gray-800">{value}</p>
+            <p className="text-2xl md:text-3xl xl:text-4xl font-bold text-gray-800 break-words leading-tight">{value}</p>
         </div>
     </div>
 );
 
 const OpStatCard: React.FC<{ title: string; value: string | number; icon: React.ReactNode; onClick?: () => void }> = ({ title, value, icon, onClick }) => (
-    <div className={`ui-card p-4 flex items-center space-x-3 ${onClick ? 'cursor-pointer hover:bg-gray-50' : ''}`} onClick={onClick}>
+    <div className={`ui-card p-4 flex items-center space-x-3 min-w-0 ${onClick ? 'cursor-pointer hover:bg-gray-50' : ''}`} onClick={onClick}>
         <div className="p-3 bg-gray-100 text-gray-600 rounded-lg">
             {icon}
         </div>
-        <div>
+        <div className="flex-1 min-w-0">
             <p className="text-xs text-gray-500">{title}</p>
-            <p className="text-lg sm:text-xl xl:text-2xl font-bold text-gray-800">{value}</p>
+            <p className="text-lg sm:text-xl xl:text-2xl font-bold text-gray-800 break-words leading-tight">{value}</p>
         </div>
     </div>
 );
@@ -113,10 +113,10 @@ const Dashboard: React.FC = () => {
 
             {/* Block 1: Key Indicators */}
             <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
-                <MainStatCard title={`Ventas (${stats.periodLabel}) · pesos colombianos`} value={formatCurrencyCOP(stats.ventesPeriode)} icon={<DollarSign size={28}/>} />
-                <MainStatCard title={`Beneficio (${stats.periodLabel}) · pesos colombianos`} value={formatCurrencyCOP(stats.beneficePeriode)} icon={<DollarSign size={28}/>} />
+                <MainStatCard title={`Ventas (${stats.periodLabel})`} value={formatCurrencyCOP(stats.ventesPeriode)} icon={<DollarSign size={28}/>} />
+                <MainStatCard title={`Beneficio (${stats.periodLabel})`} value={formatCurrencyCOP(stats.beneficePeriode)} icon={<DollarSign size={28}/>} />
                 <MainStatCard title={`Clientes (${stats.periodLabel})`} value={stats.clientsPeriode.toString()} icon={<Users size={28}/>} />
-                <MainStatCard title="Ticket promedio (pesos colombianos)" value={formatCurrencyCOP(stats.panierMoyen)} icon={<BarChart2 size={28}/>} />
+                <MainStatCard title="Ticket promedio" value={formatCurrencyCOP(stats.panierMoyen)} icon={<BarChart2 size={28}/>} />
             </div>
 
             {/* Block 2: Operational Status */}
@@ -142,8 +142,8 @@ const Dashboard: React.FC = () => {
                         <YAxis />
                         <Tooltip />
                         <Legend />
-                        <Bar dataKey="ventes" fill="#8884d8" name={`${stats.periodLabel} (pesos colombianos)`} />
-                        <Bar dataKey="ventesPeriodePrecedente" fill="#d8d6f5" name="Periodo anterior (pesos colombianos)" />
+                        <Bar dataKey="ventes" fill="#8884d8" name={`${stats.periodLabel}`} />
+                        <Bar dataKey="ventesPeriodePrecedente" fill="#d8d6f5" name="Periodo anterior" />
                     </BarChart>
                 </ResponsiveContainer>
             </div>

--- a/pages/Ingredients.tsx
+++ b/pages/Ingredients.tsx
@@ -87,7 +87,7 @@ const Ingredients: React.FC = () => {
                                 <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Nom</th>
                                 <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Stock Actuel</th>
                                 <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Stock Minimum</th>
-                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Prix unitaire moyen (pesos colombianos)</th>
+                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Prix unitaire moyen</th>
                                 {canEdit && <th className="p-3 text-right text-sm font-medium text-gray-500 uppercase tracking-wider">Actions</th>}
                             </tr>
                         </thead>
@@ -238,7 +238,7 @@ const ResupplyModal: React.FC<{ isOpen: boolean; onClose: () => void; onSuccess:
                     <input type="number" id="quantity" min="0.01" step="0.01" value={quantity} onChange={e => setQuantity(parseFloat(e.target.value))} required className="mt-1 ui-input"/>
                 </div>
                 <div>
-                    <label htmlFor="unitPrice" className="block text-sm font-medium text-gray-700">Prix par unité (pesos colombianos/{ingredient.unite})</label>
+                    <label htmlFor="unitPrice" className="block text-sm font-medium text-gray-700">Prix par unité ({ingredient.unite})</label>
                     <input type="number" id="unitPrice" min="0" step="0.01" value={unitPrice} onChange={e => setUnitPrice(parseFloat(e.target.value))} required className="mt-1 ui-input"/>
                 </div>
                 <div className="flex flex-col sm:flex-row gap-3 pt-4">

--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useCallback } from 'react';
 import { api } from '../services/api';
 import { Order, OrderItem } from '../types';
-import { Eye, User, MapPin } from 'lucide-react';
+import { Eye, User, MapPin, Phone } from 'lucide-react';
 import Modal from '../components/Modal';
 import OrderTimer from '../components/OrderTimer';
 import { getOrderUrgencyStyles } from '../utils/orderUrgency';
@@ -46,9 +46,17 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                     {order.clientInfo && (
                         <div className="space-y-2 rounded-lg border border-gray-200 bg-gray-50 p-4 shadow-sm">
                             {order.clientInfo.nom && (
-                                <div className="flex items-center gap-2 text-sm text-gray-900">
-                                    <User size={16} className={urgencyStyles.icon} />
-                                    <span className="font-medium">{order.clientInfo.nom}</span>
+                                <div className="space-y-1">
+                                    <div className="flex items-center gap-2 text-sm text-gray-900">
+                                        <User size={16} className={urgencyStyles.icon} />
+                                        <span className="font-medium">{order.clientInfo.nom}</span>
+                                    </div>
+                                    {order.clientInfo.telephone && (
+                                        <div className="flex items-center gap-2 text-xs text-gray-600 ml-6">
+                                            <Phone size={14} className="text-gray-500" />
+                                            <span>{order.clientInfo.telephone}</span>
+                                        </div>
+                                    )}
                                 </div>
                             )}
                             {order.clientInfo.adresse && (
@@ -75,7 +83,7 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
                     </div>
 
                     <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 font-semibold text-gray-900 shadow-sm">
-                        <span>Total (pesos colombianos)</span>
+                        <span>Total</span>
                         <span className="text-lg sm:text-xl text-gray-900">{formatCurrencyCOP(order.total)}</span>
                     </div>
                 </div>

--- a/pages/Produits.tsx
+++ b/pages/Produits.tsx
@@ -431,7 +431,7 @@ const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSu
                             <input type="text" value={formData.nom_produit} onChange={e => setFormData({...formData, nom_produit: e.target.value})} required className="mt-1 ui-input"/>
                         </div>
                         <div>
-                            <label className="block text-sm font-medium text-gray-700">Prix de vente (pesos colombianos)</label>
+                            <label className="block text-sm font-medium text-gray-700">Prix de vente</label>
                             <input
                                 type="number"
                                 step="0.01"
@@ -509,11 +509,11 @@ const AddEditProductModal: React.FC<{ isOpen: boolean; onClose: () => void; onSu
 
                     <div className="grid grid-cols-1 sm:grid-cols-3 gap-4 bg-gray-50 border border-gray-200 rounded-lg p-4 text-sm text-gray-700">
                         <div>
-                            <p className="text-xs uppercase tracking-wide text-gray-500">Coût de revient (pesos colombianos)</p>
+                            <p className="text-xs uppercase tracking-wide text-gray-500">Coût de revient</p>
                             <p className="text-lg font-semibold text-gray-900">{formatCurrencyCOP(recipeCost)}</p>
                         </div>
                         <div>
-                            <p className="text-xs uppercase tracking-wide text-gray-500">Marge (pesos colombianos)</p>
+                            <p className="text-xs uppercase tracking-wide text-gray-500">Marge</p>
                             <p className={`text-lg font-semibold ${marginValue >= 0 ? 'text-emerald-600' : 'text-red-600'}`}>{formatCurrencyCOP(marginValue)}</p>
                         </div>
                         <div>

--- a/pages/ResumeVentes.tsx
+++ b/pages/ResumeVentes.tsx
@@ -50,7 +50,7 @@ const ResumeVentes: React.FC = () => {
     };
 
     const exportToCSV = () => {
-        const headers = ['Fecha', 'Tipo', 'Mesa/Cliente', 'Comensales', 'Venta total (pesos colombianos)', 'Beneficio (pesos colombianos)', 'Método de pago'];
+        const headers = ['Fecha', 'Tipo', 'Mesa/Cliente', 'Comensales', 'Venta total', 'Beneficio', 'Método de pago'];
         const csvRows = [
             headers.join(','),
             ...filteredOrders.map(order => [
@@ -122,8 +122,8 @@ const ResumeVentes: React.FC = () => {
                                 <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Fecha</th>
                                 <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Tipo</th>
                                 <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Mesa/Cliente</th>
-                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider text-right">Ventas (pesos colombianos)</th>
-                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider text-right">Beneficio (pesos colombianos)</th>
+                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider text-right">Ventas</th>
+                                <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider text-right">Beneficio</th>
                                 <th className="p-3 text-sm font-medium text-gray-500 uppercase tracking-wider">Pago</th>
                             </tr>
                         </thead>
@@ -154,7 +154,7 @@ const ResumeVentes: React.FC = () => {
                                                     <h4 className="font-semibold mb-2 text-gray-800">Detalle de artículos:</h4>
                                                     <ul className="list-disc list-inside pl-2 text-gray-700">
                                                     {order.items.map(item => (
-                                                        <li key={item.id}>{item.quantite}x {item.nom_produit} - <span className="font-semibold">{formatCurrencyCOP(item.prix_unitaire * item.quantite)} (pesos colombianos)</span></li>
+                                                        <li key={item.id}>{item.quantite}x {item.nom_produit} - <span className="font-semibold">{formatCurrencyCOP(item.prix_unitaire * item.quantite)}</span></li>
                                                     ))}
                                                     </ul>
                                                 </div>


### PR DESCRIPTION
## Summary
- remove the "pesos colombianos" wording across payment, reporting, and sales screens
- align the online order tracker with the Enviado→Validado→En preparacion→Listo flow and expose takeaway client phones
- adjust navigation, dashboard card layout, and plan de salle header to improve responsiveness and spacing

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dc096742b0832aa5c62ddcd9becc98