### PR TITLE
Add editable navigation logos and refine UI spacing

### DIFF
--- a/components/SitePreviewCanvas.tsx
+++ b/components/SitePreviewCanvas.tsx
@@ -9,8 +9,8 @@ import {
 } from '../utils/siteStyleHelpers';
 import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 
-const brandLogo = '/logo-brand.svg';
-const staffLogo = '/logo-staff.svg';
+const DEFAULT_BRAND_LOGO = '/logo-brand.svg';
+const DEFAULT_STAFF_LOGO = '/logo-staff.svg';
 
 export type EditableZoneKey = 'navigation' | 'hero' | 'about' | 'menu' | 'contact' | 'footer';
 
@@ -167,6 +167,8 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
   const navigationBackgroundStyle = createBackgroundStyle(content.navigation.style);
   const navigationTextStyle = createTextStyle(content.navigation.style);
   const navigationBodyStyle = createBodyTextStyle(content.navigation.style);
+  const brandLogo = content.navigation.brandLogo ?? DEFAULT_BRAND_LOGO;
+  const staffLogo = content.navigation.staffLogo ?? DEFAULT_STAFF_LOGO;
   const heroBackgroundStyle = createHeroBackgroundStyle(content.hero.style, content.hero.backgroundImage);
   const heroTextStyle = createTextStyle(content.hero.style);
   const heroBodyTextStyle = createBodyTextStyle(content.hero.style);
@@ -357,7 +359,7 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                         <div key={index} className="hero-history__item">
                           <div className="hero-history__meta">
                             <p className="hero-history__date" style={heroBodyTextStyle}>
-                              Commande du 12/03/2024
+                              Pedido del 12/03/2024
                             </p>
                             <p className="hero-history__details" style={heroBodyTextStyle}>
                               2 article(s) • {formatCurrencyCOP(32000)}

--- a/pages/Dashboard.tsx
+++ b/pages/Dashboard.tsx
@@ -14,7 +14,12 @@ const MainStatCard: React.FC<{ title: string; value: string; icon: React.ReactNo
         </div>
         <div className="flex-1 min-w-0">
             <p className="text-sm font-semibold text-gray-500">{title}</p>
-            <p className="text-2xl md:text-3xl xl:text-4xl font-bold text-gray-800 break-words leading-tight">{value}</p>
+            <p
+                className="font-bold text-gray-800 leading-tight whitespace-nowrap"
+                style={{ fontSize: 'clamp(1.35rem, 2.8vw, 2.75rem)', letterSpacing: '-0.01em' }}
+            >
+                {value}
+            </p>
         </div>
     </div>
 );

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -16,8 +16,8 @@ import {
   createTextStyle,
 } from '../utils/siteStyleHelpers';
 
-const brandLogo = '/logo-brand.svg';
-const staffLogo = '/logo-staff.svg';
+const DEFAULT_BRAND_LOGO = '/logo-brand.svg';
+const DEFAULT_STAFF_LOGO = '/logo-staff.svg';
 
 type PinInputProps = {
   pin: string;
@@ -147,6 +147,8 @@ const Login: React.FC = () => {
   const navigate = useNavigate();
   const { content: siteContent } = useSiteContent();
   const { navigation, hero, about, menu: menuContent, contact, footer } = siteContent;
+  const brandLogo = navigation.brandLogo ?? DEFAULT_BRAND_LOGO;
+  const staffLogo = navigation.staffLogo ?? DEFAULT_STAFF_LOGO;
   const navigationBackgroundStyle = createBackgroundStyle(navigation.style);
   const navigationTextStyle = createTextStyle(navigation.style);
   const navigationBodyStyle = createBodyTextStyle(navigation.style);
@@ -380,7 +382,7 @@ const Login: React.FC = () => {
                         <div key={order.id} className="hero-history__item">
                           <div className="hero-history__meta">
                             <p className="hero-history__date" style={heroBodyTextStyle}>
-                              Commande du {new Date(order.date_creation).toLocaleDateString()}
+                              Pedido del {new Date(order.date_creation).toLocaleDateString()}
                             </p>
                             <p className="hero-history__details" style={heroBodyTextStyle}>
                               {order.items.length} article(s) • {formatCurrencyCOP(order.total)}

--- a/pages/SiteCustomization.tsx
+++ b/pages/SiteCustomization.tsx
@@ -195,6 +195,8 @@ const IMAGE_FIELD_LABELS: Record<ImageFieldKey, string> = {
   'about.image': 'Image de la section À propos',
   'menu.image': 'Image de la section Menu',
   'contact.image': 'Image de la section Contact',
+  'navigation.brandLogo': 'Logo principal (navigation)',
+  'navigation.staffLogo': "Logo d'accès équipe",
   'navigation.style.background': 'Fond personnalisé (navigation)',
   'hero.style.background': 'Fond personnalisé (hero)',
   'about.style.background': 'Fond personnalisé (À propos)',
@@ -208,6 +210,8 @@ const INITIAL_IMAGE_ERRORS: Record<ImageFieldKey, string | null> = {
   'about.image': null,
   'menu.image': null,
   'contact.image': null,
+  'navigation.brandLogo': null,
+  'navigation.staffLogo': null,
   'navigation.style.background': null,
   'hero.style.background': null,
   'about.style.background': null,
@@ -265,6 +269,8 @@ type ImageFieldKey =
   | 'about.image'
   | 'menu.image'
   | 'contact.image'
+  | 'navigation.brandLogo'
+  | 'navigation.staffLogo'
   | 'navigation.style.background'
   | 'hero.style.background'
   | 'about.style.background'
@@ -731,6 +737,22 @@ const SiteCustomization: React.FC = () => {
             contact: {
               ...prev.contact,
               image: value,
+            },
+          };
+        case 'navigation.brandLogo':
+          return {
+            ...prev,
+            navigation: {
+              ...prev.navigation,
+              brandLogo: value,
+            },
+          };
+        case 'navigation.staffLogo':
+          return {
+            ...prev,
+            navigation: {
+              ...prev.navigation,
+              staffLogo: value,
             },
           };
         case 'navigation.style.background':
@@ -1662,7 +1684,7 @@ const ZoneEditorContent: React.FC<{
   activeElement: EditableElementKey | null;
   onOpenAssets: (field: ImageFieldKey) => void;
 }> = ({ zone, context, activeElement, onOpenAssets }) => {
-  const { draft } = context;
+  const { draft, imageErrors } = context;
   const [rankDrafts, setRankDrafts] = useState<Record<string, string>>({});
 
   useEffect(() => {
@@ -1712,6 +1734,28 @@ const ZoneEditorContent: React.FC<{
     case 'navigation':
       return (
         <div className="space-y-4">
+          <MediaInputField
+            field="navigation.brandLogo"
+            label="Logo principal"
+            value={draft.navigation.brandLogo}
+            imageErrors={imageErrors}
+            handleImageInputChange={context.handleImageInputChange}
+            handleImageUpload={context.handleImageUpload}
+            handleClearImage={context.handleClearImage}
+            isUploading={context.isUploading}
+            onOpenAssets={onOpenAssets}
+          />
+          <MediaInputField
+            field="navigation.staffLogo"
+            label="Logo espace équipe"
+            value={draft.navigation.staffLogo}
+            imageErrors={imageErrors}
+            handleImageInputChange={context.handleImageInputChange}
+            handleImageUpload={context.handleImageUpload}
+            handleClearImage={context.handleClearImage}
+            isUploading={context.isUploading}
+            onOpenAssets={onOpenAssets}
+          />
           <FieldCard
             label="Nom de la marque"
             htmlFor="brand-name"

--- a/pages/Ventes.tsx
+++ b/pages/Ventes.tsx
@@ -25,6 +25,14 @@ const STATUS_DESCRIPTORS: Record<Table['statut'], StatusDescriptor> = {
   para_pagar: { text: 'Para pagar', statusClass: 'status--payment', Icon: DollarSign },
 };
 
+const formatTableName = (name: string): string => {
+  const parts = name.trim().split(/\s+/);
+  if (parts.length >= 3 && parts[0].toLowerCase() === 'table' && parts[1].toLowerCase() === 'table') {
+    return `${parts[0]} ${parts.slice(2).join(' ')}`;
+  }
+  return name;
+};
+
 const getTableStatus = (table: Table): StatusDescriptor => {
   switch (table.statut) {
     case 'libre':
@@ -125,6 +133,8 @@ const TableCard: React.FC<{
     }
   };
 
+  const displayName = formatTableName(table.nom);
+
   return (
     <div
       onClick={handleCardClick}
@@ -171,7 +181,7 @@ const TableCard: React.FC<{
       )}
 
       <div className="status-card__header">
-        <h3 className="status-card__title">{table.nom}</h3>
+        <h3 className="status-card__title">{displayName}</h3>
         {table.date_envoi_cuisine && table.statut !== 'libre' && (
           <div className="status-card__timer">
             <OrderTimer startTime={table.date_envoi_cuisine} className="w-full justify-center" />

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -145,7 +145,7 @@ body {
 }
 
 .hero-title {
-  font-size: clamp(2.75rem, 6vw, 3.75rem);
+  font-size: clamp(3rem, 6.5vw, 4.25rem);
   line-height: 1.1;
   letter-spacing: -0.015em;
   color: var(--color-surface);
@@ -154,16 +154,16 @@ body {
 }
 
 .hero-subtitle {
-  font-size: clamp(1.125rem, 2.5vw, 1.5rem);
+  font-size: clamp(1.25rem, 3vw, 1.75rem);
   color: color-mix(in srgb, var(--color-surface) 80%, transparent);
   max-width: 42ch;
   margin: 0;
 }
 
 .hero-cta {
-  font-size: calc(var(--font-size-lg) * 1.15);
-  padding-inline: clamp(2rem, 5.5vw, 3.15rem);
-  padding-block: clamp(0.95rem, 3vw, 1.3rem);
+  font-size: calc(var(--font-size-lg) * 1.3);
+  padding-inline: clamp(2.25rem, 6vw, 3.5rem);
+  padding-block: clamp(1.05rem, 3.2vw, 1.45rem);
   border-radius: 999px;
 }
 
@@ -789,6 +789,17 @@ body {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.modal-form__actions .ui-btn {
+  font-size: calc(var(--font-size-base) * 1.05);
+  padding-block: clamp(0.95rem, 3vw, 1.2rem);
+  border-radius: 0.85rem;
+}
+
+.modal-form__actions .ui-btn-primary,
+.modal-form__actions .ui-btn-secondary {
+  padding-inline: clamp(1.75rem, 5vw, 2.5rem);
 }
 
 @media (min-width: 640px) {

--- a/types/index.ts
+++ b/types/index.ts
@@ -42,6 +42,8 @@ export interface SiteAssets {
 export interface SiteContent {
   navigation: {
     brand: string;
+    brandLogo: string | null;
+    staffLogo: string | null;
     links: {
       home: string;
       about: string;

--- a/utils/siteContent.ts
+++ b/utils/siteContent.ts
@@ -240,6 +240,8 @@ const sanitizeSectionStyle = (style: SectionStyle | undefined, fallback: Section
 export const DEFAULT_SITE_CONTENT: SiteContent = {
   navigation: {
     brand: 'OUIOUITACOS',
+    brandLogo: '/logo-brand.svg',
+    staffLogo: '/logo-staff.svg',
     links: {
       home: 'Accueil',
       about: 'À propos',
@@ -296,6 +298,8 @@ export const resolveSiteContent = (content?: Partial<SiteContent> | null): SiteC
   return {
     navigation: {
       brand: resolveString(content?.navigation?.brand, base.navigation.brand),
+      brandLogo: resolveImage(content?.navigation?.brandLogo, base.navigation.brandLogo),
+      staffLogo: resolveImage(content?.navigation?.staffLogo, base.navigation.staffLogo),
       links: {
         home: resolveString(content?.navigation?.links?.home, base.navigation.links.home),
         about: resolveString(content?.navigation?.links?.about, base.navigation.links.about),
@@ -349,6 +353,8 @@ export const resolveSiteContent = (content?: Partial<SiteContent> | null): SiteC
 export const sanitizeSiteContentInput = (content: SiteContent): SiteContent => ({
   navigation: {
     brand: trimOrEmpty(content.navigation.brand),
+    brandLogo: sanitizeImage(content.navigation.brandLogo) ?? null,
+    staffLogo: sanitizeImage(content.navigation.staffLogo) ?? null,
     links: {
       home: trimOrEmpty(content.navigation.links.home),
       about: trimOrEmpty(content.navigation.links.about),


### PR DESCRIPTION
## Summary
- allow site content to define navigation brand and staff logos with customization inputs and fallbacks across the login experience and preview canvas
- translate recent order labels to Spanish and enlarge hero typography, CTA button, and login modal actions for better ergonomics
- prevent duplicated table prefixes in the floor plan view and ensure dashboard headline metrics resize to avoid overflow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dc0f7758d8832aae1b9042369d27fa