### PR TITLE
Adjust hero CTA prominence and login modal ergonomics

### DIFF
--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -545,6 +545,7 @@ const Login: React.FC = () => {
           setError('');
         }}
         title="Connexion du personnel"
+        size="lg"
       >
         <form
           onSubmit={handleFormSubmit}

--- a/pages/Ventes.tsx
+++ b/pages/Ventes.tsx
@@ -26,11 +26,24 @@ const STATUS_DESCRIPTORS: Record<Table['statut'], StatusDescriptor> = {
 };
 
 const formatTableName = (name: string): string => {
-  const parts = name.trim().split(/\s+/);
-  if (parts.length >= 3 && parts[0].toLowerCase() === 'table' && parts[1].toLowerCase() === 'table') {
-    return `${parts[0]} ${parts.slice(2).join(' ')}`;
+  const trimmed = name.trim();
+  if (!trimmed) {
+    return name;
   }
-  return name;
+
+  const parts = trimmed.split(/\s+/);
+  if (parts.length < 2) {
+    return trimmed;
+  }
+
+  const [firstWord, ...rest] = parts;
+  let index = 0;
+
+  while (index < rest.length && rest[index].toLowerCase() === firstWord.toLowerCase()) {
+    index += 1;
+  }
+
+  return [firstWord, ...rest.slice(index)].join(' ');
 };
 
 const getTableStatus = (table: Table): StatusDescriptor => {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -161,10 +161,12 @@ body {
 }
 
 .hero-cta {
-  font-size: calc(var(--font-size-lg) * 1.3);
-  padding-inline: clamp(2.25rem, 6vw, 3.5rem);
-  padding-block: clamp(1.05rem, 3.2vw, 1.45rem);
+  font-size: calc(var(--font-size-xl) * 1.05);
+  padding-inline: clamp(3rem, 8vw, 4.75rem);
+  padding-block: clamp(1.35rem, 4vw, 1.85rem);
   border-radius: 999px;
+  min-width: clamp(15rem, 45vw, 19rem);
+  box-shadow: 0 20px 45px rgba(15, 23, 42, 0.35);
 }
 
 .hero-history {
@@ -535,12 +537,12 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: clamp(2.75rem, 4vw, 3.15rem);
-  height: clamp(2.75rem, 4vw, 3.15rem);
+  width: clamp(2.5rem, 5vw, 3rem);
+  height: clamp(2.5rem, 5vw, 3rem);
   border-radius: 999px;
   border: 1px solid color-mix(in srgb, var(--color-surface) 24%, transparent);
   background: color-mix(in srgb, var(--color-heading) 72%, transparent);
-  padding: clamp(0.35rem, 1vw, 0.55rem);
+  padding: clamp(0.2rem, 0.7vw, 0.35rem);
   transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
 }
 
@@ -564,6 +566,7 @@ body {
   height: 100%;
   object-fit: contain;
   display: block;
+  filter: drop-shadow(0 4px 12px color-mix(in srgb, var(--color-heading) 25%, transparent));
 }
 
 .login-header__menu {
@@ -711,9 +714,9 @@ body {
 }
 
 .pin-pad__button {
-  height: 3.5rem;
+  height: clamp(3.75rem, 12vw, 4.5rem);
   border-radius: 999px;
-  font-size: var(--font-size-lg);
+  font-size: calc(var(--font-size-xl) * 1.05);
   font-weight: 700;
   border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
   background: color-mix(in srgb, var(--color-surface) 92%, transparent);
@@ -743,15 +746,15 @@ body {
 }
 
 .pin-indicator__slot {
-  width: clamp(2.5rem, 6vw, 3rem);
-  height: clamp(3rem, 7vw, 3.5rem);
-  border-radius: 0.75rem;
+  width: clamp(2.85rem, 7vw, 3.5rem);
+  height: clamp(3.35rem, 8vw, 4rem);
+  border-radius: 0.85rem;
   background: color-mix(in srgb, var(--color-surface) 90%, transparent);
   border: 1px solid color-mix(in srgb, var(--color-border) 55%, transparent);
   display: flex;
   align-items: center;
   justify-content: center;
-  font-size: var(--font-size-xl);
+  font-size: calc(var(--font-size-xl) * 1.1);
   font-weight: 700;
   color: var(--color-heading);
 }


### PR DESCRIPTION
## Summary
- enlarge the hero call-to-action button and align the staff navigation logo size with the brand logo for better visual balance
- increase the login modal size and keypad hit areas to improve ergonomics on small screens
- normalize duplicated "table" prefixes so plan de salle labels no longer read "table table"

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dc349784d0832a886acef070924a82