### PR TITLE
Add rich text editing and custom font support to site editor

### DIFF
--- a/components/RichTextEditor.tsx
+++ b/components/RichTextEditor.tsx
@@ -1,0 +1,196 @@
+import React, { useEffect, useRef, useState } from 'react';
+import { Bold, Italic, Palette, Strikethrough, X } from 'lucide-react';
+import { RichTextValue } from '../types';
+import { sanitizeRichTextValue } from '../utils/richText';
+
+interface RichTextEditorProps {
+  id: string;
+  value?: RichTextValue | null;
+  fallback: string;
+  onChange: (value: RichTextValue | null) => void;
+  className?: string;
+  placeholder?: string;
+}
+
+const formatButtonClassName =
+  'inline-flex h-8 w-8 items-center justify-center rounded-full border border-slate-200 bg-white text-slate-600 transition hover:border-brand-primary/50 hover:text-brand-primary focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary disabled:opacity-50';
+
+const RichTextEditor: React.FC<RichTextEditorProps> = ({
+  id,
+  value,
+  fallback,
+  onChange,
+  className,
+  placeholder,
+}) => {
+  const editorRef = useRef<HTMLDivElement | null>(null);
+  const [isEmpty, setIsEmpty] = useState(() => {
+    const initial = value?.plainText ?? fallback;
+    return initial.trim().length === 0;
+  });
+
+  const updateEmptyState = () => {
+    const editor = editorRef.current;
+    if (!editor) {
+      setIsEmpty(true);
+      return;
+    }
+    const textContent = editor.textContent ?? '';
+    setIsEmpty(textContent.trim().length === 0);
+  };
+
+  useEffect(() => {
+    const editor = editorRef.current;
+    if (!editor) {
+      return;
+    }
+    if (value && typeof value.html === 'string') {
+      if (editor.innerHTML !== value.html) {
+        editor.innerHTML = value.html;
+      }
+      updateEmptyState();
+      return;
+    }
+    if (editor.textContent !== fallback) {
+      editor.textContent = fallback;
+      updateEmptyState();
+    }
+  }, [value, fallback]);
+
+  const emitChange = () => {
+    const editor = editorRef.current;
+    if (!editor) {
+      onChange(null);
+      setIsEmpty(true);
+      return;
+    }
+    const html = editor.innerHTML;
+    const plainText = editor.innerText;
+    const sanitized = sanitizeRichTextValue({ html, plainText });
+    onChange(sanitized);
+    updateEmptyState();
+  };
+
+  const applyCommand = (command: string) => {
+    document.execCommand('styleWithCSS', false, 'true');
+    document.execCommand(command);
+    editorRef.current?.focus();
+    emitChange();
+  };
+
+  const handleColorChange = (event: React.ChangeEvent<HTMLInputElement>) => {
+    const color = event.target.value;
+    document.execCommand('styleWithCSS', false, 'true');
+    document.execCommand('foreColor', false, color);
+    editorRef.current?.focus();
+    emitChange();
+  };
+
+  const handleRemoveFormatting = () => {
+    document.execCommand('removeFormat');
+    document.execCommand('unlink');
+    editorRef.current?.focus();
+    emitChange();
+  };
+
+  const handleInput = () => {
+    emitChange();
+  };
+
+  const handleBlur = () => {
+    emitChange();
+  };
+
+  const handlePaste = (event: React.ClipboardEvent<HTMLDivElement>) => {
+    event.preventDefault();
+    const text = event.clipboardData.getData('text/plain');
+    document.execCommand('insertText', false, text);
+    emitChange();
+  };
+
+  const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'b') {
+      event.preventDefault();
+      applyCommand('bold');
+      return;
+    }
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'i') {
+      event.preventDefault();
+      applyCommand('italic');
+      return;
+    }
+    if ((event.metaKey || event.ctrlKey) && event.key.toLowerCase() === 'x' && event.shiftKey) {
+      event.preventDefault();
+      applyCommand('strikeThrough');
+    }
+  };
+
+  return (
+    <div className={`space-y-2 ${className ?? ''}`}>
+      <div className="flex flex-wrap items-center gap-2">
+        <button
+          type="button"
+          className={formatButtonClassName}
+          onClick={() => applyCommand('bold')}
+          aria-label="Mettre en gras"
+        >
+          <Bold className="h-4 w-4" aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          className={formatButtonClassName}
+          onClick={() => applyCommand('italic')}
+          aria-label="Mettre en italique"
+        >
+          <Italic className="h-4 w-4" aria-hidden="true" />
+        </button>
+        <button
+          type="button"
+          className={formatButtonClassName}
+          onClick={() => applyCommand('strikeThrough')}
+          aria-label="Barrer"
+        >
+          <Strikethrough className="h-4 w-4" aria-hidden="true" />
+        </button>
+        <label className="flex items-center gap-2 text-xs font-medium text-slate-500">
+          <Palette className="h-4 w-4" aria-hidden="true" />
+          <span className="sr-only">Choisir une couleur</span>
+          <input
+            type="color"
+            className="h-8 w-8 cursor-pointer rounded-full border border-slate-200"
+            onChange={handleColorChange}
+            aria-label="Sélectionner une couleur de texte"
+          />
+        </label>
+        <button
+          type="button"
+          className={formatButtonClassName}
+          onClick={handleRemoveFormatting}
+          aria-label="Supprimer la mise en forme"
+        >
+          <X className="h-4 w-4" aria-hidden="true" />
+        </button>
+      </div>
+      <div className="relative">
+        {placeholder && isEmpty && (
+          <div className="pointer-events-none absolute left-4 top-3 text-sm text-slate-400">{placeholder}</div>
+        )}
+        <div
+          id={id}
+          ref={editorRef}
+          className="ui-textarea w-full min-h-[120px] whitespace-pre-wrap break-words px-4 py-3"
+          contentEditable
+          role="textbox"
+          aria-multiline="true"
+          suppressContentEditableWarning
+          onInput={handleInput}
+          onBlur={handleBlur}
+          onKeyDown={handleKeyDown}
+          onPaste={handlePaste}
+        />
+      </div>
+    </div>
+  );
+};
+
+export default RichTextEditor;

--- a/components/SitePreviewCanvas.tsx
+++ b/components/SitePreviewCanvas.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Edit2, Mail, MapPin, Phone } from 'lucide-react';
 import { EditableElementKey, EditableZoneKey, Product, SiteContent } from '../types';
+import useCustomFonts from '../hooks/useCustomFonts';
 import {
   createBackgroundStyle,
   createBodyTextStyle,
@@ -151,7 +152,32 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
   const footerBackgroundStyle = createBackgroundStyle(content.footer.style);
   const footerTextStyle = createBodyTextStyle(content.footer.style);
 
+  useCustomFonts(content.assets.library);
+
   const elementStyles = content.elementStyles ?? {};
+  const elementRichText = content.elementRichText ?? {};
+
+  const getRichTextHtml = (key: EditableElementKey): string | null => {
+    const entry = elementRichText[key];
+    const html = entry?.html?.trim();
+    return html && html.length > 0 ? html : null;
+  };
+
+  const renderRichTextElement = <T extends keyof JSX.IntrinsicElements>(
+    key: EditableElementKey,
+    Component: T,
+    props: React.ComponentPropsWithoutRef<T>,
+    fallback: string,
+  ) => {
+    const html = getRichTextHtml(key);
+    if (html) {
+      return React.createElement(Component, {
+        ...props,
+        dangerouslySetInnerHTML: { __html: html },
+      });
+    }
+    return React.createElement(Component, props, fallback);
+  };
 
   const zoneStyleMap: Record<EditableZoneKey, typeof content.navigation.style> = {
     navigation: content.navigation.style,
@@ -205,12 +231,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                   className="ml-3 inline-flex items-center"
                   buttonClassName="-right-3 -top-3"
                 >
-                  <span
-                    className="login-brand__name"
-                    style={getElementTextStyle('navigation.brand')}
-                  >
-                    {content.navigation.brand}
-                  </span>
+                  {renderRichTextElement(
+                    'navigation.brand',
+                    'span',
+                    {
+                      className: 'login-brand__name',
+                      style: getElementTextStyle('navigation.brand'),
+                    },
+                    content.navigation.brand,
+                  )}
                 </EditableElement>
               </div>
               <nav className="login-nav" aria-label="Navigation principale">
@@ -222,12 +251,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                   className="inline-flex"
                   buttonClassName="-right-2 -top-2"
                 >
-                  <span
-                    className="login-nav__link"
-                    style={getElementBodyTextStyle('navigation.links.home')}
-                  >
-                    {content.navigation.links.home}
-                  </span>
+                  {renderRichTextElement(
+                    'navigation.links.home',
+                    'span',
+                    {
+                      className: 'login-nav__link',
+                      style: getElementBodyTextStyle('navigation.links.home'),
+                    },
+                    content.navigation.links.home,
+                  )}
                 </EditableElement>
                 <EditableElement
                   id="navigation.links.about"
@@ -237,12 +269,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                   className="inline-flex"
                   buttonClassName="-right-2 -top-2"
                 >
-                  <span
-                    className="login-nav__link"
-                    style={getElementBodyTextStyle('navigation.links.about')}
-                  >
-                    {content.navigation.links.about}
-                  </span>
+                  {renderRichTextElement(
+                    'navigation.links.about',
+                    'span',
+                    {
+                      className: 'login-nav__link',
+                      style: getElementBodyTextStyle('navigation.links.about'),
+                    },
+                    content.navigation.links.about,
+                  )}
                 </EditableElement>
                 <EditableElement
                   id="navigation.links.menu"
@@ -252,12 +287,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                   className="inline-flex"
                   buttonClassName="-right-2 -top-2"
                 >
-                  <span
-                    className="login-nav__link"
-                    style={getElementBodyTextStyle('navigation.links.menu')}
-                  >
-                    {content.navigation.links.menu}
-                  </span>
+                  {renderRichTextElement(
+                    'navigation.links.menu',
+                    'span',
+                    {
+                      className: 'login-nav__link',
+                      style: getElementBodyTextStyle('navigation.links.menu'),
+                    },
+                    content.navigation.links.menu,
+                  )}
                 </EditableElement>
                 <EditableElement
                   id="navigation.links.contact"
@@ -267,12 +305,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                   className="inline-flex"
                   buttonClassName="-right-2 -top-2"
                 >
-                  <span
-                    className="login-nav__link"
-                    style={getElementBodyTextStyle('navigation.links.contact')}
-                  >
-                    {content.navigation.links.contact}
-                  </span>
+                  {renderRichTextElement(
+                    'navigation.links.contact',
+                    'span',
+                    {
+                      className: 'login-nav__link',
+                      style: getElementBodyTextStyle('navigation.links.contact'),
+                    },
+                    content.navigation.links.contact,
+                  )}
                 </EditableElement>
                 <EditableElement
                   id="navigation.links.loginCta"
@@ -319,9 +360,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                   className="block"
                   buttonClassName="right-0 -top-3"
                 >
-                  <h2 className="hero-title" style={getElementTextStyle('hero.title')}>
-                    {content.hero.title}
-                  </h2>
+                  {renderRichTextElement(
+                    'hero.title',
+                    'h2',
+                    {
+                      className: 'hero-title',
+                      style: getElementTextStyle('hero.title'),
+                    },
+                    content.hero.title,
+                  )}
                 </EditableElement>
                 <EditableElement
                   id="hero.subtitle"
@@ -330,9 +377,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                   className="mt-4 block"
                   buttonClassName="right-0 -top-3"
                 >
-                  <p className="hero-subtitle" style={getElementBodyTextStyle('hero.subtitle')}>
-                    {content.hero.subtitle}
-                  </p>
+                  {renderRichTextElement(
+                    'hero.subtitle',
+                    'p',
+                    {
+                      className: 'hero-subtitle',
+                      style: getElementBodyTextStyle('hero.subtitle'),
+                    },
+                    content.hero.subtitle,
+                  )}
                 </EditableElement>
                 <EditableElement
                   id="hero.ctaLabel"
@@ -350,54 +403,76 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                     }}
                     disabled
                   >
-                    {content.hero.ctaLabel}
+                    {renderRichTextElement(
+                      'hero.ctaLabel',
+                      'span',
+                      {
+                        className: 'inline-flex items-center justify-center',
+                        style: getElementBodyTextStyle('hero.ctaLabel'),
+                      },
+                      content.hero.ctaLabel,
+                    )}
                   </button>
                 </EditableElement>
                 <div className="hero-history mt-6">
-                  <EditableElement
-                    id="hero.historyTitle"
-                    label="Modifier le titre de l'historique"
+                <EditableElement
+                  id="hero.historyTitle"
+                  label="Modifier le titre de l'historique"
                   onEdit={onEdit}
                   className="block"
                   buttonClassName="right-0 -top-3"
                 >
-                  <p className="hero-history__title" style={getElementBodyTextStyle('hero.historyTitle')}>
-                    {content.hero.historyTitle}
-                  </p>
+                  {renderRichTextElement(
+                    'hero.historyTitle',
+                    'p',
+                    {
+                      className: 'hero-history__title',
+                      style: getElementBodyTextStyle('hero.historyTitle'),
+                    },
+                    content.hero.historyTitle,
+                  )}
                 </EditableElement>
                 <EditableElement
                   id="hero.reorderCtaLabel"
-                    label="Modifier le bouton de réassort"
-                    onEdit={onEdit}
-                    className="hero-history__list"
-                    buttonClassName="right-2 top-2"
-                  >
-                    <>
-                      {[0, 1, 2].map(index => (
-                        <div key={index} className="hero-history__item">
-                          <div className="hero-history__meta">
-                            <p className="hero-history__date" style={heroBodyTextStyle}>
-                              Pedido del 12/03/2024
-                            </p>
-                            <p className="hero-history__details" style={heroBodyTextStyle}>
-                              2 article(s) • {formatCurrencyCOP(32000)}
-                            </p>
-                          </div>
-                          <button
-                            type="button"
-                            className="hero-history__cta"
-                            style={{
-                              ...getElementBodyTextStyle('hero.reorderCtaLabel'),
-                              ...getElementBackgroundStyle('hero.reorderCtaLabel'),
-                            }}
-                            disabled
-                          >
-                            {content.hero.reorderCtaLabel}
-                          </button>
+                  label="Modifier le bouton de réassort"
+                  onEdit={onEdit}
+                  className="hero-history__list"
+                  buttonClassName="right-2 top-2"
+                >
+                  <>
+                    {[0, 1, 2].map(index => (
+                      <div key={index} className="hero-history__item">
+                        <div className="hero-history__meta">
+                          <p className="hero-history__date" style={heroBodyTextStyle}>
+                            Pedido del 12/03/2024
+                          </p>
+                          <p className="hero-history__details" style={heroBodyTextStyle}>
+                            2 article(s) • {formatCurrencyCOP(32000)}
+                          </p>
                         </div>
-                      ))}
-                    </>
-                  </EditableElement>
+                        <button
+                          type="button"
+                          className="hero-history__cta"
+                          style={{
+                            ...getElementBodyTextStyle('hero.reorderCtaLabel'),
+                            ...getElementBackgroundStyle('hero.reorderCtaLabel'),
+                          }}
+                          disabled
+                        >
+                          {renderRichTextElement(
+                            'hero.reorderCtaLabel',
+                            'span',
+                            {
+                              className: 'inline-flex items-center justify-center',
+                              style: getElementBodyTextStyle('hero.reorderCtaLabel'),
+                            },
+                            content.hero.reorderCtaLabel,
+                          )}
+                        </button>
+                      </div>
+                    ))}
+                  </>
+                </EditableElement>
                 </div>
               </div>
             </div>
@@ -422,9 +497,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                 className="block"
                 buttonClassName="right-0 -top-3"
               >
-                <h2 className="section-title" style={getElementTextStyle('about.title')}>
-                  {content.about.title}
-                </h2>
+                {renderRichTextElement(
+                  'about.title',
+                  'h2',
+                  {
+                    className: 'section-title',
+                    style: getElementTextStyle('about.title'),
+                  },
+                  content.about.title,
+                )}
               </EditableElement>
               <EditableElement
                 id="about.description"
@@ -433,12 +514,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                 className="mt-4 block"
                 buttonClassName="right-0 -top-3"
               >
-                <p
-                  className="section-text section-text--muted"
-                  style={getElementBodyTextStyle('about.description')}
-                >
-                  {content.about.description}
-                </p>
+                {renderRichTextElement(
+                  'about.description',
+                  'p',
+                  {
+                    className: 'section-text section-text--muted',
+                    style: getElementBodyTextStyle('about.description'),
+                  },
+                  content.about.description,
+                )}
               </EditableElement>
               {content.about.image && (
                 <EditableElement
@@ -477,9 +561,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                 className="block"
                 buttonClassName="right-0 -top-3"
               >
-                <h2 className="section-title" style={getElementTextStyle('menu.title')}>
-                  {content.menu.title}
-                </h2>
+                {renderRichTextElement(
+                  'menu.title',
+                  'h2',
+                  {
+                    className: 'section-title',
+                    style: getElementTextStyle('menu.title'),
+                  },
+                  content.menu.title,
+                )}
               </EditableElement>
               {content.menu.image && (
                 <EditableElement
@@ -552,7 +642,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                     }}
                     disabled
                   >
-                    {content.menu.ctaLabel}
+                    {renderRichTextElement(
+                      'menu.ctaLabel',
+                      'span',
+                      {
+                        className: 'inline-flex items-center justify-center',
+                        style: getElementBodyTextStyle('menu.ctaLabel'),
+                      },
+                      content.menu.ctaLabel,
+                    )}
                   </button>
                   <EditableElement
                     id="menu.loadingLabel"
@@ -562,12 +660,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                     buttonClassName="-right-3 -top-3"
                     as="span"
                   >
-                    <p
-                      className="section-text section-text--muted"
-                      style={getElementBodyTextStyle('menu.loadingLabel')}
-                    >
-                      {content.menu.loadingLabel}
-                    </p>
+                    {renderRichTextElement(
+                      'menu.loadingLabel',
+                      'p',
+                      {
+                        className: 'section-text section-text--muted',
+                        style: getElementBodyTextStyle('menu.loadingLabel'),
+                      },
+                      content.menu.loadingLabel,
+                    )}
                   </EditableElement>
                 </div>
               </EditableElement>
@@ -593,9 +694,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                 className="block"
                 buttonClassName="right-0 -top-3"
               >
-                <h2 className="section-title" style={getElementTextStyle('contact.title')}>
-                  {content.contact.title}
-                </h2>
+                {renderRichTextElement(
+                  'contact.title',
+                  'h2',
+                  {
+                    className: 'section-title',
+                    style: getElementTextStyle('contact.title'),
+                  },
+                  content.contact.title,
+                )}
               </EditableElement>
               {content.contact.image && (
                 <EditableElement
@@ -622,9 +729,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                     className="block"
                     buttonClassName="right-0 -top-3"
                   >
-                    <h3 className="contact-card__title" style={getElementTextStyle('contact.addressLabel')}>
-                      {content.contact.addressLabel}
-                    </h3>
+                    {renderRichTextElement(
+                      'contact.addressLabel',
+                      'h3',
+                      {
+                        className: 'contact-card__title',
+                        style: getElementTextStyle('contact.addressLabel'),
+                      },
+                      content.contact.addressLabel,
+                    )}
                   </EditableElement>
                   <EditableElement
                     id="contact.address"
@@ -633,9 +746,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                     className="mt-1 block"
                     buttonClassName="right-0 -top-3"
                   >
-                    <p className="contact-card__text" style={getElementBodyTextStyle('contact.address')}>
-                      {content.contact.address}
-                    </p>
+                    {renderRichTextElement(
+                      'contact.address',
+                      'p',
+                      {
+                        className: 'contact-card__text',
+                        style: getElementBodyTextStyle('contact.address'),
+                      },
+                      content.contact.address,
+                    )}
                   </EditableElement>
                 </div>
                 <div className="contact-card" style={contactTextStyle}>
@@ -647,9 +766,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                     className="block"
                     buttonClassName="right-0 -top-3"
                   >
-                    <h3 className="contact-card__title" style={getElementTextStyle('contact.phoneLabel')}>
-                      {content.contact.phoneLabel}
-                    </h3>
+                    {renderRichTextElement(
+                      'contact.phoneLabel',
+                      'h3',
+                      {
+                        className: 'contact-card__title',
+                        style: getElementTextStyle('contact.phoneLabel'),
+                      },
+                      content.contact.phoneLabel,
+                    )}
                   </EditableElement>
                   <EditableElement
                     id="contact.phone"
@@ -658,9 +783,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                     className="mt-1 block"
                     buttonClassName="right-0 -top-3"
                   >
-                    <p className="contact-card__text" style={getElementBodyTextStyle('contact.phone')}>
-                      {content.contact.phone}
-                    </p>
+                    {renderRichTextElement(
+                      'contact.phone',
+                      'p',
+                      {
+                        className: 'contact-card__text',
+                        style: getElementBodyTextStyle('contact.phone'),
+                      },
+                      content.contact.phone,
+                    )}
                   </EditableElement>
                 </div>
                 <div className="contact-card" style={contactTextStyle}>
@@ -672,9 +803,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                     className="block"
                     buttonClassName="right-0 -top-3"
                   >
-                    <h3 className="contact-card__title" style={getElementTextStyle('contact.emailLabel')}>
-                      {content.contact.emailLabel}
-                    </h3>
+                    {renderRichTextElement(
+                      'contact.emailLabel',
+                      'h3',
+                      {
+                        className: 'contact-card__title',
+                        style: getElementTextStyle('contact.emailLabel'),
+                      },
+                      content.contact.emailLabel,
+                    )}
                   </EditableElement>
                   <EditableElement
                     id="contact.email"
@@ -683,9 +820,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                     className="mt-1 block"
                     buttonClassName="right-0 -top-3"
                   >
-                    <p className="contact-card__text" style={getElementBodyTextStyle('contact.email')}>
-                      {content.contact.email}
-                    </p>
+                    {renderRichTextElement(
+                      'contact.email',
+                      'p',
+                      {
+                        className: 'contact-card__text',
+                        style: getElementBodyTextStyle('contact.email'),
+                      },
+                      content.contact.email,
+                    )}
                   </EditableElement>
                 </div>
               </div>
@@ -712,7 +855,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                 buttonClassName="right-0 -top-3"
               >
                 <p style={getElementBodyTextStyle('footer.text')}>
-                  &copy; {new Date().getFullYear()} {content.navigation.brand}. {content.footer.text}
+                  &copy; {new Date().getFullYear()} {content.navigation.brand}.{' '}
+                  {renderRichTextElement(
+                    'footer.text',
+                    'span',
+                    {
+                      style: getElementBodyTextStyle('footer.text'),
+                    },
+                    content.footer.text,
+                  )}
                 </p>
               </EditableElement>
             </div>

--- a/hooks/useCustomFonts.ts
+++ b/hooks/useCustomFonts.ts
@@ -1,0 +1,48 @@
+import { useEffect } from 'react';
+import { CustomizationAsset } from '../types';
+import { createFontFaceDeclaration } from '../utils/fonts';
+
+const STYLE_ATTRIBUTE = 'data-custom-font-faces';
+
+const useCustomFonts = (assets: CustomizationAsset[]): void => {
+  useEffect(() => {
+    if (typeof document === 'undefined') {
+      return;
+    }
+
+    const fontAssets = assets.filter(asset => asset.type === 'font');
+
+    if (fontAssets.length === 0) {
+      return;
+    }
+
+    const uniqueDeclarations: string[] = [];
+    const seenFamilies = new Set<string>();
+
+    fontAssets.forEach(asset => {
+      const declaration = createFontFaceDeclaration(asset);
+      const familyMatch = declaration.match(/font-family: "([^"]+)";/);
+      const family = familyMatch ? familyMatch[1] : asset.name;
+      if (seenFamilies.has(family)) {
+        return;
+      }
+      seenFamilies.add(family);
+      uniqueDeclarations.push(declaration);
+    });
+
+    if (uniqueDeclarations.length === 0) {
+      return;
+    }
+
+    const styleElement = document.createElement('style');
+    styleElement.setAttribute(STYLE_ATTRIBUTE, 'true');
+    styleElement.textContent = uniqueDeclarations.join('\n');
+    document.head.appendChild(styleElement);
+
+    return () => {
+      styleElement.remove();
+    };
+  }, [assets]);
+};
+
+export default useCustomFonts;

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -3,12 +3,13 @@ import { useAuth } from '../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import Modal from '../components/Modal';
 import { api } from '../services/api';
-import { Product, Order } from '../types';
+import { EditableElementKey, Product, Order } from '../types';
 import { Mail, MapPin, Phone, Menu, X } from 'lucide-react';
 import CustomerOrderTracker from '../components/CustomerOrderTracker';
 import { clearActiveCustomerOrder, getActiveCustomerOrder } from '../services/customerOrderStorage';
 import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 import useSiteContent from '../hooks/useSiteContent';
+import useCustomFonts from '../hooks/useCustomFonts';
 import {
   createBackgroundStyle,
   createBodyTextStyle,
@@ -147,6 +148,7 @@ const Login: React.FC = () => {
   const navigate = useNavigate();
   const { content: siteContent } = useSiteContent();
   const { navigation, hero, about, menu: menuContent, contact, footer } = siteContent;
+  useCustomFonts(siteContent.assets.library);
   const brandLogo = navigation.brandLogo ?? DEFAULT_BRAND_LOGO;
   const staffLogo = navigation.staffLogo ?? DEFAULT_STAFF_LOGO;
   const navigationBackgroundStyle = createBackgroundStyle(navigation.style);
@@ -166,6 +168,30 @@ const Login: React.FC = () => {
   const contactBodyTextStyle = createBodyTextStyle(contact.style);
   const footerBackgroundStyle = createBackgroundStyle(footer.style);
   const footerTextStyle = createBodyTextStyle(footer.style);
+
+  const elementRichText = siteContent.elementRichText ?? {};
+
+  const getRichTextHtml = (key: EditableElementKey): string | null => {
+    const entry = elementRichText[key];
+    const html = entry?.html?.trim();
+    return html && html.length > 0 ? html : null;
+  };
+
+  const renderRichTextElement = <T extends keyof JSX.IntrinsicElements>(
+    key: EditableElementKey,
+    Component: T,
+    props: React.ComponentPropsWithoutRef<T>,
+    fallback: string,
+  ) => {
+    const html = getRichTextHtml(key);
+    if (html) {
+      return React.createElement(Component, {
+        ...props,
+        dangerouslySetInnerHTML: { __html: html },
+      });
+    }
+    return React.createElement(Component, props, fallback);
+  };
 
   const [bestSellers, setBestSellers] = useState<Product[]>([]);
   const [orderHistory, setOrderHistory] = useState<Order[]>([]);
@@ -262,26 +288,62 @@ const Login: React.FC = () => {
               alt={`Logo ${navigation.brand}`}
               className="login-brand__logo"
             />
-            <span className="login-brand__name">{navigation.brand}</span>
+            {renderRichTextElement(
+              'navigation.brand',
+              'span',
+              {
+                className: 'login-brand__name',
+                style: navigationTextStyle,
+              },
+              navigation.brand,
+            )}
           </div>
           <nav className="login-nav" aria-label="Navigation principale">
-            <a href="#accueil" className="login-nav__link" style={navigationBodyStyle}>
-              {navigation.links.home}
-            </a>
-            <a href="#apropos" className="login-nav__link" style={navigationBodyStyle}>
-              {navigation.links.about}
-            </a>
-            <a href="#menu" className="login-nav__link" style={navigationBodyStyle}>
-              {navigation.links.menu}
-            </a>
-            <a href="#contact" className="login-nav__link" style={navigationBodyStyle}>
-              {navigation.links.contact}
-            </a>
+            {renderRichTextElement(
+              'navigation.links.home',
+              'a',
+              {
+                href: '#accueil',
+                className: 'login-nav__link',
+                style: navigationBodyStyle,
+              },
+              navigation.links.home,
+            )}
+            {renderRichTextElement(
+              'navigation.links.about',
+              'a',
+              {
+                href: '#apropos',
+                className: 'login-nav__link',
+                style: navigationBodyStyle,
+              },
+              navigation.links.about,
+            )}
+            {renderRichTextElement(
+              'navigation.links.menu',
+              'a',
+              {
+                href: '#menu',
+                className: 'login-nav__link',
+                style: navigationBodyStyle,
+              },
+              navigation.links.menu,
+            )}
+            {renderRichTextElement(
+              'navigation.links.contact',
+              'a',
+              {
+                href: '#contact',
+                className: 'login-nav__link',
+                style: navigationBodyStyle,
+              },
+              navigation.links.contact,
+            )}
             <button
               type="button"
               onClick={() => setIsModalOpen(true)}
               className="login-nav__staff-btn"
-              aria-label="Connexion staff"
+              aria-label={navigation.links.loginCta}
               style={{ fontFamily: navigation.style.fontFamily }}
             >
               <img src={staffLogo} alt="" className="login-nav__staff-logo" aria-hidden="true" />
@@ -304,38 +366,50 @@ const Login: React.FC = () => {
             <X size={28} />
           </button>
           <nav className="login-menu-overlay__nav" aria-label="Navigation mobile" style={navigationTextStyle}>
-            <a
-              href="#accueil"
-              onClick={() => setMobileMenuOpen(false)}
-              className="login-menu-overlay__link"
-              style={navigationBodyStyle}
-            >
-              {navigation.links.home}
-            </a>
-            <a
-              href="#apropos"
-              onClick={() => setMobileMenuOpen(false)}
-              className="login-menu-overlay__link"
-              style={navigationBodyStyle}
-            >
-              {navigation.links.about}
-            </a>
-            <a
-              href="#menu"
-              onClick={() => setMobileMenuOpen(false)}
-              className="login-menu-overlay__link"
-              style={navigationBodyStyle}
-            >
-              {navigation.links.menu}
-            </a>
-            <a
-              href="#contact"
-              onClick={() => setMobileMenuOpen(false)}
-              className="login-menu-overlay__link"
-              style={navigationBodyStyle}
-            >
-              {navigation.links.contact}
-            </a>
+            {renderRichTextElement(
+              'navigation.links.home',
+              'a',
+              {
+                href: '#accueil',
+                onClick: () => setMobileMenuOpen(false),
+                className: 'login-menu-overlay__link',
+                style: navigationBodyStyle,
+              },
+              navigation.links.home,
+            )}
+            {renderRichTextElement(
+              'navigation.links.about',
+              'a',
+              {
+                href: '#apropos',
+                onClick: () => setMobileMenuOpen(false),
+                className: 'login-menu-overlay__link',
+                style: navigationBodyStyle,
+              },
+              navigation.links.about,
+            )}
+            {renderRichTextElement(
+              'navigation.links.menu',
+              'a',
+              {
+                href: '#menu',
+                onClick: () => setMobileMenuOpen(false),
+                className: 'login-menu-overlay__link',
+                style: navigationBodyStyle,
+              },
+              navigation.links.menu,
+            )}
+            {renderRichTextElement(
+              'navigation.links.contact',
+              'a',
+              {
+                href: '#contact',
+                onClick: () => setMobileMenuOpen(false),
+                className: 'login-menu-overlay__link',
+                style: navigationBodyStyle,
+              },
+              navigation.links.contact,
+            )}
             <button
               type="button"
               onClick={() => {
@@ -343,7 +417,7 @@ const Login: React.FC = () => {
                 setMobileMenuOpen(false);
               }}
               className="login-nav__staff-btn login-menu-overlay__staff-btn"
-              aria-label="Connexion staff"
+              aria-label={navigation.links.loginCta}
               style={{ fontFamily: navigation.style.fontFamily }}
             >
               <img src={staffLogo} alt="" className="login-nav__staff-logo" aria-hidden="true" />
@@ -359,24 +433,50 @@ const Login: React.FC = () => {
               <CustomerOrderTracker orderId={activeOrderId} onNewOrderClick={handleNewOrder} variant="hero" />
             ) : (
               <div className="hero-content" style={heroTextStyle}>
-                <h2 className="hero-title" style={heroTextStyle}>
-                  {hero.title}
-                </h2>
-                <p className="hero-subtitle" style={heroBodyTextStyle}>
-                  {hero.subtitle}
-                </p>
+                {renderRichTextElement(
+                  'hero.title',
+                  'h2',
+                  {
+                    className: 'hero-title',
+                    style: heroTextStyle,
+                  },
+                  hero.title,
+                )}
+                {renderRichTextElement(
+                  'hero.subtitle',
+                  'p',
+                  {
+                    className: 'hero-subtitle',
+                    style: heroBodyTextStyle,
+                  },
+                  hero.subtitle,
+                )}
                 <button
                   onClick={() => navigate('/commande-client')}
                   className="ui-btn ui-btn-accent hero-cta"
                   style={{ fontFamily: hero.style.fontFamily }}
                 >
-                  {hero.ctaLabel}
+                  {renderRichTextElement(
+                    'hero.ctaLabel',
+                    'span',
+                    {
+                      className: 'inline-flex items-center justify-center',
+                      style: heroBodyTextStyle,
+                    },
+                    hero.ctaLabel,
+                  )}
                 </button>
                 {orderHistory.length > 0 && (
                   <div className="hero-history">
-                    <p className="hero-history__title" style={heroBodyTextStyle}>
-                      {hero.historyTitle}
-                    </p>
+                    {renderRichTextElement(
+                      'hero.historyTitle',
+                      'p',
+                      {
+                        className: 'hero-history__title',
+                        style: heroBodyTextStyle,
+                      },
+                      hero.historyTitle,
+                    )}
                     <div className="hero-history__list">
                       {orderHistory.slice(0, 3).map(order => (
                         <div key={order.id} className="hero-history__item">
@@ -394,7 +494,15 @@ const Login: React.FC = () => {
                             className="hero-history__cta"
                             style={{ fontFamily: hero.style.fontFamily }}
                           >
-                            {hero.reorderCtaLabel}
+                            {renderRichTextElement(
+                              'hero.reorderCtaLabel',
+                              'span',
+                              {
+                                className: 'inline-flex items-center justify-center',
+                                style: heroBodyTextStyle,
+                              },
+                              hero.reorderCtaLabel,
+                            )}
                           </button>
                         </div>
                       ))}
@@ -412,12 +520,24 @@ const Login: React.FC = () => {
           style={{ ...aboutBackgroundStyle, ...aboutTextStyle }}
         >
           <div className="section-inner section-inner--center" style={aboutTextStyle}>
-            <h2 className="section-title" style={aboutTextStyle}>
-              {about.title}
-            </h2>
-            <p className="section-text section-text--muted" style={aboutBodyTextStyle}>
-              {about.description}
-            </p>
+            {renderRichTextElement(
+              'about.title',
+              'h2',
+              {
+                className: 'section-title',
+                style: aboutTextStyle,
+              },
+              about.title,
+            )}
+            {renderRichTextElement(
+              'about.description',
+              'p',
+              {
+                className: 'section-text section-text--muted',
+                style: aboutBodyTextStyle,
+              },
+              about.description,
+            )}
             {about.image && (
               <img
                 src={about.image}
@@ -434,9 +554,15 @@ const Login: React.FC = () => {
           style={{ ...menuBackgroundStyle, ...menuTextStyle }}
         >
           <div className="section-inner section-inner--wide section-inner--center" style={menuTextStyle}>
-            <h2 className="section-title" style={menuTextStyle}>
-              {menuContent.title}
-            </h2>
+            {renderRichTextElement(
+              'menu.title',
+              'h2',
+              {
+                className: 'section-title',
+                style: menuTextStyle,
+              },
+              menuContent.title,
+            )}
             {menuContent.image && (
               <img
                 src={menuContent.image}
@@ -445,9 +571,15 @@ const Login: React.FC = () => {
               />
             )}
             {menuLoading ? (
-              <p className="section-text section-text--muted" style={menuBodyTextStyle}>
-                {menuContent.loadingLabel}
-              </p>
+              renderRichTextElement(
+                'menu.loadingLabel',
+                'p',
+                {
+                  className: 'section-text section-text--muted',
+                  style: menuBodyTextStyle,
+                },
+                menuContent.loadingLabel,
+              )
             ) : (
               <div className={menuGridClassName}>
                 {bestSellersToDisplay.map(product => (
@@ -474,7 +606,15 @@ const Login: React.FC = () => {
                 className="ui-btn ui-btn-primary hero-cta"
                 style={{ fontFamily: menuContent.style.fontFamily }}
               >
-                {menuContent.ctaLabel}
+                {renderRichTextElement(
+                  'menu.ctaLabel',
+                  'span',
+                  {
+                    className: 'inline-flex items-center justify-center',
+                    style: menuBodyTextStyle,
+                  },
+                  menuContent.ctaLabel,
+                )}
               </button>
             </div>
           </div>
@@ -486,9 +626,15 @@ const Login: React.FC = () => {
           style={{ ...contactBackgroundStyle, ...contactTextStyle }}
         >
           <div className="section-inner section-inner--wide section-inner--center" style={contactTextStyle}>
-            <h2 className="section-title" style={contactTextStyle}>
-              {contact.title}
-            </h2>
+            {renderRichTextElement(
+              'contact.title',
+              'h2',
+              {
+                className: 'section-title',
+                style: contactTextStyle,
+              },
+              contact.title,
+            )}
             {contact.image && (
               <img
                 src={contact.image}
@@ -499,30 +645,66 @@ const Login: React.FC = () => {
             <div className="contact-grid">
               <div className="contact-card" style={contactTextStyle}>
                 <MapPin className="contact-card__icon" />
-                <h3 className="contact-card__title" style={contactTextStyle}>
-                  {contact.addressLabel}
-                </h3>
-                <p className="contact-card__text" style={contactBodyTextStyle}>
-                  {contact.address}
-                </p>
+                {renderRichTextElement(
+                  'contact.addressLabel',
+                  'h3',
+                  {
+                    className: 'contact-card__title',
+                    style: contactTextStyle,
+                  },
+                  contact.addressLabel,
+                )}
+                {renderRichTextElement(
+                  'contact.address',
+                  'p',
+                  {
+                    className: 'contact-card__text',
+                    style: contactBodyTextStyle,
+                  },
+                  contact.address,
+                )}
               </div>
               <div className="contact-card" style={contactTextStyle}>
                 <Phone className="contact-card__icon" />
-                <h3 className="contact-card__title" style={contactTextStyle}>
-                  {contact.phoneLabel}
-                </h3>
-                <p className="contact-card__text" style={contactBodyTextStyle}>
-                  {contact.phone}
-                </p>
+                {renderRichTextElement(
+                  'contact.phoneLabel',
+                  'h3',
+                  {
+                    className: 'contact-card__title',
+                    style: contactTextStyle,
+                  },
+                  contact.phoneLabel,
+                )}
+                {renderRichTextElement(
+                  'contact.phone',
+                  'p',
+                  {
+                    className: 'contact-card__text',
+                    style: contactBodyTextStyle,
+                  },
+                  contact.phone,
+                )}
               </div>
               <div className="contact-card" style={contactTextStyle}>
                 <Mail className="contact-card__icon" />
-                <h3 className="contact-card__title" style={contactTextStyle}>
-                  {contact.emailLabel}
-                </h3>
-                <p className="contact-card__text" style={contactBodyTextStyle}>
-                  {contact.email}
-                </p>
+                {renderRichTextElement(
+                  'contact.emailLabel',
+                  'h3',
+                  {
+                    className: 'contact-card__title',
+                    style: contactTextStyle,
+                  },
+                  contact.emailLabel,
+                )}
+                {renderRichTextElement(
+                  'contact.email',
+                  'p',
+                  {
+                    className: 'contact-card__text',
+                    style: contactBodyTextStyle,
+                  },
+                  contact.email,
+                )}
               </div>
             </div>
           </div>
@@ -532,7 +714,15 @@ const Login: React.FC = () => {
       <footer className="site-footer" style={{ ...footerBackgroundStyle, ...footerTextStyle }}>
         <div className="layout-container site-footer__inner" style={footerTextStyle}>
           <p style={footerTextStyle}>
-            &copy; {new Date().getFullYear()} {navigation.brand}. {footer.text}
+            &copy; {new Date().getFullYear()} {navigation.brand}.{' '}
+            {renderRichTextElement(
+              'footer.text',
+              'span',
+              {
+                style: footerTextStyle,
+              },
+              footer.text,
+            )}
           </p>
         </div>
       </footer>

--- a/pages/SiteCustomization.tsx
+++ b/pages/SiteCustomization.tsx
@@ -7,6 +7,7 @@ import React, {
   useState,
 } from 'react';
 import useSiteContent, { DEFAULT_SITE_CONTENT } from '../hooks/useSiteContent';
+import RichTextEditor from '../components/RichTextEditor';
 import {
   CustomizationAsset,
   CustomizationAssetType,
@@ -14,6 +15,7 @@ import {
   EditableZoneKey,
   ElementStyle,
   Product,
+  RichTextValue,
   SectionStyle,
   SiteContent,
   STYLE_EDITABLE_ELEMENT_KEYS,
@@ -39,6 +41,8 @@ import {
   Video,
   X,
 } from 'lucide-react';
+import { sanitizeFontFamilyName } from '../utils/fonts';
+import { updateElementRichTextMap } from '../utils/richText';
 
 const imageWarning = "L'URL doit provenir de Cloudinary (https://*.cloudinary.com).";
 
@@ -313,19 +317,6 @@ type ContactFieldKey = Exclude<keyof SiteContent['contact'], 'image' | 'style'>;
 
 type ElementStyleProperty = keyof ElementStyle;
 
-type NavigationChangeHandler = (
-  key: NavigationFieldKey,
-) => (event: React.ChangeEvent<HTMLInputElement>) => void;
-type HeroChangeHandler = (
-  key: HeroFieldKey,
-) => (event: React.ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => void;
-type MenuChangeHandler = (
-  key: MenuFieldKey,
-) => (event: React.ChangeEvent<HTMLInputElement>) => void;
-type ContactChangeHandler = (
-  key: ContactFieldKey,
-) => (event: React.ChangeEvent<HTMLInputElement>) => void;
-
 type ImageInputHandler = (
   field: ImageFieldKey,
 ) => (event: React.ChangeEvent<HTMLInputElement>) => void;
@@ -447,14 +438,6 @@ type EditorContext = {
   draft: SiteContent;
   imageErrors: Record<ImageFieldKey, string | null>;
   isUploading: (field: ImageFieldKey) => boolean;
-  handleBrandChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  handleNavigationChange: NavigationChangeHandler;
-  handleHeroFieldChange: HeroChangeHandler;
-  handleAboutChange: (event: React.ChangeEvent<HTMLTextAreaElement>) => void;
-  handleAboutTitleChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
-  handleMenuFieldChange: MenuChangeHandler;
-  handleContactFieldChange: ContactChangeHandler;
-  handleFooterTextChange: (event: React.ChangeEvent<HTMLInputElement>) => void;
   handleImageInputChange: ImageInputHandler;
   handleImageUpload: ImageUploadHandler;
   handleClearImage: ImageClearHandler;
@@ -474,14 +457,22 @@ type EditorContext = {
   handleElementStyleReset: (element: EditableElementKey, property?: ElementStyleProperty) => void;
   fontOptions: readonly string[];
   fontSizeOptions: readonly string[];
-  setBrandValue: (value: string) => void;
-  setNavigationLinkValue: (key: NavigationFieldKey, value: string) => void;
-  setHeroFieldValue: (key: HeroFieldKey, value: string) => void;
-  setAboutTitleValue: (value: string) => void;
-  setAboutDescriptionValue: (value: string) => void;
-  setMenuFieldValue: (key: MenuFieldKey, value: string) => void;
-  setContactFieldValue: (key: ContactFieldKey, value: string) => void;
-  setFooterTextValue: (value: string) => void;
+  setBrandValue: (value: string, richText?: RichTextValue | null) => void;
+  setNavigationLinkValue: (
+    key: NavigationFieldKey,
+    value: string,
+    richText?: RichTextValue | null,
+  ) => void;
+  setHeroFieldValue: (key: HeroFieldKey, value: string, richText?: RichTextValue | null) => void;
+  setAboutTitleValue: (value: string, richText?: RichTextValue | null) => void;
+  setAboutDescriptionValue: (value: string, richText?: RichTextValue | null) => void;
+  setMenuFieldValue: (key: MenuFieldKey, value: string, richText?: RichTextValue | null) => void;
+  setContactFieldValue: (
+    key: ContactFieldKey,
+    value: string,
+    richText?: RichTextValue | null,
+  ) => void;
+  setFooterTextValue: (value: string, richText?: RichTextValue | null) => void;
   bestSellerProducts: Product[];
   bestSellerLoading: boolean;
   bestSellerError: string | null;
@@ -581,12 +572,23 @@ const SiteCustomization: React.FC = () => {
   const fontOptions = useMemo(() => {
     const customFonts = draft.assets.library
       .filter(asset => asset.type === 'font')
-      .map(asset => `"${asset.name}"`)
+      .map(asset => `"${sanitizeFontFamilyName(asset.name)}"`)
       .filter((value, index, list) => list.indexOf(value) === index);
     return [...FONT_FAMILY_SUGGESTIONS, ...customFonts];
   }, [draft.assets.library]);
 
   const fontSizeOptions = useMemo(() => [...FONT_SIZE_SUGGESTIONS], []);
+
+  const resolveNextElementRichText = (
+    prev: SiteContent,
+    key: EditableElementKey,
+    value: RichTextValue | null | undefined,
+  ) => {
+    if (value === undefined) {
+      return prev.elementRichText;
+    }
+    return updateElementRichTextMap(prev.elementRichText, key, value);
+  };
 
   const cleanElementStyle = useCallback((style: ElementStyle | undefined): ElementStyle | null => {
     if (!style) {
@@ -665,17 +667,23 @@ const SiteCustomization: React.FC = () => {
     }));
   };
 
-  const setBrandValue = (value: string) => {
+  const setBrandValue = (value: string, richText?: RichTextValue | null) => {
     mutateDraft(prev => ({
       ...prev,
       navigation: {
         ...prev.navigation,
         brand: value,
       },
+      elementRichText: resolveNextElementRichText(prev, 'navigation.brand', richText),
     }));
   };
 
-  const setNavigationLinkValue = (key: NavigationFieldKey, value: string) => {
+  const setNavigationLinkValue = (
+    key: NavigationFieldKey,
+    value: string,
+    richText?: RichTextValue | null,
+  ) => {
+    const elementKey = `navigation.links.${key}` as EditableElementKey;
     mutateDraft(prev => ({
       ...prev,
       navigation: {
@@ -685,99 +693,81 @@ const SiteCustomization: React.FC = () => {
           [key]: value,
         },
       },
+      elementRichText: resolveNextElementRichText(prev, elementKey, richText),
     }));
   };
 
-  const setHeroFieldValue = (key: HeroFieldKey, value: string) => {
+  const setHeroFieldValue = (key: HeroFieldKey, value: string, richText?: RichTextValue | null) => {
+    const elementKey = `hero.${key}` as EditableElementKey;
     mutateDraft(prev => ({
       ...prev,
       hero: {
         ...prev.hero,
         [key]: value,
       },
+      elementRichText: resolveNextElementRichText(prev, elementKey, richText),
     }));
   };
 
-  const setAboutTitleValue = (value: string) => {
+  const setAboutTitleValue = (value: string, richText?: RichTextValue | null) => {
     mutateDraft(prev => ({
       ...prev,
       about: {
         ...prev.about,
         title: value,
       },
+      elementRichText: resolveNextElementRichText(prev, 'about.title', richText),
     }));
   };
 
-  const setAboutDescriptionValue = (value: string) => {
+  const setAboutDescriptionValue = (value: string, richText?: RichTextValue | null) => {
     mutateDraft(prev => ({
       ...prev,
       about: {
         ...prev.about,
         description: value,
       },
+      elementRichText: resolveNextElementRichText(prev, 'about.description', richText),
     }));
   };
 
-  const setMenuFieldValue = (key: MenuFieldKey, value: string) => {
+  const setMenuFieldValue = (key: MenuFieldKey, value: string, richText?: RichTextValue | null) => {
+    const elementKey = `menu.${key}` as EditableElementKey;
     mutateDraft(prev => ({
       ...prev,
       menu: {
         ...prev.menu,
         [key]: value,
       },
+      elementRichText: resolveNextElementRichText(prev, elementKey, richText),
     }));
   };
 
-  const setContactFieldValue = (key: ContactFieldKey, value: string) => {
+  const setContactFieldValue = (
+    key: ContactFieldKey,
+    value: string,
+    richText?: RichTextValue | null,
+  ) => {
+    const elementKey = `contact.${key}` as EditableElementKey;
     mutateDraft(prev => ({
       ...prev,
       contact: {
         ...prev.contact,
         [key]: value,
       },
+      elementRichText: resolveNextElementRichText(prev, elementKey, richText),
     }));
   };
 
-  const setFooterTextValue = (value: string) => {
+  const setFooterTextValue = (value: string, richText?: RichTextValue | null) => {
     mutateDraft(prev => ({
       ...prev,
       footer: {
         ...prev.footer,
         text: value,
       },
+      elementRichText: resolveNextElementRichText(prev, 'footer.text', richText),
     }));
-  };
-
-  const handleNavigationChange: NavigationChangeHandler = key => event => {
-    setNavigationLinkValue(key, event.target.value);
-  };
-
-  const handleBrandChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setBrandValue(event.target.value);
-  };
-
-  const handleHeroFieldChange: HeroChangeHandler = key => event => {
-    setHeroFieldValue(key, event.target.value);
-  };
-
-  const handleAboutTitleChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setAboutTitleValue(event.target.value);
-  };
-
-  const handleAboutChange = (event: React.ChangeEvent<HTMLTextAreaElement>) => {
-    setAboutDescriptionValue(event.target.value);
-  };
-
-  const handleMenuFieldChange: MenuChangeHandler = key => event => {
-    setMenuFieldValue(key, event.target.value);
-  };
-
-  const handleContactFieldChange: ContactChangeHandler = key => event => {
-    setContactFieldValue(key, event.target.value);
-  };
-
-  const handleFooterTextChange = (event: React.ChangeEvent<HTMLInputElement>) => {
-    setFooterTextValue(event.target.value);
   };
 
   const setImageField = (field: ImageFieldKey, value: string | null) => {
@@ -1123,14 +1113,6 @@ const SiteCustomization: React.FC = () => {
     draft,
     imageErrors,
     isUploading,
-    handleBrandChange,
-    handleNavigationChange,
-    handleHeroFieldChange,
-    handleAboutChange,
-    handleAboutTitleChange,
-    handleMenuFieldChange,
-    handleContactFieldChange,
-    handleFooterTextChange,
     handleImageInputChange,
     handleImageUpload,
     handleClearImage,
@@ -2115,6 +2097,23 @@ const ZoneEditorContent: React.FC<{ zone: EditableZoneKey; context: EditorContex
     [context],
   );
 
+  const getRichTextValue = (key: EditableElementKey) => draft.elementRichText?.[key] ?? null;
+
+  const renderRichTextField = (
+    key: EditableElementKey,
+    fallback: string,
+    onValueChange: (plainText: string, richText?: RichTextValue | null) => void,
+    placeholder?: string,
+  ) => (
+    <RichTextEditor
+      id={`${key.replace(/\./g, '-')}-editor`}
+      value={getRichTextValue(key)}
+      fallback={fallback}
+      onChange={next => onValueChange(next?.plainText ?? '', next)}
+      placeholder={placeholder}
+    />
+  );
+
   if (zone !== 'menu') {
     return null;
   }
@@ -2332,13 +2331,11 @@ const getElementEditorConfig = (
         title: 'Nom de la marque',
         content: (
           <FieldCard label="Nom de la marque" htmlFor="brand-name">
-            <input
-              id="brand-name"
-              className="ui-input w-full"
-              value={draft.navigation.brand}
-              onChange={context.handleBrandChange}
+            {renderRichTextField('navigation.brand', draft.navigation.brand, context.setBrandValue)}
+            <SuggestionChips
+              options={NAVIGATION_BRAND_SUGGESTIONS}
+              onSelect={value => context.setBrandValue(value, null)}
             />
-            <SuggestionChips options={NAVIGATION_BRAND_SUGGESTIONS} onSelect={context.setBrandValue} />
           </FieldCard>
         ),
       };
@@ -2352,15 +2349,14 @@ const getElementEditorConfig = (
         title: label,
         content: (
           <FieldCard label={label} htmlFor={`nav-${key}`}>
-            <input
-              id={`nav-${key}`}
-              className="ui-input w-full"
-              value={draft.navigation.links[key]}
-              onChange={context.handleNavigationChange(key)}
-            />
+            {renderRichTextField(
+              element,
+              draft.navigation.links[key],
+              (text, rich) => context.setNavigationLinkValue(key, text, rich),
+            )}
             <SuggestionChips
               options={NAVIGATION_LINK_SUGGESTIONS[key]}
-              onSelect={value => context.setNavigationLinkValue(key, value)}
+              onSelect={value => context.setNavigationLinkValue(key, value, null)}
             />
           </FieldCard>
         ),
@@ -2371,15 +2367,14 @@ const getElementEditorConfig = (
         title: "Bouton d'accès équipe",
         content: (
           <FieldCard label="Bouton d'accès équipe" htmlFor="nav-login">
-            <input
-              id="nav-login"
-              className="ui-input w-full"
-              value={draft.navigation.links.loginCta}
-              onChange={context.handleNavigationChange('loginCta')}
-            />
+            {renderRichTextField(
+              'navigation.links.loginCta',
+              draft.navigation.links.loginCta,
+              (text, rich) => context.setNavigationLinkValue('loginCta', text, rich),
+            )}
             <SuggestionChips
               options={NAVIGATION_LINK_SUGGESTIONS.loginCta}
-              onSelect={value => context.setNavigationLinkValue('loginCta', value)}
+              onSelect={value => context.setNavigationLinkValue('loginCta', value, null)}
             />
           </FieldCard>
         ),
@@ -2428,15 +2423,12 @@ const getElementEditorConfig = (
         title: 'Titre principal',
         content: (
           <FieldCard label="Titre principal" htmlFor="hero-title">
-            <input
-              id="hero-title"
-              className="ui-input w-full"
-              value={draft.hero.title}
-              onChange={context.handleHeroFieldChange('title')}
-            />
+            {renderRichTextField('hero.title', draft.hero.title, (text, rich) =>
+              context.setHeroFieldValue('title', text, rich),
+            )}
             <SuggestionChips
               options={HERO_TITLE_SUGGESTIONS}
-              onSelect={value => context.setHeroFieldValue('title', value)}
+              onSelect={value => context.setHeroFieldValue('title', value, null)}
             />
           </FieldCard>
         ),
@@ -2446,16 +2438,12 @@ const getElementEditorConfig = (
         title: 'Sous-titre',
         content: (
           <FieldCard label="Sous-titre" htmlFor="hero-subtitle">
-            <textarea
-              id="hero-subtitle"
-              className="ui-textarea w-full"
-              rows={3}
-              value={draft.hero.subtitle}
-              onChange={context.handleHeroFieldChange('subtitle')}
-            />
+            {renderRichTextField('hero.subtitle', draft.hero.subtitle, (text, rich) =>
+              context.setHeroFieldValue('subtitle', text, rich),
+            )}
             <SuggestionChips
               options={HERO_SUBTITLE_SUGGESTIONS}
-              onSelect={value => context.setHeroFieldValue('subtitle', value)}
+              onSelect={value => context.setHeroFieldValue('subtitle', value, null)}
             />
           </FieldCard>
         ),
@@ -2465,15 +2453,12 @@ const getElementEditorConfig = (
         title: 'CTA principal',
         content: (
           <FieldCard label="CTA principal" htmlFor="hero-cta">
-            <input
-              id="hero-cta"
-              className="ui-input w-full"
-              value={draft.hero.ctaLabel}
-              onChange={context.handleHeroFieldChange('ctaLabel')}
-            />
+            {renderRichTextField('hero.ctaLabel', draft.hero.ctaLabel, (text, rich) =>
+              context.setHeroFieldValue('ctaLabel', text, rich),
+            )}
             <SuggestionChips
               options={HERO_CTA_SUGGESTIONS}
-              onSelect={value => context.setHeroFieldValue('ctaLabel', value)}
+              onSelect={value => context.setHeroFieldValue('ctaLabel', value, null)}
             />
           </FieldCard>
         ),
@@ -2483,15 +2468,12 @@ const getElementEditorConfig = (
         title: 'CTA historique',
         content: (
           <FieldCard label="CTA historique" htmlFor="hero-reorder">
-            <input
-              id="hero-reorder"
-              className="ui-input w-full"
-              value={draft.hero.reorderCtaLabel}
-              onChange={context.handleHeroFieldChange('reorderCtaLabel')}
-            />
+            {renderRichTextField('hero.reorderCtaLabel', draft.hero.reorderCtaLabel, (text, rich) =>
+              context.setHeroFieldValue('reorderCtaLabel', text, rich),
+            )}
             <SuggestionChips
               options={HERO_REORDER_SUGGESTIONS}
-              onSelect={value => context.setHeroFieldValue('reorderCtaLabel', value)}
+              onSelect={value => context.setHeroFieldValue('reorderCtaLabel', value, null)}
             />
           </FieldCard>
         ),
@@ -2501,15 +2483,12 @@ const getElementEditorConfig = (
         title: 'Titre du bloc historique',
         content: (
           <FieldCard label="Titre du bloc historique" htmlFor="hero-history">
-            <input
-              id="hero-history"
-              className="ui-input w-full"
-              value={draft.hero.historyTitle}
-              onChange={context.handleHeroFieldChange('historyTitle')}
-            />
+            {renderRichTextField('hero.historyTitle', draft.hero.historyTitle, (text, rich) =>
+              context.setHeroFieldValue('historyTitle', text, rich),
+            )}
             <SuggestionChips
               options={HERO_HISTORY_TITLE_SUGGESTIONS}
-              onSelect={value => context.setHeroFieldValue('historyTitle', value)}
+              onSelect={value => context.setHeroFieldValue('historyTitle', value, null)}
             />
           </FieldCard>
         ),
@@ -2541,13 +2520,13 @@ const getElementEditorConfig = (
         title: 'Titre',
         content: (
           <FieldCard label="Titre" htmlFor="about-title">
-            <input
-              id="about-title"
-              className="ui-input w-full"
-              value={draft.about.title}
-              onChange={context.handleAboutTitleChange}
+            {renderRichTextField('about.title', draft.about.title, (text, rich) =>
+              context.setAboutTitleValue(text, rich),
+            )}
+            <SuggestionChips
+              options={ABOUT_TITLE_SUGGESTIONS}
+              onSelect={value => context.setAboutTitleValue(value, null)}
             />
-            <SuggestionChips options={ABOUT_TITLE_SUGGESTIONS} onSelect={context.setAboutTitleValue} />
           </FieldCard>
         ),
       };
@@ -2556,14 +2535,13 @@ const getElementEditorConfig = (
         title: 'Description',
         content: (
           <FieldCard label="Description" htmlFor="about-description">
-            <textarea
-              id="about-description"
-              className="ui-textarea w-full"
-              rows={4}
-              value={draft.about.description}
-              onChange={context.handleAboutChange}
+            {renderRichTextField('about.description', draft.about.description, (text, rich) =>
+              context.setAboutDescriptionValue(text, rich),
+            )}
+            <SuggestionChips
+              options={ABOUT_DESCRIPTION_SUGGESTIONS}
+              onSelect={value => context.setAboutDescriptionValue(value, null)}
             />
-            <SuggestionChips options={ABOUT_DESCRIPTION_SUGGESTIONS} onSelect={context.setAboutDescriptionValue} />
           </FieldCard>
         ),
       };
@@ -2594,12 +2572,9 @@ const getElementEditorConfig = (
         title: 'Titre',
         content: (
           <FieldCard label="Titre" htmlFor="menu-title">
-            <input
-              id="menu-title"
-              className="ui-input w-full"
-              value={draft.menu.title}
-              onChange={context.handleMenuFieldChange('title')}
-            />
+            {renderRichTextField('menu.title', draft.menu.title, (text, rich) =>
+              context.setMenuFieldValue('title', text, rich),
+            )}
           </FieldCard>
         ),
       };
@@ -2608,13 +2583,13 @@ const getElementEditorConfig = (
         title: 'CTA',
         content: (
           <FieldCard label="CTA" htmlFor="menu-cta">
-            <input
-              id="menu-cta"
-              className="ui-input w-full"
-              value={draft.menu.ctaLabel}
-              onChange={context.handleMenuFieldChange('ctaLabel')}
+            {renderRichTextField('menu.ctaLabel', draft.menu.ctaLabel, (text, rich) =>
+              context.setMenuFieldValue('ctaLabel', text, rich),
+            )}
+            <SuggestionChips
+              options={MENU_CTA_SUGGESTIONS}
+              onSelect={value => context.setMenuFieldValue('ctaLabel', value, null)}
             />
-            <SuggestionChips options={MENU_CTA_SUGGESTIONS} onSelect={value => context.setMenuFieldValue('ctaLabel', value)} />
           </FieldCard>
         ),
       };
@@ -2623,15 +2598,12 @@ const getElementEditorConfig = (
         title: 'Message de chargement',
         content: (
           <FieldCard label="Message de chargement" htmlFor="menu-loading">
-            <input
-              id="menu-loading"
-              className="ui-input w-full"
-              value={draft.menu.loadingLabel}
-              onChange={context.handleMenuFieldChange('loadingLabel')}
-            />
+            {renderRichTextField('menu.loadingLabel', draft.menu.loadingLabel, (text, rich) =>
+              context.setMenuFieldValue('loadingLabel', text, rich),
+            )}
             <SuggestionChips
               options={MENU_LOADING_SUGGESTIONS}
-              onSelect={value => context.setMenuFieldValue('loadingLabel', value)}
+              onSelect={value => context.setMenuFieldValue('loadingLabel', value, null)}
             />
           </FieldCard>
         ),
@@ -2663,12 +2635,9 @@ const getElementEditorConfig = (
         title: 'Titre',
         content: (
           <FieldCard label="Titre" htmlFor="contact-title">
-            <input
-              id="contact-title"
-              className="ui-input w-full"
-              value={draft.contact.title}
-              onChange={context.handleContactFieldChange('title')}
-            />
+            {renderRichTextField('contact.title', draft.contact.title, (text, rich) =>
+              context.setContactFieldValue('title', text, rich),
+            )}
           </FieldCard>
         ),
       };
@@ -2677,12 +2646,9 @@ const getElementEditorConfig = (
         title: 'Label adresse',
         content: (
           <FieldCard label="Label adresse" htmlFor="contact-address-label">
-            <input
-              id="contact-address-label"
-              className="ui-input w-full"
-              value={draft.contact.addressLabel}
-              onChange={context.handleContactFieldChange('addressLabel')}
-            />
+            {renderRichTextField('contact.addressLabel', draft.contact.addressLabel, (text, rich) =>
+              context.setContactFieldValue('addressLabel', text, rich),
+            )}
           </FieldCard>
         ),
       };
@@ -2691,15 +2657,12 @@ const getElementEditorConfig = (
         title: 'Adresse',
         content: (
           <FieldCard label="Adresse" htmlFor="contact-address">
-            <input
-              id="contact-address"
-              className="ui-input w-full"
-              value={draft.contact.address}
-              onChange={context.handleContactFieldChange('address')}
-            />
+            {renderRichTextField('contact.address', draft.contact.address, (text, rich) =>
+              context.setContactFieldValue('address', text, rich),
+            )}
             <SuggestionChips
               options={CONTACT_ADDRESS_SUGGESTIONS}
-              onSelect={value => context.setContactFieldValue('address', value)}
+              onSelect={value => context.setContactFieldValue('address', value, null)}
             />
           </FieldCard>
         ),
@@ -2709,12 +2672,9 @@ const getElementEditorConfig = (
         title: 'Label téléphone',
         content: (
           <FieldCard label="Label téléphone" htmlFor="contact-phone-label">
-            <input
-              id="contact-phone-label"
-              className="ui-input w-full"
-              value={draft.contact.phoneLabel}
-              onChange={context.handleContactFieldChange('phoneLabel')}
-            />
+            {renderRichTextField('contact.phoneLabel', draft.contact.phoneLabel, (text, rich) =>
+              context.setContactFieldValue('phoneLabel', text, rich),
+            )}
           </FieldCard>
         ),
       };
@@ -2723,15 +2683,12 @@ const getElementEditorConfig = (
         title: 'Téléphone',
         content: (
           <FieldCard label="Téléphone" htmlFor="contact-phone">
-            <input
-              id="contact-phone"
-              className="ui-input w-full"
-              value={draft.contact.phone}
-              onChange={context.handleContactFieldChange('phone')}
-            />
+            {renderRichTextField('contact.phone', draft.contact.phone, (text, rich) =>
+              context.setContactFieldValue('phone', text, rich),
+            )}
             <SuggestionChips
               options={CONTACT_PHONE_SUGGESTIONS}
-              onSelect={value => context.setContactFieldValue('phone', value)}
+              onSelect={value => context.setContactFieldValue('phone', value, null)}
             />
           </FieldCard>
         ),
@@ -2741,12 +2698,9 @@ const getElementEditorConfig = (
         title: 'Label email',
         content: (
           <FieldCard label="Label email" htmlFor="contact-email-label">
-            <input
-              id="contact-email-label"
-              className="ui-input w-full"
-              value={draft.contact.emailLabel}
-              onChange={context.handleContactFieldChange('emailLabel')}
-            />
+            {renderRichTextField('contact.emailLabel', draft.contact.emailLabel, (text, rich) =>
+              context.setContactFieldValue('emailLabel', text, rich),
+            )}
           </FieldCard>
         ),
       };
@@ -2755,15 +2709,12 @@ const getElementEditorConfig = (
         title: 'Email',
         content: (
           <FieldCard label="Email" htmlFor="contact-email">
-            <input
-              id="contact-email"
-              className="ui-input w-full"
-              value={draft.contact.email}
-              onChange={context.handleContactFieldChange('email')}
-            />
+            {renderRichTextField('contact.email', draft.contact.email, (text, rich) =>
+              context.setContactFieldValue('email', text, rich),
+            )}
             <SuggestionChips
               options={CONTACT_EMAIL_SUGGESTIONS}
-              onSelect={value => context.setContactFieldValue('email', value)}
+              onSelect={value => context.setContactFieldValue('email', value, null)}
             />
           </FieldCard>
         ),
@@ -2795,13 +2746,13 @@ const getElementEditorConfig = (
         title: 'Texte de pied de page',
         content: (
           <FieldCard label="Texte" htmlFor="footer-text">
-            <input
-              id="footer-text"
-              className="ui-input w-full"
-              value={draft.footer.text}
-              onChange={context.handleFooterTextChange}
+            {renderRichTextField('footer.text', draft.footer.text, (text, rich) =>
+              context.setFooterTextValue(text, rich),
+            )}
+            <SuggestionChips
+              options={FOOTER_TEXT_SUGGESTIONS}
+              onSelect={value => context.setFooterTextValue(value, null)}
             />
-            <SuggestionChips options={FOOTER_TEXT_SUGGESTIONS} onSelect={context.setFooterTextValue} />
           </FieldCard>
         ),
       };

--- a/types/index.ts
+++ b/types/index.ts
@@ -81,6 +81,15 @@ export interface ElementStyle {
 
 export type ElementStyles = Partial<Record<EditableElementKey, ElementStyle>>;
 
+export type RichTextMark = 'bold' | 'italic' | 'strikethrough';
+
+export interface RichTextValue {
+  html: string;
+  plainText: string;
+}
+
+export type ElementRichText = Partial<Record<EditableElementKey, RichTextValue>>;
+
 export type CustomizationAssetType = 'image' | 'video' | 'audio' | 'font' | 'raw';
 
 export interface CustomizationAsset {
@@ -149,6 +158,7 @@ export interface SiteContent {
     style: SectionStyle;
   };
   elementStyles: ElementStyles;
+  elementRichText: ElementRichText;
   assets: SiteAssets;
 }
 

--- a/utils/fonts.ts
+++ b/utils/fonts.ts
@@ -1,0 +1,71 @@
+import { CustomizationAsset } from '../types';
+
+const MIME_TO_FORMAT: Record<string, string> = {
+  'font/woff2': 'woff2',
+  'application/font-woff2': 'woff2',
+  'application/x-font-woff2': 'woff2',
+  'font/woff': 'woff',
+  'application/font-woff': 'woff',
+  'application/x-font-woff': 'woff',
+  'application/x-font-ttf': 'truetype',
+  'font/ttf': 'truetype',
+  'application/x-font-otf': 'opentype',
+  'font/otf': 'opentype',
+  'application/vnd.ms-fontobject': 'embedded-opentype',
+  'application/x-font-eot': 'embedded-opentype',
+  'image/svg+xml': 'svg',
+};
+
+const EXTENSION_TO_FORMAT: Record<string, string> = {
+  woff2: 'woff2',
+  woff: 'woff',
+  ttf: 'truetype',
+  otf: 'opentype',
+  eot: 'embedded-opentype',
+  svg: 'svg',
+};
+
+export const sanitizeFontFamilyName = (name: string): string => {
+  const trimmed = name.trim();
+  const safe = trimmed.length > 0 ? trimmed : 'Custom Font';
+  return safe.replace(/"|'/g, '');
+};
+
+const inferFormatFromMime = (mime: string | undefined): string | null => {
+  if (!mime) {
+    return null;
+  }
+  const lower = mime.toLowerCase();
+  for (const [key, format] of Object.entries(MIME_TO_FORMAT)) {
+    if (lower.includes(key)) {
+      return format;
+    }
+  }
+  return null;
+};
+
+const inferFormatFromUrl = (url: string): string | null => {
+  const lower = url.toLowerCase();
+  const match = lower.match(/\.([a-z0-9]+)(?:\?|#|$)/);
+  if (!match) {
+    return null;
+  }
+  const extension = match[1];
+  return EXTENSION_TO_FORMAT[extension] ?? null;
+};
+
+export const inferFontFormat = (asset: CustomizationAsset): string | null => {
+  const fromMime = inferFormatFromMime(asset.format);
+  if (fromMime) {
+    return fromMime;
+  }
+  return inferFormatFromUrl(asset.url);
+};
+
+export const createFontFaceDeclaration = (asset: CustomizationAsset): string => {
+  const family = sanitizeFontFamilyName(asset.name);
+  const format = inferFontFormat(asset);
+  const formatSuffix = format ? ` format("${format}")` : '';
+  const src = `url("${asset.url}")${formatSuffix}`;
+  return `@font-face {\n  font-family: "${family}";\n  src: ${src};\n  font-style: normal;\n  font-weight: 400;\n  font-display: swap;\n}`;
+};

--- a/utils/richText.ts
+++ b/utils/richText.ts
@@ -1,0 +1,218 @@
+import { ElementRichText, EditableElementKey, RichTextValue } from '../types';
+
+const ALLOWED_TAGS = new Set([
+  'STRONG',
+  'EM',
+  'S',
+  'SPAN',
+  'BR',
+  'DIV',
+  'P',
+  'B',
+  'I',
+]);
+
+const HEX_COLOR_PATTERN = /^#([0-9a-fA-F]{3}|[0-9a-fA-F]{6}|[0-9a-fA-F]{8})$/;
+const RGB_COLOR_PATTERN = /^rgba?\((\s*\d{1,3}\s*,){2}\s*\d{1,3}\s*(,\s*(0|1|0?\.\d+))?\s*\)$/;
+
+const hasDOM = typeof window !== 'undefined' && typeof document !== 'undefined';
+
+const escapeHtml = (value: string): string =>
+  value
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+
+const sanitizeColor = (value: string): string | null => {
+  const trimmed = value.trim().replace(/"|'/g, '');
+  if (HEX_COLOR_PATTERN.test(trimmed)) {
+    return trimmed.toLowerCase();
+  }
+  if (RGB_COLOR_PATTERN.test(trimmed)) {
+    return trimmed.replace(/\s+/g, '');
+  }
+  return null;
+};
+
+const unwrapElement = (element: Element) => {
+  const parent = element.parentNode;
+  if (!parent) {
+    element.remove();
+    return;
+  }
+  while (element.firstChild) {
+    parent.insertBefore(element.firstChild, element);
+  }
+  parent.removeChild(element);
+};
+
+const normalizeElementTag = (element: HTMLElement): HTMLElement => {
+  if (element.tagName === 'B') {
+    const replacement = document.createElement('strong');
+    while (element.firstChild) {
+      replacement.appendChild(element.firstChild);
+    }
+    element.replaceWith(replacement);
+    return replacement;
+  }
+  if (element.tagName === 'I') {
+    const replacement = document.createElement('em');
+    while (element.firstChild) {
+      replacement.appendChild(element.firstChild);
+    }
+    element.replaceWith(replacement);
+    return replacement;
+  }
+  return element;
+};
+
+const sanitizeElement = (element: HTMLElement) => {
+  if (!ALLOWED_TAGS.has(element.tagName)) {
+    unwrapElement(element);
+    return;
+  }
+
+  const normalized = normalizeElementTag(element);
+
+  Array.from(normalized.attributes).forEach(attr => {
+    if (attr.name !== 'style') {
+      normalized.removeAttribute(attr.name);
+    }
+  });
+
+  if (normalized.hasAttribute('style')) {
+    const style = normalized.getAttribute('style') ?? '';
+    const declarations = style
+      .split(';')
+      .map(item => item.trim())
+      .filter(Boolean);
+    const colorDeclaration = declarations.find(decl => decl.toLowerCase().startsWith('color'));
+
+    if (colorDeclaration) {
+      const [, rawValue] = colorDeclaration.split(':');
+      const sanitized = rawValue ? sanitizeColor(rawValue) : null;
+      if (sanitized) {
+        normalized.setAttribute('style', `color: ${sanitized}`);
+      } else {
+        normalized.removeAttribute('style');
+      }
+    } else {
+      normalized.removeAttribute('style');
+    }
+  }
+
+  Array.from(normalized.childNodes).forEach(child => {
+    if (child.nodeType === Node.COMMENT_NODE) {
+      child.parentNode?.removeChild(child);
+      return;
+    }
+    if (child.nodeType === Node.ELEMENT_NODE) {
+      sanitizeElement(child as HTMLElement);
+    }
+  });
+};
+
+const fallbackSanitize = (html: string): string =>
+  html
+    .replace(/<\/?(?!br\b)[^>]+>/gi, '')
+    .replace(/\r\n|\r|\n/g, '<br>')
+    .replace(/<script[^>]*>[\s\S]*?<\/script>/gi, '');
+
+export const sanitizeRichTextHtml = (html: string): string => {
+  const input = html ?? '';
+  if (input.trim().length === 0) {
+    return '';
+  }
+
+  if (!hasDOM) {
+    return fallbackSanitize(input).trim();
+  }
+
+  const template = document.createElement('template');
+  template.innerHTML = input;
+
+  Array.from(template.content.childNodes).forEach(node => {
+    if (node.nodeType === Node.COMMENT_NODE) {
+      node.parentNode?.removeChild(node);
+      return;
+    }
+    if (node.nodeType === Node.ELEMENT_NODE) {
+      sanitizeElement(node as HTMLElement);
+    }
+  });
+
+  return template.innerHTML.trim();
+};
+
+const stripHtml = (html: string): string => {
+  if (!hasDOM) {
+    return html.replace(/<[^>]+>/g, '');
+  }
+  const template = document.createElement('template');
+  template.innerHTML = html;
+  return template.content.textContent ?? '';
+};
+
+const normalizePlainText = (value: string): string =>
+  value
+    .replace(/[\u200B\u200C\u200D\uFEFF]/g, '')
+    .replace(/\r\n/g, '\n');
+
+export const sanitizeRichTextValue = (
+  value: RichTextValue | null | undefined,
+): RichTextValue | null => {
+  if (!value) {
+    return null;
+  }
+
+  const sanitizedHtml = sanitizeRichTextHtml(value.html ?? '');
+  const providedPlainText = normalizePlainText(value.plainText ?? '');
+  const htmlPlainText = normalizePlainText(stripHtml(sanitizedHtml));
+  const effectivePlainText = providedPlainText.trim().length > 0 ? providedPlainText : htmlPlainText;
+
+  if (sanitizedHtml.trim().length === 0 && effectivePlainText.trim().length === 0) {
+    return null;
+  }
+
+  return {
+    html: sanitizedHtml,
+    plainText: effectivePlainText,
+  };
+};
+
+export const updateElementRichTextMap = (
+  map: ElementRichText,
+  key: EditableElementKey,
+  value: RichTextValue | null | undefined,
+): ElementRichText => {
+  if (value === undefined) {
+    return map;
+  }
+  const sanitized = sanitizeRichTextValue(value);
+  if (!sanitized) {
+    if (!(key in map)) {
+      return map;
+    }
+    const next = { ...map };
+    delete next[key];
+    return next;
+  }
+  return {
+    ...map,
+    [key]: sanitized,
+  };
+};
+
+export const plainTextToHtml = (plainText: string): string => {
+  if (plainText.trim().length === 0) {
+    return '';
+  }
+  return escapeHtml(plainText).replace(/\r\n|\r|\n/g, '<br>');
+};
+
+export const createPlainTextRichTextValue = (plainText: string): RichTextValue => ({
+  plainText: normalizePlainText(plainText),
+  html: plainTextToHtml(plainText),
+});

--- a/utils/siteContent.ts
+++ b/utils/siteContent.ts
@@ -2,6 +2,7 @@ import {
   CustomizationAsset,
   CustomizationAssetType,
   EditableElementKey,
+  ElementRichText,
   ElementStyle,
   ElementStyles,
   SectionStyle,
@@ -10,6 +11,7 @@ import {
   EDITABLE_ELEMENT_KEYS,
 } from '../types';
 import { normalizeCloudinaryImageUrl } from '../services/cloudinary';
+import { sanitizeRichTextValue } from './richText';
 
 const trimOrEmpty = (value: string): string => value.trim();
 
@@ -114,6 +116,42 @@ const sanitizeElementStyles = (styles: ElementStyles | undefined, fallback: Elem
     const entry = sanitizeElementStyle(source[key] ?? null);
     if (entry) {
       sanitized[key as EditableElementKey] = entry;
+    }
+  });
+
+  return sanitized;
+};
+
+const resolveElementRichText = (
+  richText: ElementRichText | null | undefined,
+  fallback: ElementRichText,
+): ElementRichText => {
+  const source: ElementRichText = richText ?? fallback;
+  const resolved: ElementRichText = {};
+
+  EDITABLE_ELEMENT_KEYS.forEach(key => {
+    const entry = source[key as EditableElementKey];
+    const sanitized = sanitizeRichTextValue(entry ?? null);
+    if (sanitized) {
+      resolved[key as EditableElementKey] = sanitized;
+    }
+  });
+
+  return resolved;
+};
+
+const sanitizeElementRichText = (
+  richText: ElementRichText | undefined,
+  fallback: ElementRichText,
+): ElementRichText => {
+  const source: ElementRichText = richText ?? fallback;
+  const sanitized: ElementRichText = {};
+
+  EDITABLE_ELEMENT_KEYS.forEach(key => {
+    const entry = source[key as EditableElementKey];
+    const value = sanitizeRichTextValue(entry ?? null);
+    if (value) {
+      sanitized[key as EditableElementKey] = value;
     }
   });
 
@@ -273,6 +311,7 @@ const DEFAULT_SITE_ASSETS: SiteAssets = {
 };
 
 const DEFAULT_ELEMENT_STYLES: ElementStyles = {};
+const DEFAULT_ELEMENT_RICH_TEXT: ElementRichText = {};
 
 const resolveSectionStyle = (style: Partial<SectionStyle> | undefined, fallback: SectionStyle): SectionStyle => {
   const backgroundType = style?.background?.type === 'image' ? 'image' : 'color';
@@ -365,6 +404,7 @@ export const DEFAULT_SITE_CONTENT: SiteContent = {
     style: DEFAULT_FOOTER_STYLE,
   },
   elementStyles: DEFAULT_ELEMENT_STYLES,
+  elementRichText: DEFAULT_ELEMENT_RICH_TEXT,
   assets: DEFAULT_SITE_ASSETS,
 };
 
@@ -422,6 +462,7 @@ export const resolveSiteContent = (content?: Partial<SiteContent> | null): SiteC
       style: resolveSectionStyle(content?.footer?.style, base.footer.style),
     },
     elementStyles: resolveElementStyles(content?.elementStyles ?? null, base.elementStyles),
+    elementRichText: resolveElementRichText(content?.elementRichText ?? null, base.elementRichText),
     assets: resolveSiteAssets(content?.assets ?? null, DEFAULT_SITE_ASSETS),
   };
 };
@@ -478,5 +519,6 @@ export const sanitizeSiteContentInput = (content: SiteContent): SiteContent => (
     style: sanitizeSectionStyle(content.footer.style, DEFAULT_FOOTER_STYLE),
   },
   elementStyles: sanitizeElementStyles(content.elementStyles, DEFAULT_ELEMENT_STYLES),
+  elementRichText: sanitizeElementRichText(content.elementRichText, DEFAULT_ELEMENT_RICH_TEXT),
   assets: sanitizeSiteAssets(content.assets, DEFAULT_SITE_ASSETS),
 });


### PR DESCRIPTION
## Summary
- introduce rich text metadata types and sanitization to store inline styling across editable elements
- replace text inputs with a toolbar-backed rich text editor and render sanitized HTML in previews and login page
- dynamically load uploaded font assets and expose them in style selectors for text groups

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dce4a78474832a9333386b86f2b503