### PR TITLE
Add customizable find-us section with Google Maps preview

### DIFF
--- a/components/SitePreviewCanvas.tsx
+++ b/components/SitePreviewCanvas.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Edit2, Mail, MapPin, Phone } from 'lucide-react';
+import { Clock, Edit2, Mail, MapPin, Phone } from 'lucide-react';
 import { EditableElementKey, EditableZoneKey, Product, SiteContent } from '../types';
 import useCustomFonts from '../hooks/useCustomFonts';
 import {
@@ -31,6 +31,9 @@ export const resolveZoneFromElement = (element: EditableElementKey): EditableZon
   }
   if (element.startsWith('contact.')) {
     return 'contact';
+  }
+  if (element.startsWith('findUs.')) {
+    return 'findUs';
   }
   if (element.startsWith('footer.')) {
     return 'footer';
@@ -149,6 +152,8 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
   const contactBackgroundStyle = createBackgroundStyle(content.contact.style);
   const contactTextStyle = createTextStyle(content.contact.style);
   const contactBodyTextStyle = createBodyTextStyle(content.contact.style);
+  const findUsBackgroundStyle = createBackgroundStyle(content.findUs.style);
+  const findUsTextStyle = createTextStyle(content.findUs.style);
   const footerBackgroundStyle = createBackgroundStyle(content.footer.style);
   const footerTextStyle = createBodyTextStyle(content.footer.style);
 
@@ -185,6 +190,7 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
     about: content.about.style,
     menu: content.menu.style,
     contact: content.contact.style,
+    findUs: content.findUs.style,
     footer: content.footer.style,
   };
 
@@ -204,6 +210,15 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
     const zone = resolveZoneFromElement(key);
     return createElementBackgroundStyle(zoneStyleMap[zone], getElementStyle(key));
   };
+
+  const findUsMapQuery = [content.findUs.address, content.findUs.city].filter(Boolean).join(', ').trim();
+  const encodedFindUsQuery = findUsMapQuery.length > 0 ? encodeURIComponent(findUsMapQuery) : '';
+  const findUsMapUrl = encodedFindUsQuery
+    ? `https://www.google.com/maps?q=${encodedFindUsQuery}`
+    : 'https://www.google.com/maps';
+  const findUsMapEmbedUrl = encodedFindUsQuery
+    ? `https://www.google.com/maps?q=${encodedFindUsQuery}&output=embed`
+    : 'about:blank';
 
   return (
     <div className="space-y-6 rounded-[2.5rem] border border-gray-200 bg-slate-50 p-6 shadow-inner">
@@ -831,6 +846,218 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                     )}
                   </EditableElement>
                 </div>
+              </div>
+            </div>
+          </section>
+        </EditableElement>
+      </SectionCard>
+
+      <SectionCard zone="findUs" activeZone={activeZone}>
+        <EditableElement
+          id="findUs.style.background"
+          label="Modifier le fond de la section Encuéntranos"
+          onEdit={onEdit}
+          className="block"
+          buttonClassName="right-4 top-4"
+        >
+          <section className="section section-surface" style={{ ...findUsBackgroundStyle, ...findUsTextStyle }}>
+            <div className="find-us-grid" style={findUsTextStyle}>
+              <div className="find-us-panel" style={findUsTextStyle}>
+                <EditableElement
+                  id="findUs.title"
+                  label="Modifier le titre Encuéntranos"
+                  onEdit={onEdit}
+                  className="block"
+                  buttonClassName="right-0 -top-3"
+                >
+                  {renderRichTextElement(
+                    'findUs.title',
+                    'h2',
+                    {
+                      className: 'section-title',
+                      style: getElementTextStyle('findUs.title'),
+                    },
+                    content.findUs.title,
+                  )}
+                </EditableElement>
+                <div className="find-us-details">
+                  <div className="find-us-detail" style={findUsTextStyle}>
+                    <MapPin className="find-us-detail__icon" aria-hidden="true" />
+                    <div>
+                      <EditableElement
+                        id="findUs.addressLabel"
+                        label="Modifier le libellé de l'adresse"
+                        onEdit={onEdit}
+                        className="block"
+                        buttonClassName="right-0 -top-3"
+                      >
+                        {renderRichTextElement(
+                          'findUs.addressLabel',
+                          'h3',
+                          {
+                            className: 'find-us-detail__title',
+                            style: getElementTextStyle('findUs.addressLabel'),
+                          },
+                          content.findUs.addressLabel,
+                        )}
+                      </EditableElement>
+                      <EditableElement
+                        id="findUs.address"
+                        label="Modifier l'adresse"
+                        onEdit={onEdit}
+                        className="mt-1 block"
+                        buttonClassName="right-0 -top-3"
+                      >
+                        {renderRichTextElement(
+                          'findUs.address',
+                          'p',
+                          {
+                            className: 'find-us-detail__text',
+                            style: getElementBodyTextStyle('findUs.address'),
+                          },
+                          content.findUs.address,
+                        )}
+                      </EditableElement>
+                    </div>
+                  </div>
+                  <div className="find-us-detail" style={findUsTextStyle}>
+                    <MapPin className="find-us-detail__icon" aria-hidden="true" />
+                    <div>
+                      <EditableElement
+                        id="findUs.cityLabel"
+                        label="Modifier le libellé de la ville"
+                        onEdit={onEdit}
+                        className="block"
+                        buttonClassName="right-0 -top-3"
+                      >
+                        {renderRichTextElement(
+                          'findUs.cityLabel',
+                          'h3',
+                          {
+                            className: 'find-us-detail__title',
+                            style: getElementTextStyle('findUs.cityLabel'),
+                          },
+                          content.findUs.cityLabel,
+                        )}
+                      </EditableElement>
+                      <EditableElement
+                        id="findUs.city"
+                        label="Modifier la ville"
+                        onEdit={onEdit}
+                        className="mt-1 block"
+                        buttonClassName="right-0 -top-3"
+                      >
+                        {renderRichTextElement(
+                          'findUs.city',
+                          'p',
+                          {
+                            className: 'find-us-detail__text',
+                            style: getElementBodyTextStyle('findUs.city'),
+                          },
+                          content.findUs.city,
+                        )}
+                      </EditableElement>
+                    </div>
+                  </div>
+                  <div className="find-us-detail" style={findUsTextStyle}>
+                    <Clock className="find-us-detail__icon" aria-hidden="true" />
+                    <div>
+                      <EditableElement
+                        id="findUs.hoursLabel"
+                        label="Modifier le libellé des horaires"
+                        onEdit={onEdit}
+                        className="block"
+                        buttonClassName="right-0 -top-3"
+                      >
+                        {renderRichTextElement(
+                          'findUs.hoursLabel',
+                          'h3',
+                          {
+                            className: 'find-us-detail__title',
+                            style: getElementTextStyle('findUs.hoursLabel'),
+                          },
+                          content.findUs.hoursLabel,
+                        )}
+                      </EditableElement>
+                      <EditableElement
+                        id="findUs.hours"
+                        label="Modifier les horaires"
+                        onEdit={onEdit}
+                        className="mt-1 block"
+                        buttonClassName="right-0 -top-3"
+                      >
+                        {renderRichTextElement(
+                          'findUs.hours',
+                          'p',
+                          {
+                            className: 'find-us-detail__text',
+                            style: getElementBodyTextStyle('findUs.hours'),
+                          },
+                          content.findUs.hours,
+                        )}
+                      </EditableElement>
+                    </div>
+                  </div>
+                </div>
+              </div>
+              <div className="find-us-map" style={findUsTextStyle}>
+                {encodedFindUsQuery ? (
+                  <div className="find-us-map__frame">
+                    <iframe
+                      title={`Carte Google Maps pour ${findUsMapQuery}`}
+                      src={findUsMapEmbedUrl}
+                      loading="lazy"
+                      allowFullScreen
+                      referrerPolicy="no-referrer-when-downgrade"
+                    />
+                    <a
+                      className="find-us-map__link"
+                      href={findUsMapUrl}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                    >
+                      <EditableElement
+                        id="findUs.mapLabel"
+                        label="Modifier le libellé du lien Google Maps"
+                        onEdit={onEdit}
+                        className="inline-flex"
+                        buttonClassName="-right-3 -top-3"
+                        as="span"
+                      >
+                        {renderRichTextElement(
+                          'findUs.mapLabel',
+                          'span',
+                          {
+                            className: 'find-us-map__label',
+                            style: getElementBodyTextStyle('findUs.mapLabel'),
+                          },
+                          content.findUs.mapLabel,
+                        )}
+                      </EditableElement>
+                    </a>
+                  </div>
+                ) : (
+                  <div className="find-us-map__placeholder">
+                    <EditableElement
+                      id="findUs.mapLabel"
+                      label="Modifier le libellé du lien Google Maps"
+                      onEdit={onEdit}
+                      className="inline-flex"
+                      buttonClassName="-right-3 -top-3"
+                      as="span"
+                    >
+                      {renderRichTextElement(
+                        'findUs.mapLabel',
+                        'span',
+                        {
+                          className: 'find-us-map__label',
+                          style: getElementBodyTextStyle('findUs.mapLabel'),
+                        },
+                        content.findUs.mapLabel,
+                      )}
+                    </EditableElement>
+                  </div>
+                )}
               </div>
             </div>
           </section>

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import Modal from '../components/Modal';
 import { api } from '../services/api';
 import { EditableElementKey, Product, Order } from '../types';
-import { Mail, MapPin, Phone, Menu, X } from 'lucide-react';
+import { Clock, Mail, MapPin, Phone, Menu, X } from 'lucide-react';
 import CustomerOrderTracker from '../components/CustomerOrderTracker';
 import { clearActiveCustomerOrder, getActiveCustomerOrder } from '../services/customerOrderStorage';
 import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
@@ -147,7 +147,7 @@ const Login: React.FC = () => {
   const { login } = useAuth();
   const navigate = useNavigate();
   const { content: siteContent } = useSiteContent();
-  const { navigation, hero, about, menu: menuContent, contact, footer } = siteContent;
+  const { navigation, hero, about, menu: menuContent, contact, findUs, footer } = siteContent;
   useCustomFonts(siteContent.assets.library);
   const brandLogo = navigation.brandLogo ?? DEFAULT_BRAND_LOGO;
   const staffLogo = navigation.staffLogo ?? DEFAULT_STAFF_LOGO;
@@ -166,6 +166,9 @@ const Login: React.FC = () => {
   const contactBackgroundStyle = createBackgroundStyle(contact.style);
   const contactTextStyle = createTextStyle(contact.style);
   const contactBodyTextStyle = createBodyTextStyle(contact.style);
+  const findUsBackgroundStyle = createBackgroundStyle(findUs.style);
+  const findUsTextStyle = createTextStyle(findUs.style);
+  const findUsBodyTextStyle = createBodyTextStyle(findUs.style);
   const footerBackgroundStyle = createBackgroundStyle(footer.style);
   const footerTextStyle = createBodyTextStyle(footer.style);
 
@@ -198,6 +201,14 @@ const Login: React.FC = () => {
   const [menuLoading, setMenuLoading] = useState(true);
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [activeOrder, setActiveOrder] = useState(() => getActiveCustomerOrder());
+  const findUsMapQuery = [findUs.address, findUs.city].filter(Boolean).join(', ').trim();
+  const encodedFindUsQuery = findUsMapQuery.length > 0 ? encodeURIComponent(findUsMapQuery) : '';
+  const findUsMapUrl = encodedFindUsQuery
+    ? `https://www.google.com/maps?q=${encodedFindUsQuery}`
+    : 'https://www.google.com/maps';
+  const findUsMapEmbedUrl = encodedFindUsQuery
+    ? `https://www.google.com/maps?q=${encodedFindUsQuery}&output=embed`
+    : 'about:blank';
   const activeOrderId = activeOrder?.orderId ?? null;
   const bestSellersToDisplay = bestSellers.slice(0, 6);
   const bestSellerCount = bestSellersToDisplay.length;
@@ -706,6 +717,138 @@ const Login: React.FC = () => {
                   contact.email,
                 )}
               </div>
+            </div>
+          </div>
+        </section>
+
+        <section
+          id="find-us"
+          className="section section-surface"
+          style={{ ...findUsBackgroundStyle, ...findUsTextStyle }}
+        >
+          <div className="section-inner section-inner--wide find-us-grid" style={findUsTextStyle}>
+            <div className="find-us-panel" style={findUsTextStyle}>
+              {renderRichTextElement(
+                'findUs.title',
+                'h2',
+                {
+                  className: 'section-title',
+                  style: findUsTextStyle,
+                },
+                findUs.title,
+              )}
+              <div className="find-us-details">
+                <div className="find-us-detail" style={findUsTextStyle}>
+                  <MapPin className="find-us-detail__icon" aria-hidden="true" />
+                  <div>
+                    {renderRichTextElement(
+                      'findUs.addressLabel',
+                      'h3',
+                      {
+                        className: 'find-us-detail__title',
+                        style: findUsTextStyle,
+                      },
+                      findUs.addressLabel,
+                    )}
+                    {renderRichTextElement(
+                      'findUs.address',
+                      'p',
+                      {
+                        className: 'find-us-detail__text',
+                        style: findUsBodyTextStyle,
+                      },
+                      findUs.address,
+                    )}
+                  </div>
+                </div>
+                <div className="find-us-detail" style={findUsTextStyle}>
+                  <MapPin className="find-us-detail__icon" aria-hidden="true" />
+                  <div>
+                    {renderRichTextElement(
+                      'findUs.cityLabel',
+                      'h3',
+                      {
+                        className: 'find-us-detail__title',
+                        style: findUsTextStyle,
+                      },
+                      findUs.cityLabel,
+                    )}
+                    {renderRichTextElement(
+                      'findUs.city',
+                      'p',
+                      {
+                        className: 'find-us-detail__text',
+                        style: findUsBodyTextStyle,
+                      },
+                      findUs.city,
+                    )}
+                  </div>
+                </div>
+                <div className="find-us-detail" style={findUsTextStyle}>
+                  <Clock className="find-us-detail__icon" aria-hidden="true" />
+                  <div>
+                    {renderRichTextElement(
+                      'findUs.hoursLabel',
+                      'h3',
+                      {
+                        className: 'find-us-detail__title',
+                        style: findUsTextStyle,
+                      },
+                      findUs.hoursLabel,
+                    )}
+                    {renderRichTextElement(
+                      'findUs.hours',
+                      'p',
+                      {
+                        className: 'find-us-detail__text',
+                        style: findUsBodyTextStyle,
+                      },
+                      findUs.hours,
+                    )}
+                  </div>
+                </div>
+              </div>
+            </div>
+            <div className="find-us-map" style={findUsTextStyle}>
+              {encodedFindUsQuery ? (
+                <div className="find-us-map__frame">
+                  <iframe
+                    title={`Carte Google Maps pour ${findUsMapQuery}`}
+                    src={findUsMapEmbedUrl}
+                    loading="lazy"
+                    allowFullScreen
+                    referrerPolicy="no-referrer-when-downgrade"
+                  />
+                  <a
+                    className="find-us-map__link"
+                    href={findUsMapUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                  >
+                    {renderRichTextElement(
+                      'findUs.mapLabel',
+                      'span',
+                      {
+                        className: 'find-us-map__label',
+                        style: findUsBodyTextStyle,
+                      },
+                      findUs.mapLabel,
+                    )}
+                  </a>
+                </div>
+              ) : (
+                <div className="find-us-map__placeholder">
+                  {renderRichTextElement(
+                    'findUs.mapLabel',
+                    'span',
+                    {
+                      className: 'find-us-map__label',
+                      style: findUsBodyTextStyle,
+                    },
+                    findUs.mapLabel,
+                  )}
+                </div>
+              )}
             </div>
           </div>
         </section>

--- a/pages/SiteCustomization.tsx
+++ b/pages/SiteCustomization.tsx
@@ -134,13 +134,30 @@ const CONTACT_ADDRESS_SUGGESTIONS = [
 const CONTACT_PHONE_SUGGESTIONS = ['+57 320 456 98 12', '+57 311 234 56 78', '+57 315 987 65 43'] as const;
 const CONTACT_EMAIL_SUGGESTIONS = ['hola@ouiouipos.co', 'contact@maison-gourmet.co', 'bonjour@cantinalatina.co'] as const;
 
+const FIND_US_TITLE_SUGGESTIONS = ['Encuéntranos', 'Visítanos hoy', 'Tu próxima parada foodie'] as const;
+const FIND_US_ADDRESS_LABEL_SUGGESTIONS = ['Dirección', 'Ubicación', 'Nos encuentras en'] as const;
+const FIND_US_ADDRESS_SUGGESTIONS = ['Cra 53 #75 - 98', 'Calle 84 #51B - 145', 'Av. Olaya Herrera #70 - 21'] as const;
+const FIND_US_CITY_LABEL_SUGGESTIONS = ['Ciudad', 'Estamos en', 'Localización'] as const;
+const FIND_US_CITY_SUGGESTIONS = [
+  'Barranquilla, Colombie',
+  'Medellín, Colombie',
+  'Cartagena, Colombie',
+] as const;
+const FIND_US_HOURS_LABEL_SUGGESTIONS = ['Horarios', 'Horario de atención', 'Abrimos'] as const;
+const FIND_US_HOURS_SUGGESTIONS = [
+  'Lunes a domingo · 11h00 - 23h00',
+  'Martes a domingo · 12h00 - 22h30',
+  'Jueves a sábado · 18h00 - 02h00',
+] as const;
+const FIND_US_MAP_LABEL_SUGGESTIONS = ['Ver en Google Maps', 'Abrir mapa', 'Cómo llegar'] as const;
+
 const FOOTER_TEXT_SUGGESTIONS = [
   '© 2024 Taqueria Sol — Toute la gourmandise du soleil en un clic.',
   'Avec amour depuis Bogotá. Merci de soutenir les artisans locaux.',
   'Cuisine responsable, service souriant. À très vite !',
 ] as const;
 
-const ZONE_ORDER: readonly EditableZoneKey[] = ['navigation', 'hero', 'about', 'menu', 'contact', 'footer'];
+const ZONE_ORDER: readonly EditableZoneKey[] = ['navigation', 'hero', 'about', 'menu', 'contact', 'findUs', 'footer'];
 
 const ZONE_STEPS: ReadonlyArray<{
   key: EditableZoneKey;
@@ -179,6 +196,13 @@ const ZONE_STEPS: ReadonlyArray<{
     helper: 'Adresse, téléphone et email permettent à vos clients de vous joindre facilement — pensez à vérifier leur exactitude.',
   },
   {
+    key: 'findUs',
+    label: 'Encuéntranos',
+    description: 'Mettez en avant votre localisation et facilitez la venue sur place.',
+    helper:
+      'Adresse précise, ville et horaires rassurent vos visiteurs. Ajoutez un lien Google Maps pour guider facilement le déplacement.',
+  },
+  {
     key: 'footer',
     label: 'Pied de page',
     description: 'Terminez avec un message de marque et vos mentions utiles.',
@@ -192,6 +216,7 @@ const STYLE_BACKGROUND_FIELD_KEYS: Record<EditableZoneKey, ImageFieldKey> = {
   about: 'about.style.background',
   menu: 'menu.style.background',
   contact: 'contact.style.background',
+  findUs: 'findUs.style.background',
   footer: 'footer.style.background',
 };
 
@@ -207,6 +232,7 @@ const IMAGE_FIELD_LABELS: Record<ImageFieldKey, string> = {
   'about.style.background': 'Fond personnalisé (À propos)',
   'menu.style.background': 'Fond personnalisé (menu)',
   'contact.style.background': 'Fond personnalisé (contact)',
+  'findUs.style.background': 'Fond personnalisé (Encuéntranos)',
   'footer.style.background': 'Fond personnalisé (pied de page)',
 };
 
@@ -234,6 +260,14 @@ const ELEMENT_STYLE_LABELS: Partial<Record<EditableElementKey, string>> = {
   'contact.phone': 'Téléphone',
   'contact.emailLabel': "Libellé de l'email",
   'contact.email': 'Email',
+  'findUs.title': 'Titre Encuéntranos',
+  'findUs.addressLabel': "Libellé de l'adresse (Encuéntranos)",
+  'findUs.address': 'Adresse (Encuéntranos)',
+  'findUs.cityLabel': 'Libellé de la ville',
+  'findUs.city': 'Ville',
+  'findUs.hoursLabel': 'Libellé des horaires',
+  'findUs.hours': 'Horaires',
+  'findUs.mapLabel': 'Libellé du lien carte',
   'footer.text': 'Texte du pied de page',
 };
 
@@ -249,6 +283,7 @@ const INITIAL_IMAGE_ERRORS: Record<ImageFieldKey, string | null> = {
   'about.style.background': null,
   'menu.style.background': null,
   'contact.style.background': null,
+  'findUs.style.background': null,
   'footer.style.background': null,
 };
 
@@ -284,6 +319,15 @@ const EDITABLE_ELEMENT_INPUT_IDS: Partial<Record<EditableElementKey, string>> = 
   'contact.email': 'contact-email',
   'contact.image': 'contact-image',
   'contact.style.background': 'contact-background-type',
+  'findUs.title': 'find-us-title',
+  'findUs.addressLabel': 'find-us-address-label',
+  'findUs.address': 'find-us-address',
+  'findUs.cityLabel': 'find-us-city-label',
+  'findUs.city': 'find-us-city',
+  'findUs.hoursLabel': 'find-us-hours-label',
+  'findUs.hours': 'find-us-hours',
+  'findUs.mapLabel': 'find-us-map-label',
+  'findUs.style.background': 'find-us-background-type',
   'footer.text': 'footer-text',
   'footer.style.background': 'footer-background-type',
 };
@@ -308,12 +352,14 @@ type ImageFieldKey =
   | 'about.style.background'
   | 'menu.style.background'
   | 'contact.style.background'
+  | 'findUs.style.background'
   | 'footer.style.background';
 
 type NavigationFieldKey = keyof SiteContent['navigation']['links'];
 type HeroFieldKey = Exclude<keyof SiteContent['hero'], 'backgroundImage' | 'style'>;
 type MenuFieldKey = Exclude<keyof SiteContent['menu'], 'image' | 'style'>;
 type ContactFieldKey = Exclude<keyof SiteContent['contact'], 'image' | 'style'>;
+type FindUsFieldKey = Exclude<keyof SiteContent['findUs'], 'style'>;
 
 type ElementStyleProperty = keyof ElementStyle;
 
@@ -418,6 +464,17 @@ const createZoneChecklist = (draft: SiteContent): ZoneChecklistRecord => ({
     { label: 'Adresse complète indiquée', done: draft.contact.address.trim().length > 0 },
     { label: 'Téléphone ou email actifs', done: draft.contact.phone.trim().length > 0 && draft.contact.email.trim().length > 0 },
   ],
+  findUs: [
+    { label: 'Titre Encuéntranos défini', done: draft.findUs.title.trim().length > 0 },
+    {
+      label: 'Adresse et ville renseignées',
+      done: draft.findUs.address.trim().length > 0 && draft.findUs.city.trim().length > 0,
+    },
+    {
+      label: 'Horaires et lien carte prêts',
+      done: draft.findUs.hours.trim().length > 0 && draft.findUs.mapLabel.trim().length > 0,
+    },
+  ],
   footer: [
     { label: 'Message de pied de page personnalisé', done: draft.footer.text.trim().length > 0 },
   ],
@@ -472,6 +529,7 @@ type EditorContext = {
     value: string,
     richText?: RichTextValue | null,
   ) => void;
+  setFindUsFieldValue: (key: FindUsFieldKey, value: string, richText?: RichTextValue | null) => void;
   setFooterTextValue: (value: string, richText?: RichTextValue | null) => void;
   bestSellerProducts: Product[];
   bestSellerLoading: boolean;
@@ -759,6 +817,18 @@ const SiteCustomization: React.FC = () => {
     }));
   };
 
+  const setFindUsFieldValue = (key: FindUsFieldKey, value: string, richText?: RichTextValue | null) => {
+    const elementKey = `findUs.${key}` as EditableElementKey;
+    mutateDraft(prev => ({
+      ...prev,
+      findUs: {
+        ...prev.findUs,
+        [key]: value,
+      },
+      elementRichText: resolveNextElementRichText(prev, elementKey, richText),
+    }));
+  };
+
   const setFooterTextValue = (value: string, richText?: RichTextValue | null) => {
     mutateDraft(prev => ({
       ...prev,
@@ -890,6 +960,21 @@ const SiteCustomization: React.FC = () => {
                 ...prev.contact.style,
                 background: {
                   ...prev.contact.style.background,
+                  type: 'image',
+                  image: value,
+                },
+              },
+            },
+          };
+        case 'findUs.style.background':
+          return {
+            ...prev,
+            findUs: {
+              ...prev.findUs,
+              style: {
+                ...prev.findUs.style,
+                background: {
+                  ...prev.findUs.style.background,
                   type: 'image',
                   image: value,
                 },
@@ -1205,6 +1290,7 @@ const SiteCustomization: React.FC = () => {
     setAboutDescriptionValue,
     setMenuFieldValue,
     setContactFieldValue,
+    setFindUsFieldValue,
     setFooterTextValue,
   };
 
@@ -2740,6 +2826,131 @@ const getElementEditorConfig = (
       return {
         title: IMAGE_FIELD_LABELS['contact.style.background'],
         content: renderBackgroundEditor('contact'),
+      };
+    case 'findUs.title':
+      return {
+        title: 'Titre',
+        content: (
+          <FieldCard label="Titre" htmlFor="find-us-title">
+            {renderRichTextField('findUs.title', draft.findUs.title, (text, rich) =>
+              context.setFindUsFieldValue('title', text, rich),
+            )}
+            <SuggestionChips
+              options={FIND_US_TITLE_SUGGESTIONS}
+              onSelect={value => context.setFindUsFieldValue('title', value, null)}
+            />
+          </FieldCard>
+        ),
+      };
+    case 'findUs.addressLabel':
+      return {
+        title: 'Label adresse',
+        content: (
+          <FieldCard label="Label adresse" htmlFor="find-us-address-label">
+            {renderRichTextField('findUs.addressLabel', draft.findUs.addressLabel, (text, rich) =>
+              context.setFindUsFieldValue('addressLabel', text, rich),
+            )}
+            <SuggestionChips
+              options={FIND_US_ADDRESS_LABEL_SUGGESTIONS}
+              onSelect={value => context.setFindUsFieldValue('addressLabel', value, null)}
+            />
+          </FieldCard>
+        ),
+      };
+    case 'findUs.address':
+      return {
+        title: 'Adresse',
+        content: (
+          <FieldCard label="Adresse" htmlFor="find-us-address">
+            {renderRichTextField('findUs.address', draft.findUs.address, (text, rich) =>
+              context.setFindUsFieldValue('address', text, rich),
+            )}
+            <SuggestionChips
+              options={FIND_US_ADDRESS_SUGGESTIONS}
+              onSelect={value => context.setFindUsFieldValue('address', value, null)}
+            />
+          </FieldCard>
+        ),
+      };
+    case 'findUs.cityLabel':
+      return {
+        title: 'Label ville',
+        content: (
+          <FieldCard label="Label ville" htmlFor="find-us-city-label">
+            {renderRichTextField('findUs.cityLabel', draft.findUs.cityLabel, (text, rich) =>
+              context.setFindUsFieldValue('cityLabel', text, rich),
+            )}
+            <SuggestionChips
+              options={FIND_US_CITY_LABEL_SUGGESTIONS}
+              onSelect={value => context.setFindUsFieldValue('cityLabel', value, null)}
+            />
+          </FieldCard>
+        ),
+      };
+    case 'findUs.city':
+      return {
+        title: 'Ville',
+        content: (
+          <FieldCard label="Ville" htmlFor="find-us-city">
+            {renderRichTextField('findUs.city', draft.findUs.city, (text, rich) =>
+              context.setFindUsFieldValue('city', text, rich),
+            )}
+            <SuggestionChips
+              options={FIND_US_CITY_SUGGESTIONS}
+              onSelect={value => context.setFindUsFieldValue('city', value, null)}
+            />
+          </FieldCard>
+        ),
+      };
+    case 'findUs.hoursLabel':
+      return {
+        title: 'Label horaires',
+        content: (
+          <FieldCard label="Label horaires" htmlFor="find-us-hours-label">
+            {renderRichTextField('findUs.hoursLabel', draft.findUs.hoursLabel, (text, rich) =>
+              context.setFindUsFieldValue('hoursLabel', text, rich),
+            )}
+            <SuggestionChips
+              options={FIND_US_HOURS_LABEL_SUGGESTIONS}
+              onSelect={value => context.setFindUsFieldValue('hoursLabel', value, null)}
+            />
+          </FieldCard>
+        ),
+      };
+    case 'findUs.hours':
+      return {
+        title: 'Horaires',
+        content: (
+          <FieldCard label="Horaires" htmlFor="find-us-hours">
+            {renderRichTextField('findUs.hours', draft.findUs.hours, (text, rich) =>
+              context.setFindUsFieldValue('hours', text, rich),
+            )}
+            <SuggestionChips
+              options={FIND_US_HOURS_SUGGESTIONS}
+              onSelect={value => context.setFindUsFieldValue('hours', value, null)}
+            />
+          </FieldCard>
+        ),
+      };
+    case 'findUs.mapLabel':
+      return {
+        title: 'Libellé du lien carte',
+        content: (
+          <FieldCard label="Libellé du lien carte" htmlFor="find-us-map-label">
+            {renderRichTextField('findUs.mapLabel', draft.findUs.mapLabel, (text, rich) =>
+              context.setFindUsFieldValue('mapLabel', text, rich),
+            )}
+            <SuggestionChips
+              options={FIND_US_MAP_LABEL_SUGGESTIONS}
+              onSelect={value => context.setFindUsFieldValue('mapLabel', value, null)}
+            />
+          </FieldCard>
+        ),
+      };
+    case 'findUs.style.background':
+      return {
+        title: IMAGE_FIELD_LABELS['findUs.style.background'],
+        content: renderBackgroundEditor('findUs'),
       };
     case 'footer.text':
       return {

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -446,6 +446,132 @@ body {
   margin: 0;
 }
 
+.find-us-grid {
+  display: grid;
+  gap: clamp(1.5rem, 4vw, 3rem);
+  align-items: stretch;
+}
+
+@media (min-width: 1024px) {
+  .find-us-grid {
+    grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+  }
+}
+
+.find-us-panel {
+  display: flex;
+  flex-direction: column;
+  gap: clamp(1.25rem, 3vw, 1.75rem);
+  padding: clamp(1.5rem, 4vw, 2.25rem);
+  border-radius: 1.5rem;
+  background: color-mix(in srgb, var(--color-surface) 96%, transparent);
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.08);
+  border: 1px solid color-mix(in srgb, var(--color-border) 70%, transparent);
+}
+
+.find-us-details {
+  display: grid;
+  gap: clamp(1rem, 3vw, 1.5rem);
+}
+
+.find-us-detail {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.85rem;
+  padding: 1rem 1.25rem;
+  border-radius: 1.25rem;
+  background: color-mix(in srgb, var(--color-surface) 94%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-border) 65%, transparent);
+  box-shadow: 0 16px 28px rgba(15, 23, 42, 0.08);
+}
+
+.find-us-detail__icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  flex-shrink: 0;
+  color: var(--color-accent);
+}
+
+.find-us-detail__title {
+  margin: 0;
+  font-size: var(--font-size-md);
+  font-weight: 600;
+  color: var(--color-heading);
+}
+
+.find-us-detail__text {
+  margin: 0.15rem 0 0;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-muted);
+}
+
+.find-us-map {
+  position: relative;
+  border-radius: 1.5rem;
+  overflow: hidden;
+  min-height: 280px;
+  box-shadow: 0 18px 32px rgba(15, 23, 42, 0.08);
+}
+
+.find-us-map__frame {
+  position: relative;
+  width: 100%;
+  height: 100%;
+}
+
+.find-us-map__frame iframe {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  border: 0;
+  border-radius: inherit;
+}
+
+.find-us-map__link {
+  position: absolute;
+  right: 1rem;
+  bottom: 1rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.65rem 1.1rem;
+  border-radius: 9999px;
+  background: rgba(15, 23, 42, 0.82);
+  color: #ffffff;
+  text-decoration: none;
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.25);
+  transition: background-color 0.2s ease, transform 0.2s ease;
+}
+
+.find-us-map__link:hover,
+.find-us-map__link:focus-visible {
+  background: rgba(15, 23, 42, 0.92);
+  transform: translateY(-1px);
+}
+
+.find-us-map__label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.find-us-map__placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 280px;
+  border-radius: 1.5rem;
+  border: 1px dashed color-mix(in srgb, var(--color-border) 70%, transparent);
+  background: color-mix(in srgb, var(--color-surface) 92%, transparent);
+  color: var(--color-text-muted);
+  font-size: var(--font-size-sm);
+  text-align: center;
+  padding: 1.5rem;
+}
+
 .site-footer {
   background: color-mix(in srgb, var(--color-heading) 94%, transparent);
   color: var(--color-surface);

--- a/types/index.ts
+++ b/types/index.ts
@@ -23,7 +23,7 @@ export interface SectionStyle {
   textColor: string;
 }
 
-export const EDITABLE_ZONE_KEYS = ['navigation', 'hero', 'about', 'menu', 'contact', 'footer'] as const;
+export const EDITABLE_ZONE_KEYS = ['navigation', 'hero', 'about', 'menu', 'contact', 'findUs', 'footer'] as const;
 
 export type EditableZoneKey = (typeof EDITABLE_ZONE_KEYS)[number];
 
@@ -59,6 +59,15 @@ export const EDITABLE_ELEMENT_KEYS = [
   'contact.email',
   'contact.image',
   'contact.style.background',
+  'findUs.title',
+  'findUs.addressLabel',
+  'findUs.address',
+  'findUs.cityLabel',
+  'findUs.city',
+  'findUs.hoursLabel',
+  'findUs.hours',
+  'findUs.mapLabel',
+  'findUs.style.background',
   'footer.text',
   'footer.style.background',
 ] as const;
@@ -151,6 +160,17 @@ export interface SiteContent {
     emailLabel: string;
     email: string;
     image: string | null;
+    style: SectionStyle;
+  };
+  findUs: {
+    title: string;
+    addressLabel: string;
+    address: string;
+    cityLabel: string;
+    city: string;
+    hoursLabel: string;
+    hours: string;
+    mapLabel: string;
     style: SectionStyle;
   };
   footer: {

--- a/utils/siteContent.ts
+++ b/utils/siteContent.ts
@@ -295,6 +295,17 @@ const DEFAULT_CONTACT_STYLE: SectionStyle = {
   textColor: '#111827',
 };
 
+export const DEFAULT_FIND_US_STYLE: SectionStyle = {
+  background: {
+    type: 'color',
+    color: '#f8fafc',
+    image: null,
+  },
+  fontFamily: 'Inter',
+  fontSize: '16px',
+  textColor: '#0f172a',
+};
+
 const DEFAULT_FOOTER_STYLE: SectionStyle = {
   background: {
     type: 'color',
@@ -399,6 +410,17 @@ export const DEFAULT_SITE_CONTENT: SiteContent = {
     image: null,
     style: DEFAULT_CONTACT_STYLE,
   },
+  findUs: {
+    title: 'Encuéntranos',
+    addressLabel: 'Dirección',
+    address: 'Cra 53 #75 - 98',
+    cityLabel: 'Ciudad',
+    city: 'Barranquilla, Colombie',
+    hoursLabel: 'Horarios',
+    hours: 'Lunes a domingo · 11h00 - 23h00',
+    mapLabel: 'Ver en Google Maps',
+    style: DEFAULT_FIND_US_STYLE,
+  },
   footer: {
     text: 'Tous droits réservés.',
     style: DEFAULT_FOOTER_STYLE,
@@ -457,6 +479,17 @@ export const resolveSiteContent = (content?: Partial<SiteContent> | null): SiteC
       image: resolveImage(content?.contact?.image, base.contact.image),
       style: resolveSectionStyle(content?.contact?.style, base.contact.style),
     },
+    findUs: {
+      title: resolveString(content?.findUs?.title, base.findUs.title),
+      addressLabel: resolveString(content?.findUs?.addressLabel, base.findUs.addressLabel),
+      address: resolveString(content?.findUs?.address, base.findUs.address),
+      cityLabel: resolveString(content?.findUs?.cityLabel, base.findUs.cityLabel),
+      city: resolveString(content?.findUs?.city, base.findUs.city),
+      hoursLabel: resolveString(content?.findUs?.hoursLabel, base.findUs.hoursLabel),
+      hours: resolveString(content?.findUs?.hours, base.findUs.hours),
+      mapLabel: resolveString(content?.findUs?.mapLabel, base.findUs.mapLabel),
+      style: resolveSectionStyle(content?.findUs?.style, base.findUs.style),
+    },
     footer: {
       text: resolveString(content?.footer?.text, base.footer.text),
       style: resolveSectionStyle(content?.footer?.style, base.footer.style),
@@ -513,6 +546,17 @@ export const sanitizeSiteContentInput = (content: SiteContent): SiteContent => (
     email: trimOrEmpty(content.contact.email),
     image: sanitizeImage(content.contact.image),
     style: sanitizeSectionStyle(content.contact.style, DEFAULT_CONTACT_STYLE),
+  },
+  findUs: {
+    title: trimOrEmpty(content.findUs.title),
+    addressLabel: trimOrEmpty(content.findUs.addressLabel),
+    address: trimOrEmpty(content.findUs.address),
+    cityLabel: trimOrEmpty(content.findUs.cityLabel),
+    city: trimOrEmpty(content.findUs.city),
+    hoursLabel: trimOrEmpty(content.findUs.hoursLabel),
+    hours: trimOrEmpty(content.findUs.hours),
+    mapLabel: trimOrEmpty(content.findUs.mapLabel),
+    style: sanitizeSectionStyle(content.findUs.style, DEFAULT_FIND_US_STYLE),
   },
   footer: {
     text: trimOrEmpty(content.footer.text),


### PR DESCRIPTION
## Summary
- add find-us zone to site content types, defaults, and sanitization to manage editable location details
- render and edit the Encuéntranos section with map preview across the site preview and login marketing page
- extend customization UI, suggestions, and global styles to support editing and styling the new section

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dcebf220d4832aa53f32b038ea265e