### PR TITLE
Align landing page layout with streamlined login and find-us details

### DIFF
--- a/components/SitePreviewCanvas.tsx
+++ b/components/SitePreviewCanvas.tsx
@@ -14,7 +14,6 @@ import {
 import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 
 const DEFAULT_BRAND_LOGO = '/logo-brand.svg';
-const DEFAULT_STAFF_LOGO = '/logo-staff.svg';
 
 export const resolveZoneFromElement = (element: EditableElementKey): EditableZoneKey => {
   if (element.startsWith('navigation.')) {
@@ -139,7 +138,7 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
   const navigationTextStyle = createTextStyle(content.navigation.style);
   const navigationBodyStyle = createBodyTextStyle(content.navigation.style);
   const brandLogo = content.navigation.brandLogo ?? DEFAULT_BRAND_LOGO;
-  const staffLogo = content.navigation.staffLogo ?? DEFAULT_STAFF_LOGO;
+  const staffTriggerLogo = content.navigation.brandLogo ?? DEFAULT_BRAND_LOGO;
   const heroBackgroundStyle = createHeroBackgroundStyle(content.hero.style, content.hero.backgroundImage);
   const heroTextStyle = createTextStyle(content.hero.style);
   const heroBodyTextStyle = createBodyTextStyle(content.hero.style);
@@ -211,7 +210,7 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
     return createElementBackgroundStyle(zoneStyleMap[zone], getElementStyle(key));
   };
 
-  const findUsMapQuery = [content.findUs.address, content.findUs.city].filter(Boolean).join(', ').trim();
+  const findUsMapQuery = content.findUs.address.trim();
   const encodedFindUsQuery = findUsMapQuery.length > 0 ? encodeURIComponent(findUsMapQuery) : '';
   const findUsMapUrl = encodedFindUsQuery
     ? `https://www.google.com/maps?q=${encodedFindUsQuery}`
@@ -313,24 +312,6 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                   )}
                 </EditableElement>
                 <EditableElement
-                  id="navigation.links.contact"
-                  label="Modifier le lien Contact"
-                  onEdit={onEdit}
-                  as="span"
-                  className="inline-flex"
-                  buttonClassName="-right-2 -top-2"
-                >
-                  {renderRichTextElement(
-                    'navigation.links.contact',
-                    'span',
-                    {
-                      className: 'login-nav__link',
-                      style: getElementBodyTextStyle('navigation.links.contact'),
-                    },
-                    content.navigation.links.contact,
-                  )}
-                </EditableElement>
-                <EditableElement
                   id="navigation.links.loginCta"
                   label="Modifier le bouton personnel"
                   onEdit={onEdit}
@@ -341,14 +322,10 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                   <button
                     type="button"
                     className="login-nav__staff-btn"
-                    style={{
-                      ...getElementBodyTextStyle('navigation.links.loginCta'),
-                      ...getElementBackgroundStyle('navigation.links.loginCta'),
-                    }}
                     aria-label={content.navigation.links.loginCta}
                     disabled
                   >
-                    <img src={staffLogo} alt="" className="login-nav__staff-logo" aria-hidden="true" />
+                    <img src={staffTriggerLogo} alt="" className="login-brand__logo" aria-hidden="true" />
                   </button>
                 </EditableElement>
               </nav>
@@ -920,84 +897,84 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                       </EditableElement>
                     </div>
                   </div>
-                  <div className="find-us-detail" style={findUsTextStyle}>
-                    <MapPin className="find-us-detail__icon" aria-hidden="true" />
-                    <div>
-                      <EditableElement
-                        id="findUs.cityLabel"
-                        label="Modifier le libellé de la ville"
-                        onEdit={onEdit}
-                        className="block"
-                        buttonClassName="right-0 -top-3"
-                      >
-                        {renderRichTextElement(
-                          'findUs.cityLabel',
-                          'h3',
-                          {
-                            className: 'find-us-detail__title',
-                            style: getElementTextStyle('findUs.cityLabel'),
-                          },
-                          content.findUs.cityLabel,
-                        )}
-                      </EditableElement>
-                      <EditableElement
-                        id="findUs.city"
-                        label="Modifier la ville"
-                        onEdit={onEdit}
-                        className="mt-1 block"
-                        buttonClassName="right-0 -top-3"
-                      >
-                        {renderRichTextElement(
-                          'findUs.city',
-                          'p',
-                          {
-                            className: 'find-us-detail__text',
-                            style: getElementBodyTextStyle('findUs.city'),
-                          },
-                          content.findUs.city,
-                        )}
-                      </EditableElement>
-                    </div>
+                <div className="find-us-detail" style={findUsTextStyle}>
+                  <Clock className="find-us-detail__icon" aria-hidden="true" />
+                  <div>
+                    <EditableElement
+                      id="findUs.hoursLabel"
+                      label="Modifier le libellé des horaires"
+                      onEdit={onEdit}
+                      className="block"
+                      buttonClassName="right-0 -top-3"
+                    >
+                      {renderRichTextElement(
+                        'findUs.hoursLabel',
+                        'h3',
+                        {
+                          className: 'find-us-detail__title',
+                          style: getElementTextStyle('findUs.hoursLabel'),
+                        },
+                        content.findUs.hoursLabel,
+                      )}
+                    </EditableElement>
+                    <EditableElement
+                      id="findUs.hours"
+                      label="Modifier les horaires"
+                      onEdit={onEdit}
+                      className="mt-1 block"
+                      buttonClassName="right-0 -top-3"
+                    >
+                      {renderRichTextElement(
+                        'findUs.hours',
+                        'p',
+                        {
+                          className: 'find-us-detail__text',
+                          style: getElementBodyTextStyle('findUs.hours'),
+                        },
+                        content.findUs.hours,
+                      )}
+                    </EditableElement>
                   </div>
-                  <div className="find-us-detail" style={findUsTextStyle}>
-                    <Clock className="find-us-detail__icon" aria-hidden="true" />
-                    <div>
-                      <EditableElement
-                        id="findUs.hoursLabel"
-                        label="Modifier le libellé des horaires"
-                        onEdit={onEdit}
-                        className="block"
-                        buttonClassName="right-0 -top-3"
-                      >
-                        {renderRichTextElement(
-                          'findUs.hoursLabel',
-                          'h3',
-                          {
-                            className: 'find-us-detail__title',
-                            style: getElementTextStyle('findUs.hoursLabel'),
-                          },
-                          content.findUs.hoursLabel,
-                        )}
-                      </EditableElement>
-                      <EditableElement
-                        id="findUs.hours"
-                        label="Modifier les horaires"
-                        onEdit={onEdit}
-                        className="mt-1 block"
-                        buttonClassName="right-0 -top-3"
-                      >
-                        {renderRichTextElement(
-                          'findUs.hours',
-                          'p',
-                          {
-                            className: 'find-us-detail__text',
-                            style: getElementBodyTextStyle('findUs.hours'),
-                          },
-                          content.findUs.hours,
-                        )}
-                      </EditableElement>
-                    </div>
+                </div>
+                <div className="find-us-detail" style={findUsTextStyle}>
+                  <Mail className="find-us-detail__icon" aria-hidden="true" />
+                  <div>
+                    <EditableElement
+                      id="findUs.cityLabel"
+                      label="Modifier le libellé de l'email"
+                      onEdit={onEdit}
+                      className="block"
+                      buttonClassName="right-0 -top-3"
+                    >
+                      {renderRichTextElement(
+                        'findUs.cityLabel',
+                        'h3',
+                        {
+                          className: 'find-us-detail__title',
+                          style: getElementTextStyle('findUs.cityLabel'),
+                        },
+                        content.findUs.cityLabel,
+                      )}
+                    </EditableElement>
+                    <EditableElement
+                      id="findUs.city"
+                      label="Modifier l'email"
+                      onEdit={onEdit}
+                      className="mt-1 block"
+                      buttonClassName="right-0 -top-3"
+                    >
+                      {renderRichTextElement(
+                        'findUs.city',
+                        'p',
+                        {
+                          className: 'find-us-detail__text',
+                          style: getElementBodyTextStyle('findUs.city'),
+                        },
+                        content.findUs.city,
+                      )}
+                    </EditableElement>
                   </div>
+                </div>
                 </div>
               </div>
               <div className="find-us-map" style={findUsTextStyle}>

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -4,7 +4,7 @@ import { useNavigate } from 'react-router-dom';
 import Modal from '../components/Modal';
 import { api } from '../services/api';
 import { EditableElementKey, Product, Order } from '../types';
-import { Clock, Mail, MapPin, Phone, Menu, X, ChevronLeft, ChevronRight, Star, Quote, ShieldCheck } from 'lucide-react';
+import { Clock, Mail, MapPin, Menu, X, ChevronLeft, ChevronRight, Star, Quote } from 'lucide-react';
 import CustomerOrderTracker from '../components/CustomerOrderTracker';
 import { clearActiveCustomerOrder, getActiveCustomerOrder } from '../services/customerOrderStorage';
 import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
@@ -18,7 +18,6 @@ import {
 } from '../utils/siteStyleHelpers';
 
 const DEFAULT_BRAND_LOGO = '/logo-brand.svg';
-const DEFAULT_STAFF_LOGO = '/logo-staff.svg';
 
 const INSTAGRAM_REVIEWS = [
   {
@@ -189,10 +188,10 @@ const Login: React.FC = () => {
   const { login } = useAuth();
   const navigate = useNavigate();
   const { content: siteContent } = useSiteContent();
-  const { navigation, hero, about, menu: menuContent, contact, findUs, footer } = siteContent;
+  const { navigation, hero, about, menu: menuContent, findUs, footer } = siteContent;
   useCustomFonts(siteContent.assets.library);
   const brandLogo = navigation.brandLogo ?? DEFAULT_BRAND_LOGO;
-  const staffLogo = navigation.staffLogo ?? DEFAULT_STAFF_LOGO;
+  const staffTriggerLogo = navigation.brandLogo ?? DEFAULT_BRAND_LOGO;
   const navigationBackgroundStyle = createBackgroundStyle(navigation.style);
   const navigationTextStyle = createTextStyle(navigation.style);
   const navigationBodyStyle = createBodyTextStyle(navigation.style);
@@ -205,9 +204,6 @@ const Login: React.FC = () => {
   const menuBackgroundStyle = createBackgroundStyle(menuContent.style);
   const menuTextStyle = createTextStyle(menuContent.style);
   const menuBodyTextStyle = createBodyTextStyle(menuContent.style);
-  const contactBackgroundStyle = createBackgroundStyle(contact.style);
-  const contactTextStyle = createTextStyle(contact.style);
-  const contactBodyTextStyle = createBodyTextStyle(contact.style);
   const findUsBackgroundStyle = createBackgroundStyle(findUs.style);
   const findUsTextStyle = createTextStyle(findUs.style);
   const findUsBodyTextStyle = createBodyTextStyle(findUs.style);
@@ -244,7 +240,7 @@ const Login: React.FC = () => {
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [activeOrder, setActiveOrder] = useState(() => getActiveCustomerOrder());
   const [activeReviewIndex, setActiveReviewIndex] = useState(0);
-  const findUsMapQuery = [findUs.address, findUs.city].filter(Boolean).join(', ').trim();
+  const findUsMapQuery = findUs.address.trim();
   const encodedFindUsQuery = findUsMapQuery.length > 0 ? encodeURIComponent(findUsMapQuery) : '';
   const findUsMapUrl = encodedFindUsQuery
     ? `https://www.google.com/maps?q=${encodedFindUsQuery}`
@@ -260,9 +256,6 @@ const Login: React.FC = () => {
   const instagramReviews = INSTAGRAM_REVIEWS;
   const reviewCount = instagramReviews.length;
   const isSingleReview = reviewCount <= 1;
-  const hasSupportContact = Boolean(contact.phone || contact.email);
-  const contactPhoneHref = contact.phone ? `tel:${contact.phone.replace(/[^+\d]/g, '')}` : null;
-  const contactEmailHref = contact.email ? `mailto:${contact.email}` : null;
 
   const handleNextReview = useCallback(() => {
     setActiveReviewIndex(index => (index + 1) % reviewCount);
@@ -407,24 +400,13 @@ const Login: React.FC = () => {
               },
               navigation.links.menu,
             )}
-            {renderRichTextElement(
-              'navigation.links.contact',
-              'a',
-              {
-                href: '#contact',
-                className: 'login-nav__link',
-                style: navigationBodyStyle,
-              },
-              navigation.links.contact,
-            )}
             <button
               type="button"
               onClick={() => setIsModalOpen(true)}
               className="login-nav__staff-btn"
               aria-label={navigation.links.loginCta}
-              style={{ fontFamily: navigation.style.fontFamily }}
             >
-              <img src={staffLogo} alt="" className="login-nav__staff-logo" aria-hidden="true" />
+              <img src={staffTriggerLogo} alt="" className="login-brand__logo" aria-hidden="true" />
             </button>
           </nav>
           <button
@@ -477,17 +459,6 @@ const Login: React.FC = () => {
               },
               navigation.links.menu,
             )}
-            {renderRichTextElement(
-              'navigation.links.contact',
-              'a',
-              {
-                href: '#contact',
-                onClick: () => setMobileMenuOpen(false),
-                className: 'login-menu-overlay__link',
-                style: navigationBodyStyle,
-              },
-              navigation.links.contact,
-            )}
             <button
               type="button"
               onClick={() => {
@@ -496,9 +467,8 @@ const Login: React.FC = () => {
               }}
               className="login-nav__staff-btn login-menu-overlay__staff-btn"
               aria-label={navigation.links.loginCta}
-              style={{ fontFamily: navigation.style.fontFamily }}
             >
-              <img src={staffLogo} alt="" className="login-nav__staff-logo" aria-hidden="true" />
+              <img src={staffTriggerLogo} alt="" className="login-brand__logo" aria-hidden="true" />
             </button>
           </nav>
         </div>
@@ -587,110 +557,6 @@ const Login: React.FC = () => {
                     </div>
                   </div>
                 )}
-              </div>
-            )}
-          </div>
-        </section>
-
-        <section
-          aria-labelledby="instagram-reviews-title"
-          className="section section-reviews"
-        >
-          <div className="section-inner section-inner--wide">
-            <div className="reviews-heading">
-              <h2 id="instagram-reviews-title" className="section-title">
-                Ils nous adorent sur Instagram
-              </h2>
-              <p className="reviews-subtitle">
-                Des foodies de toute la Colombie partagent leur coup de cœur pour notre cuisine : ambiance solaire, service
-                attentionné et assiettes qui brillent autant que leurs stories.
-              </p>
-            </div>
-            <div className="reviews-carousel">
-              <div
-                className="reviews-track"
-                style={{ transform: `translateX(-${activeReviewIndex * 100}%)` }}
-              >
-                {instagramReviews.map((review, index) => (
-                  <article
-                    key={review.id}
-                    className="review-card"
-                    aria-hidden={index !== activeReviewIndex}
-                  >
-                    <div className="review-card__content">
-                      <header className="review-card__header">
-                        <span className="review-card__avatar" aria-hidden="true">
-                          <img src={review.avatarUrl} alt="" />
-                        </span>
-                        <div className="review-card__meta">
-                          <p className="review-card__name">{review.name}</p>
-                          <p className="review-card__handle">{review.handle} • {review.timeAgo}</p>
-                        </div>
-                        <span className="review-card__badge">Instagram</span>
-                      </header>
-                      <div className="review-card__stars" aria-label="Note 5 sur 5">
-                        {Array.from({ length: 5 }).map((_, starIndex) => (
-                          <Star key={starIndex} aria-hidden="true" />
-                        ))}
-                      </div>
-                      <blockquote className="review-card__quote">
-                        <Quote aria-hidden="true" className="review-card__quote-icon" />
-                        <p>{review.message}</p>
-                      </blockquote>
-                      <div className="review-card__footer">
-                        <div className="review-card__highlight">
-                          <span className="review-card__story-ring" aria-hidden="true">
-                            <img src={review.postImageUrl} alt="" />
-                          </span>
-                          <div>
-                            <p className="review-card__highlight-title">{review.highlight}</p>
-                            <p className="review-card__highlight-caption">5 étoiles assurées ✨</p>
-                          </div>
-                        </div>
-                        <p className="review-card__location">{review.location}</p>
-                      </div>
-                    </div>
-                    <div className="review-card__media">
-                      <span className="review-card__media-frame">
-                        <img src={review.postImageUrl} alt={review.postImageAlt} />
-                      </span>
-                    </div>
-                  </article>
-                ))}
-              </div>
-              {!isSingleReview && (
-                <div className="reviews-controls">
-                  <button
-                    type="button"
-                    className="reviews-control"
-                    onClick={handlePreviousReview}
-                    aria-label="Voir l'avis précédent"
-                  >
-                    <ChevronLeft aria-hidden="true" />
-                  </button>
-                  <button
-                    type="button"
-                    className="reviews-control"
-                    onClick={handleNextReview}
-                    aria-label="Voir l'avis suivant"
-                  >
-                    <ChevronRight aria-hidden="true" />
-                  </button>
-                </div>
-              )}
-            </div>
-            {reviewCount > 1 && (
-              <div className="reviews-pagination" role="tablist" aria-label="Avis Instagram">
-                {instagramReviews.map((review, index) => (
-                  <button
-                    key={review.id}
-                    type="button"
-                    className={`reviews-dot${index === activeReviewIndex ? ' reviews-dot--active' : ''}`}
-                    onClick={() => setActiveReviewIndex(index)}
-                    aria-label={`Afficher l'avis de ${review.name}`}
-                    aria-current={index === activeReviewIndex}
-                  />
-                ))}
               </div>
             )}
           </div>
@@ -802,93 +668,97 @@ const Login: React.FC = () => {
           </div>
         </section>
 
-        <section
-          id="contact"
-          className="section section-surface"
-          style={{ ...contactBackgroundStyle, ...contactTextStyle }}
-        >
-          <div className="section-inner section-inner--wide section-inner--center" style={contactTextStyle}>
-            {renderRichTextElement(
-              'contact.title',
-              'h2',
-              {
-                className: 'section-title',
-                style: contactTextStyle,
-              },
-              contact.title,
-            )}
-            {contact.image && (
-              <img
-                src={contact.image}
-                alt={contact.title}
-                className="mb-8 h-64 w-full rounded-xl object-cover shadow-lg"
-              />
-            )}
-            <div className="contact-grid">
-              <div className="contact-card" style={contactTextStyle}>
-                <MapPin className="contact-card__icon" />
-                {renderRichTextElement(
-                  'contact.addressLabel',
-                  'h3',
-                  {
-                    className: 'contact-card__title',
-                    style: contactTextStyle,
-                  },
-                  contact.addressLabel,
-                )}
-                {renderRichTextElement(
-                  'contact.address',
-                  'p',
-                  {
-                    className: 'contact-card__text',
-                    style: contactBodyTextStyle,
-                  },
-                  contact.address,
-                )}
-              </div>
-              <div className="contact-card" style={contactTextStyle}>
-                <Phone className="contact-card__icon" />
-                {renderRichTextElement(
-                  'contact.phoneLabel',
-                  'h3',
-                  {
-                    className: 'contact-card__title',
-                    style: contactTextStyle,
-                  },
-                  contact.phoneLabel,
-                )}
-                {renderRichTextElement(
-                  'contact.phone',
-                  'p',
-                  {
-                    className: 'contact-card__text',
-                    style: contactBodyTextStyle,
-                  },
-                  contact.phone,
-                )}
-              </div>
-              <div className="contact-card" style={contactTextStyle}>
-                <Mail className="contact-card__icon" />
-                {renderRichTextElement(
-                  'contact.emailLabel',
-                  'h3',
-                  {
-                    className: 'contact-card__title',
-                    style: contactTextStyle,
-                  },
-                  contact.emailLabel,
-                )}
-                {renderRichTextElement(
-                  'contact.email',
-                  'p',
-                  {
-                    className: 'contact-card__text',
-                    style: contactBodyTextStyle,
-                  },
-                  contact.email,
-                )}
-              </div>
+        <section aria-labelledby="instagram-reviews-title" className="section section-reviews">
+          <div className="section-inner section-inner--wide">
+            <div className="reviews-heading">
+              <h2 id="instagram-reviews-title" className="section-title">
+                Ils nous adorent sur Instagram
+              </h2>
+              <p className="reviews-subtitle">
+                Des foodies de toute la Colombie partagent leur coup de cœur pour notre cuisine : ambiance solaire, service
+                attentionné et assiettes qui brillent autant que leurs stories.
+              </p>
             </div>
+            <div className="reviews-carousel">
+              <div className="reviews-track" style={{ transform: `translateX(-${activeReviewIndex * 100}%)` }}>
+                {instagramReviews.map((review, index) => (
+                  <article key={review.id} className="review-card" aria-hidden={index !== activeReviewIndex}>
+                    <div className="review-card__content">
+                      <header className="review-card__header">
+                        <span className="review-card__avatar" aria-hidden="true">
+                          <img src={review.avatarUrl} alt="" />
+                        </span>
+                        <div className="review-card__meta">
+                          <p className="review-card__name">{review.name}</p>
+                          <p className="review-card__handle">{review.handle} • {review.timeAgo}</p>
+                        </div>
+                        <span className="review-card__badge">Instagram</span>
+                      </header>
+                      <div className="review-card__stars" aria-label="Note 5 sur 5">
+                        {Array.from({ length: 5 }).map((_, starIndex) => (
+                          <Star key={starIndex} aria-hidden="true" />
+                        ))}
+                      </div>
+                      <blockquote className="review-card__quote">
+                        <Quote aria-hidden="true" className="review-card__quote-icon" />
+                        <p>{review.message}</p>
+                      </blockquote>
+                      <div className="review-card__footer">
+                        <div className="review-card__highlight">
+                          <span className="review-card__story-ring" aria-hidden="true">
+                            <img src={review.postImageUrl} alt="" />
+                          </span>
+                          <div>
+                            <p className="review-card__highlight-title">{review.highlight}</p>
+                            <p className="review-card__highlight-caption">5 étoiles assurées ✨</p>
+                          </div>
+                        </div>
+                        <p className="review-card__location">{review.location}</p>
+                      </div>
+                    </div>
+                    <div className="review-card__media">
+                      <span className="review-card__media-frame">
+                        <img src={review.postImageUrl} alt={review.postImageAlt} />
+                      </span>
+                    </div>
+                  </article>
+                ))}
+              </div>
+              {!isSingleReview && (
+                <div className="reviews-controls">
+                  <button
+                    type="button"
+                    className="reviews-control"
+                    onClick={handlePreviousReview}
+                    aria-label="Voir l'avis précédent"
+                  >
+                    <ChevronLeft aria-hidden="true" />
+                  </button>
+                  <button
+                    type="button"
+                    className="reviews-control"
+                    onClick={handleNextReview}
+                    aria-label="Voir l'avis suivant"
+                  >
+                    <ChevronRight aria-hidden="true" />
+                  </button>
+                </div>
+              )}
+            </div>
+            {reviewCount > 1 && (
+              <div className="reviews-pagination" role="tablist" aria-label="Avis Instagram">
+                {instagramReviews.map((review, index) => (
+                  <button
+                    key={review.id}
+                    type="button"
+                    className={`reviews-dot${index === activeReviewIndex ? ' reviews-dot--active' : ''}`}
+                    onClick={() => setActiveReviewIndex(index)}
+                    aria-label={`Afficher l'avis de ${review.name}`}
+                    aria-current={index === activeReviewIndex}
+                  />
+                ))}
+              </div>
+            )}
           </div>
         </section>
 
@@ -933,29 +803,6 @@ const Login: React.FC = () => {
                   </div>
                 </div>
                 <div className="find-us-detail" style={findUsTextStyle}>
-                  <MapPin className="find-us-detail__icon" aria-hidden="true" />
-                  <div>
-                    {renderRichTextElement(
-                      'findUs.cityLabel',
-                      'h3',
-                      {
-                        className: 'find-us-detail__title',
-                        style: findUsTextStyle,
-                      },
-                      findUs.cityLabel,
-                    )}
-                    {renderRichTextElement(
-                      'findUs.city',
-                      'p',
-                      {
-                        className: 'find-us-detail__text',
-                        style: findUsBodyTextStyle,
-                      },
-                      findUs.city,
-                    )}
-                  </div>
-                </div>
-                <div className="find-us-detail" style={findUsTextStyle}>
                   <Clock className="find-us-detail__icon" aria-hidden="true" />
                   <div>
                     {renderRichTextElement(
@@ -975,6 +822,29 @@ const Login: React.FC = () => {
                         style: findUsBodyTextStyle,
                       },
                       findUs.hours,
+                    )}
+                  </div>
+                </div>
+                <div className="find-us-detail" style={findUsTextStyle}>
+                  <Mail className="find-us-detail__icon" aria-hidden="true" />
+                  <div>
+                    {renderRichTextElement(
+                      'findUs.cityLabel',
+                      'h3',
+                      {
+                        className: 'find-us-detail__title',
+                        style: findUsTextStyle,
+                      },
+                      findUs.cityLabel,
+                    )}
+                    {renderRichTextElement(
+                      'findUs.city',
+                      'p',
+                      {
+                        className: 'find-us-detail__text',
+                        style: findUsBodyTextStyle,
+                      },
+                      findUs.city,
                     )}
                   </div>
                 </div>
@@ -1052,96 +922,21 @@ const Login: React.FC = () => {
         size="lg"
       >
         <div className="login-modal">
-          <header className="login-modal__header">
-            <div className="login-modal__badge" aria-hidden="true">
-              <img
-                src={staffLogo}
-                alt={navigation.brand ? `Logo ${navigation.brand}` : 'Logo du personnel'}
-                loading="lazy"
-              />
-            </div>
-            <div className="login-modal__intro">
-              <span className="login-modal__eyebrow">
-                <ShieldCheck size={16} aria-hidden="true" />
-                Espace sécurisé
-              </span>
-              <p id="staff-pin-help" className="login-modal__subtitle">
-                Entrez votre code PIN à 6 chiffres pour accéder au tableau de bord du personnel.
-              </p>
-            </div>
-          </header>
-          <form
-            onSubmit={handleFormSubmit}
-            className="login-modal__form"
-            aria-describedby={`staff-pin-help${hasSupportContact ? ' login-support-hint' : ''}`}
-          >
+          <form onSubmit={handleFormSubmit} className="login-modal__form" aria-describedby={error ? 'staff-pin-error' : undefined}>
             <div className="login-modal__panel">
               <PinInput
                 ref={pinInputRef}
                 pin={pin}
                 onPinChange={setPin}
                 pinLength={6}
-                describedBy="staff-pin-help"
+                describedBy={error ? 'staff-pin-error' : undefined}
               />
-              <p className="login-modal__error" role="alert" aria-live="assertive">
-                {error}
-              </p>
-              <div className="login-modal__actions">
-                <button
-                  type="submit"
-                  disabled={loading || pin.length !== 6}
-                  className="ui-btn ui-btn-primary ui-btn--block"
-                  data-state={loading ? 'loading' : 'idle'}
-                >
-                  {loading ? 'Connexion...' : 'Valider'}
-                </button>
-                <button
-                  type="button"
-                  className="ui-btn ui-btn-secondary ui-btn--block"
-                  onClick={() => {
-                    setIsModalOpen(false);
-                    setPin('');
-                    setError('');
-                  }}
-                >
-                  Annuler
-                </button>
-              </div>
+              {error && (
+                <p id="staff-pin-error" className="login-modal__error" role="alert" aria-live="assertive">
+                  {error}
+                </p>
+              )}
             </div>
-            {hasSupportContact && (
-              <div className="login-modal__support" id="login-support-hint">
-                <h4>Besoin d'aide ?</h4>
-                <p>Contactez un manager pour récupérer ou réinitialiser votre code.</p>
-                <ul className="login-modal__support-list">
-                  {contact.phone && (
-                    <li className="login-modal__support-item">
-                      <span className="login-modal__support-icon" aria-hidden="true">
-                        <Phone size={18} />
-                      </span>
-                      <div>
-                        <p className="login-modal__support-label">{contact.phoneLabel}</p>
-                        <a href={contactPhoneHref ?? undefined} className="login-modal__support-link">
-                          {contact.phone}
-                        </a>
-                      </div>
-                    </li>
-                  )}
-                  {contact.email && (
-                    <li className="login-modal__support-item">
-                      <span className="login-modal__support-icon" aria-hidden="true">
-                        <Mail size={18} />
-                      </span>
-                      <div>
-                        <p className="login-modal__support-label">{contact.emailLabel}</p>
-                        <a href={contactEmailHref ?? undefined} className="login-modal__support-link">
-                          {contact.email}
-                        </a>
-                      </div>
-                    </li>
-                  )}
-                </ul>
-              </div>
-            )}
           </form>
         </div>
       </Modal>

--- a/pages/SiteCustomization.tsx
+++ b/pages/SiteCustomization.tsx
@@ -137,12 +137,8 @@ const CONTACT_EMAIL_SUGGESTIONS = ['hola@ouiouipos.co', 'contact@maison-gourmet.
 const FIND_US_TITLE_SUGGESTIONS = ['Encuéntranos', 'Visítanos hoy', 'Tu próxima parada foodie'] as const;
 const FIND_US_ADDRESS_LABEL_SUGGESTIONS = ['Dirección', 'Ubicación', 'Nos encuentras en'] as const;
 const FIND_US_ADDRESS_SUGGESTIONS = ['Cra 53 #75 - 98', 'Calle 84 #51B - 145', 'Av. Olaya Herrera #70 - 21'] as const;
-const FIND_US_CITY_LABEL_SUGGESTIONS = ['Ciudad', 'Estamos en', 'Localización'] as const;
-const FIND_US_CITY_SUGGESTIONS = [
-  'Barranquilla, Colombie',
-  'Medellín, Colombie',
-  'Cartagena, Colombie',
-] as const;
+const FIND_US_CITY_LABEL_SUGGESTIONS = ['Email', 'Escríbenos', 'Contacto'] as const;
+const FIND_US_CITY_SUGGESTIONS = ['hola@ouiouipos.co', 'reservas@ouiouipos.co', 'eventos@ouiouipos.co'] as const;
 const FIND_US_HOURS_LABEL_SUGGESTIONS = ['Horarios', 'Horario de atención', 'Abrimos'] as const;
 const FIND_US_HOURS_SUGGESTIONS = [
   'Lunes a domingo · 11h00 - 23h00',
@@ -200,7 +196,7 @@ const ZONE_STEPS: ReadonlyArray<{
     label: 'Encuéntranos',
     description: 'Mettez en avant votre localisation et facilitez la venue sur place.',
     helper:
-      'Adresse précise, ville et horaires rassurent vos visiteurs. Ajoutez un lien Google Maps pour guider facilement le déplacement.',
+      'Adresse précise, horaires et email rassurent vos visiteurs. Ajoutez un lien Google Maps pour guider facilement le déplacement.',
   },
   {
     key: 'footer',
@@ -263,8 +259,8 @@ const ELEMENT_STYLE_LABELS: Partial<Record<EditableElementKey, string>> = {
   'findUs.title': 'Titre Encuéntranos',
   'findUs.addressLabel': "Libellé de l'adresse (Encuéntranos)",
   'findUs.address': 'Adresse (Encuéntranos)',
-  'findUs.cityLabel': 'Libellé de la ville',
-  'findUs.city': 'Ville',
+  'findUs.cityLabel': "Libellé de l'email",
+  'findUs.city': 'Email',
   'findUs.hoursLabel': 'Libellé des horaires',
   'findUs.hours': 'Horaires',
   'findUs.mapLabel': 'Libellé du lien carte',
@@ -467,7 +463,7 @@ const createZoneChecklist = (draft: SiteContent): ZoneChecklistRecord => ({
   findUs: [
     { label: 'Titre Encuéntranos défini', done: draft.findUs.title.trim().length > 0 },
     {
-      label: 'Adresse et ville renseignées',
+      label: 'Adresse et email renseignés',
       done: draft.findUs.address.trim().length > 0 && draft.findUs.city.trim().length > 0,
     },
     {
@@ -2874,9 +2870,9 @@ const getElementEditorConfig = (
       };
     case 'findUs.cityLabel':
       return {
-        title: 'Label ville',
+        title: 'Label email',
         content: (
-          <FieldCard label="Label ville" htmlFor="find-us-city-label">
+          <FieldCard label="Label email" htmlFor="find-us-city-label">
             {renderRichTextField('findUs.cityLabel', draft.findUs.cityLabel, (text, rich) =>
               context.setFindUsFieldValue('cityLabel', text, rich),
             )}
@@ -2889,9 +2885,9 @@ const getElementEditorConfig = (
       };
     case 'findUs.city':
       return {
-        title: 'Ville',
+        title: 'Email',
         content: (
-          <FieldCard label="Ville" htmlFor="find-us-city">
+          <FieldCard label="Email" htmlFor="find-us-city">
             {renderRichTextField('findUs.city', draft.findUs.city, (text, rich) =>
               context.setFindUsFieldValue('city', text, rich),
             )}

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -801,6 +801,7 @@ body {
   margin: 0.15rem 0 0;
   font-size: var(--font-size-sm);
   color: var(--color-text-muted);
+  white-space: pre-line;
 }
 
 .find-us-map {
@@ -961,36 +962,15 @@ body {
   display: inline-flex;
   align-items: center;
   justify-content: center;
-  width: clamp(2.5rem, 5vw, 3rem);
-  height: clamp(2.5rem, 5vw, 3rem);
-  border-radius: 999px;
-  border: 1px solid color-mix(in srgb, var(--color-surface) 24%, transparent);
-  background: color-mix(in srgb, var(--color-heading) 72%, transparent);
-  padding: clamp(0.2rem, 0.7vw, 0.35rem);
-  transition: transform 0.2s ease, border-color 0.2s ease, box-shadow 0.2s ease;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
 }
 
-.login-nav__staff-btn:hover,
 .login-nav__staff-btn:focus-visible {
-  transform: translateY(-1px);
-  border-color: color-mix(in srgb, var(--color-surface) 35%, transparent);
-  box-shadow: 0 6px 16px color-mix(in srgb, var(--color-heading) 22%, transparent);
-  outline: none;
-}
-
-.login-nav__staff-btn:disabled {
-  cursor: default;
-  opacity: 0.65;
-  transform: none;
-  box-shadow: none;
-}
-
-.login-nav__staff-logo {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-  display: block;
-  filter: drop-shadow(0 4px 12px color-mix(in srgb, var(--color-heading) 25%, transparent));
+  outline: 2px solid color-mix(in srgb, var(--color-surface) 65%, transparent);
+  outline-offset: 6px;
 }
 
 .login-header__menu {
@@ -1054,15 +1034,8 @@ body {
 }
 
 .login-menu-overlay__staff-btn {
-  width: clamp(3rem, 12vw, 3.75rem);
-  height: clamp(3rem, 12vw, 3.75rem);
-  background: color-mix(in srgb, var(--color-surface) 10%, transparent);
-  border-color: color-mix(in srgb, var(--color-surface) 40%, transparent);
-}
-
-.login-menu-overlay__staff-btn:hover,
-.login-menu-overlay__staff-btn:focus-visible {
-  background: color-mix(in srgb, var(--color-surface) 20%, transparent);
+  width: auto;
+  height: auto;
 }
 
 @media (max-width: 640px) {
@@ -1186,78 +1159,13 @@ body {
 
 .login-modal {
   display: flex;
-  flex-direction: column;
-  gap: clamp(1.5rem, 4vw, 2.5rem);
-}
-
-.login-modal__header {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: clamp(1rem, 3vw, 1.5rem);
-  padding: clamp(1rem, 3vw, 1.5rem);
-  border-radius: 1.25rem;
-  background: color-mix(in srgb, var(--color-surface) 92%, rgba(15, 23, 42, 0.05));
-  border: 1px solid color-mix(in srgb, var(--color-border-strong) 50%, transparent);
-}
-
-.login-modal__badge {
-  display: grid;
-  place-items: center;
-  width: clamp(3rem, 12vw, 3.75rem);
-  height: clamp(3rem, 12vw, 3.75rem);
-  border-radius: 1rem;
-  background: color-mix(in srgb, var(--color-accent) 12%, transparent);
-  overflow: hidden;
-}
-
-.login-modal__badge img {
-  width: 100%;
-  height: 100%;
-  object-fit: contain;
-}
-
-.login-modal__intro {
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
-  min-width: min(18rem, 100%);
-}
-
-.login-modal__eyebrow {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.4rem;
-  font-size: var(--font-size-xs);
-  font-weight: 600;
-  text-transform: uppercase;
-  letter-spacing: 0.08em;
-  color: var(--color-accent);
-}
-
-.login-modal__eyebrow svg {
-  width: 1rem;
-  height: 1rem;
-}
-
-.login-modal__subtitle {
-  margin: 0;
-  font-size: calc(var(--font-size-base) * 0.95);
-  line-height: 1.6;
-  color: var(--color-text-muted);
-  max-width: 42ch;
+  justify-content: center;
+  padding: clamp(1.5rem, 4vw, 2.5rem);
 }
 
 .login-modal__form {
-  display: grid;
-  gap: clamp(1.5rem, 4vw, 2rem);
-}
-
-@media (min-width: 768px) {
-  .login-modal__form {
-    grid-template-columns: minmax(0, 1fr) minmax(0, 18rem);
-    align-items: start;
-  }
+  display: flex;
+  justify-content: center;
 }
 
 .login-modal__panel {
@@ -1265,6 +1173,7 @@ body {
   flex-direction: column;
   align-items: center;
   gap: 1.25rem;
+  max-width: min(26rem, 100%);
 }
 
 .login-modal__error {
@@ -1273,39 +1182,6 @@ body {
   text-align: center;
   font-size: var(--font-size-sm);
   color: var(--color-danger);
-}
-
-.login-modal__actions {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
-  width: 100%;
-}
-
-.login-modal__actions .ui-btn {
-  font-size: calc(var(--font-size-base) * 1.05);
-  padding-block: clamp(0.9rem, 3vw, 1.1rem);
-  border-radius: 0.85rem;
-}
-
-@media (min-width: 480px) {
-  .login-modal__actions {
-    flex-direction: row;
-  }
-
-  .login-modal__actions .ui-btn {
-    flex: 1;
-  }
-}
-
-.login-modal__support {
-  display: flex;
-  flex-direction: column;
-  gap: 1rem;
-  padding: clamp(1rem, 3vw, 1.5rem);
-  border-radius: 1.25rem;
-  background: color-mix(in srgb, var(--color-surface) 94%, rgba(15, 23, 42, 0.05));
-  border: 1px solid color-mix(in srgb, var(--color-border-strong) 50%, transparent);
 }
 
 .login-modal__support h4 {

--- a/utils/siteContent.ts
+++ b/utils/siteContent.ts
@@ -413,9 +413,9 @@ export const DEFAULT_SITE_CONTENT: SiteContent = {
   findUs: {
     title: 'Encuéntranos',
     addressLabel: 'Dirección',
-    address: 'Cra 53 #75 - 98',
-    cityLabel: 'Ciudad',
-    city: 'Barranquilla, Colombie',
+    address: 'Cra 53 #75 - 98\nBarranquilla\nEn el local y terraza del bar RedDoor',
+    cityLabel: 'Email',
+    city: 'hola@ouiouipos.co',
     hoursLabel: 'Horarios',
     hours: 'Lunes a domingo · 11h00 - 23h00',
     mapLabel: 'Ver en Google Maps',


### PR DESCRIPTION
## Summary
- simplify the staff login modal to only present the PIN input and keypad while keeping error messaging concise
- make the staff login trigger reuse the brand logo styling, drop the contact nav entry, and reposition the Instagram reviews beneath the best sellers
- refresh the “Encuéntranos” defaults and customization tooling to show the multi-line address, hours, and an email contact with matching CSS tweaks

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dcfba244fc832a8fbc80701215f63a