### PR TITLE
Fix background color overrides for customized text

### DIFF
--- a/utils/siteStyleHelpers.ts
+++ b/utils/siteStyleHelpers.ts
@@ -61,10 +61,18 @@ export const createBodyTextStyle = (style: SectionStyle): CSSProperties => ({
 export const createElementTextStyle = (
   sectionStyle: SectionStyle,
   elementStyle?: ElementStyle | null,
-): CSSProperties => ({
-  color: elementStyle?.textColor ?? sectionStyle.textColor,
-  fontFamily: elementStyle?.fontFamily ?? sectionStyle.fontFamily,
-});
+): CSSProperties => {
+  const style: CSSProperties = {
+    color: elementStyle?.textColor ?? sectionStyle.textColor,
+    fontFamily: elementStyle?.fontFamily ?? sectionStyle.fontFamily,
+  };
+
+  if (elementStyle?.backgroundColor && elementStyle.backgroundColor.trim().length > 0) {
+    style.backgroundColor = elementStyle.backgroundColor;
+  }
+
+  return style;
+};
 
 export const createElementBodyTextStyle = (
   sectionStyle: SectionStyle,


### PR DESCRIPTION
## Summary
- ensure element-specific background colors are applied when previewing customized text

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dd1f5e64dc832ab509fbefd287cadb