### PR TITLE
Ensure rich text editor uses semantic formatting tags

### DIFF
--- a/components/RichTextEditor.tsx
+++ b/components/RichTextEditor.tsx
@@ -72,7 +72,7 @@ const RichTextEditor: React.FC<RichTextEditorProps> = ({
   };
 
   const applyCommand = (command: string) => {
-    document.execCommand('styleWithCSS', false, 'true');
+    document.execCommand('styleWithCSS', false, 'false');
     document.execCommand(command);
     editorRef.current?.focus();
     emitChange();

--- a/utils/richText.ts
+++ b/utils/richText.ts
@@ -4,6 +4,7 @@ const ALLOWED_TAGS = new Set([
   'STRONG',
   'EM',
   'S',
+  'STRIKE',
   'SPAN',
   'BR',
   'DIV',
@@ -49,23 +50,24 @@ const unwrapElement = (element: Element) => {
 };
 
 const normalizeElementTag = (element: HTMLElement): HTMLElement => {
-  if (element.tagName === 'B') {
-    const replacement = document.createElement('strong');
-    while (element.firstChild) {
-      replacement.appendChild(element.firstChild);
-    }
-    element.replaceWith(replacement);
-    return replacement;
+  const tagMap: Record<string, string> = {
+    B: 'strong',
+    I: 'em',
+    STRIKE: 's',
+  };
+
+  const replacementTag = tagMap[element.tagName];
+
+  if (!replacementTag) {
+    return element;
   }
-  if (element.tagName === 'I') {
-    const replacement = document.createElement('em');
-    while (element.firstChild) {
-      replacement.appendChild(element.firstChild);
-    }
-    element.replaceWith(replacement);
-    return replacement;
+
+  const replacement = document.createElement(replacementTag);
+  while (element.firstChild) {
+    replacement.appendChild(element.firstChild);
   }
-  return element;
+  element.replaceWith(replacement);
+  return replacement;
 };
 
 const sanitizeElement = (element: HTMLElement) => {


### PR DESCRIPTION
## Summary
- ensure bold, italic, and strikethrough commands produce semantic tags instead of inline styles
- normalize sanitized HTML to convert legacy <strike> tags into <s> elements while keeping only color styles

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dd36936024832aba4813c2d801d7d6