### PR TITLE
Convert editors to anchored popovers

### DIFF
--- a/components/SitePreviewCanvas.tsx
+++ b/components/SitePreviewCanvas.tsx
@@ -44,7 +44,10 @@ export const resolveZoneFromElement = (element: EditableElementKey): EditableZon
 interface SitePreviewCanvasProps {
   content: SiteContent;
   bestSellerProducts: Product[];
-  onEdit: (element: EditableElementKey, meta: { zone: EditableZoneKey; anchor: DOMRect | null }) => void;
+  onEdit: (
+    element: EditableElementKey,
+    meta: { zone: EditableZoneKey; anchor: DOMRect | DOMRectReadOnly | null },
+  ) => void;
   activeZone?: EditableZoneKey | null;
   showEditButtons?: boolean;
 }
@@ -111,6 +114,7 @@ const EditableElement: React.FC<EditableElementProps> = ({
         onClick={handleEdit}
         className={buttonClasses}
         aria-label={label}
+        data-element-id={id}
       >
         <Edit2 className="h-3.5 w-3.5" aria-hidden="true" />
       </button>

--- a/pages/SiteCustomization.tsx
+++ b/pages/SiteCustomization.tsx
@@ -1,4 +1,13 @@
-import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  useLayoutEffect,
+  useId,
+} from 'react';
+import { createPortal } from 'react-dom';
 import { AlertTriangle, CheckCircle2, Loader2, Upload, X } from 'lucide-react';
 import SitePreviewCanvas, { resolveZoneFromElement } from '../components/SitePreviewCanvas';
 import useSiteContent from '../hooks/useSiteContent';
@@ -296,34 +305,276 @@ const createAssetFromFile = (file: File, url: string): CustomizationAsset => {
   };
 };
 
-interface ModalProps {
+type AnchorRect = Pick<DOMRectReadOnly, 'x' | 'y' | 'top' | 'left' | 'bottom' | 'right' | 'width' | 'height'>;
+
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), textarea:not([disabled]), input:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+const useIsomorphicLayoutEffect = typeof window !== 'undefined' ? useLayoutEffect : useEffect;
+
+const escapeAttributeValue = (value: string): string => {
+  if (typeof window !== 'undefined' && window.CSS && typeof window.CSS.escape === 'function') {
+    return window.CSS.escape(value);
+  }
+  return value.replace(/"/g, '\\"');
+};
+
+const cloneAnchorRect = (rect: DOMRect | DOMRectReadOnly | AnchorRect | null): AnchorRect | null => {
+  if (!rect) {
+    return null;
+  }
+  const { x, y, top, left, bottom, right, width, height } = rect;
+  return { x, y, top, left, bottom, right, width, height };
+};
+
+interface EditorPopoverProps {
   title: string;
   onClose: () => void;
   children: React.ReactNode;
   footer: React.ReactNode;
+  anchor: AnchorRect | null;
+  elementId: EditableElementKey;
 }
 
-const Modal: React.FC<ModalProps> = ({ title, onClose, children, footer }) => (
-  <div className="fixed inset-0 z-50 flex items-center justify-center bg-slate-900/40 p-6">
-    <div className="w-full max-w-3xl overflow-hidden rounded-3xl bg-white shadow-2xl">
-      <div className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
-        <h2 className="text-lg font-semibold text-slate-900">{title}</h2>
-        <button
-          type="button"
-          onClick={onClose}
-          className="rounded-full p-1 text-slate-500 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
-        >
-          <X className="h-5 w-5" aria-hidden="true" />
-          <span className="sr-only">Fermer</span>
-        </button>
+const EditorPopover: React.FC<EditorPopoverProps> = ({
+  title,
+  onClose,
+  children,
+  footer,
+  anchor,
+  elementId,
+}) => {
+  const headingId = useId();
+  const containerRef = useRef<HTMLDivElement | null>(null);
+  const [position, setPosition] = useState<{ top: number; left: number }>({ top: 0, left: 0 });
+  const [placement, setPlacement] = useState<'top' | 'bottom'>('top');
+  const [isMounted, setIsMounted] = useState(false);
+  const [isPositioned, setIsPositioned] = useState(false);
+  const [arrowPosition, setArrowPosition] = useState<{ top: number; left: number } | null>(null);
+
+  useEffect(() => {
+    setIsMounted(true);
+  }, []);
+
+  const updatePosition = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+    const node = containerRef.current;
+    if (!node) {
+      return;
+    }
+
+    const anchorSelector = `[data-element-id="${escapeAttributeValue(elementId)}"]`;
+    const anchorElement = document.querySelector(anchorSelector) as HTMLElement | null;
+    const rect = anchorElement?.getBoundingClientRect() ?? anchor;
+
+    const { width: dialogWidth, height: dialogHeight } = node.getBoundingClientRect();
+    const viewportWidth = document.documentElement.clientWidth;
+    const viewportHeight = window.innerHeight;
+    const gutter = 16;
+    const offset = 12;
+
+    if (!rect) {
+      const fallbackLeft = Math.max(gutter, (viewportWidth - dialogWidth) / 2);
+      const fallbackTop = Math.max(gutter, (viewportHeight - dialogHeight) / 2);
+      setPosition({ top: fallbackTop, left: fallbackLeft });
+      setPlacement('top');
+      setIsPositioned(true);
+      setArrowPosition(null);
+      return;
+    }
+
+    let top = rect.top - dialogHeight - offset;
+    let currentPlacement: 'top' | 'bottom' = 'top';
+    if (top < gutter) {
+      top = rect.bottom + offset;
+      currentPlacement = 'bottom';
+    }
+
+    if (top + dialogHeight > viewportHeight - gutter) {
+      const availableAbove = rect.top - gutter;
+      const availableBelow = viewportHeight - rect.bottom - gutter;
+      if (availableAbove > availableBelow) {
+        top = Math.max(gutter, rect.top - dialogHeight - offset);
+        currentPlacement = 'top';
+      } else {
+        top = Math.min(viewportHeight - dialogHeight - gutter, rect.bottom + offset);
+        currentPlacement = 'bottom';
+      }
+    }
+
+    const desiredLeft = rect.left + rect.width / 2 - dialogWidth / 2;
+    const maxLeft = viewportWidth - dialogWidth - gutter;
+    const clampedLeft = Math.max(gutter, Math.min(desiredLeft, maxLeft));
+
+    setPosition({ top, left: clampedLeft });
+    setPlacement(currentPlacement);
+    setIsPositioned(true);
+
+    const arrowCenter = Math.max(
+      clampedLeft + 12,
+      Math.min(rect.left + rect.width / 2, clampedLeft + dialogWidth - 12),
+    );
+    const arrowTop = currentPlacement === 'top' ? top + dialogHeight - 6 : top - 6;
+    setArrowPosition({ top: arrowTop, left: arrowCenter - 6 });
+  }, [anchor, elementId]);
+
+  useIsomorphicLayoutEffect(() => {
+    if (!isMounted) {
+      return;
+    }
+    updatePosition();
+  }, [updatePosition, isMounted]);
+
+  useEffect(() => {
+    if (!isMounted) {
+      return;
+    }
+    const handleScroll = () => updatePosition();
+    window.addEventListener('scroll', handleScroll, true);
+    window.addEventListener('resize', handleScroll);
+
+    const anchorSelector = `[data-element-id="${escapeAttributeValue(elementId)}"]`;
+    const anchorElement = document.querySelector(anchorSelector) as HTMLElement | null;
+    const observers: ResizeObserver[] = [];
+    if (typeof ResizeObserver !== 'undefined') {
+      const resizeObserver = new ResizeObserver(() => updatePosition());
+      if (anchorElement) {
+        resizeObserver.observe(anchorElement);
+      }
+      const node = containerRef.current;
+      if (node) {
+        resizeObserver.observe(node);
+      }
+      observers.push(resizeObserver);
+    }
+
+    return () => {
+      window.removeEventListener('scroll', handleScroll, true);
+      window.removeEventListener('resize', handleScroll);
+      observers.forEach(observer => observer.disconnect());
+    };
+  }, [updatePosition, elementId, isMounted]);
+
+  useEffect(() => {
+    if (!isMounted) {
+      return;
+    }
+    const handleKeyDown = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') {
+        event.preventDefault();
+        onClose();
+        return;
+      }
+      if (event.key === 'Tab') {
+        const node = containerRef.current;
+        if (!node) {
+          return;
+        }
+        const focusable = Array.from(node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR)).filter(element =>
+          element.tabIndex !== -1 && !element.hasAttribute('disabled') && !element.getAttribute('aria-hidden'),
+        );
+        if (focusable.length === 0) {
+          event.preventDefault();
+          node.focus();
+          return;
+        }
+        const first = focusable[0];
+        const last = focusable[focusable.length - 1];
+        if (event.shiftKey) {
+          if (document.activeElement === first || !node.contains(document.activeElement)) {
+            event.preventDefault();
+            last.focus();
+          }
+          return;
+        }
+        if (document.activeElement === last) {
+          event.preventDefault();
+          first.focus();
+        }
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [onClose, isMounted]);
+
+  useEffect(() => {
+    if (!isMounted) {
+      return;
+    }
+    const handlePointerDown = (event: MouseEvent) => {
+      const node = containerRef.current;
+      if (!node) {
+        return;
+      }
+      if (!node.contains(event.target as Node)) {
+        onClose();
+      }
+    };
+    document.addEventListener('mousedown', handlePointerDown);
+    return () => document.removeEventListener('mousedown', handlePointerDown);
+  }, [onClose, isMounted]);
+
+  useEffect(() => {
+    if (!isMounted) {
+      return;
+    }
+    const node = containerRef.current;
+    if (!node) {
+      return;
+    }
+    const focusable = node.querySelectorAll<HTMLElement>(FOCUSABLE_SELECTOR);
+    const target = focusable[0] ?? node;
+    target.focus({ preventScroll: true });
+  }, [isMounted]);
+
+  if (typeof document === 'undefined' || !isMounted) {
+    return null;
+  }
+
+  const content = (
+    <div className="fixed inset-0 z-[60] pointer-events-none">
+      <div
+        ref={containerRef}
+        role="dialog"
+        aria-modal="true"
+        aria-labelledby={headingId}
+        tabIndex={-1}
+        className="pointer-events-auto flex w-[min(90vw,32rem)] flex-col overflow-hidden rounded-3xl bg-white shadow-2xl ring-1 ring-slate-200"
+        style={{ position: 'absolute', top: position.top, left: position.left, opacity: isPositioned ? 1 : 0 }}
+      >
+        <div className="flex items-center justify-between border-b border-slate-200 px-6 py-4">
+          <h2 id={headingId} className="text-lg font-semibold text-slate-900">
+            {title}
+          </h2>
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-full p-1 text-slate-500 transition hover:text-slate-900 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-brand-primary"
+          >
+            <X className="h-5 w-5" aria-hidden="true" />
+            <span className="sr-only">Fermer</span>
+          </button>
+        </div>
+        <div className="max-h-[70vh] overflow-y-auto px-6 py-5">{children}</div>
+        <div className="flex items-center justify-end gap-3 border-t border-slate-200 bg-slate-50 px-6 py-4">{footer}</div>
       </div>
-      <div className="max-h-[70vh] overflow-y-auto px-6 py-5">{children}</div>
-      <div className="flex items-center justify-end gap-3 border-t border-slate-200 bg-slate-50 px-6 py-4">
-        {footer}
-      </div>
+      {arrowPosition ? (
+        <span
+          aria-hidden="true"
+          className={`pointer-events-none absolute h-3 w-3 rotate-45 rounded-sm bg-white shadow-[0_0_0_1px_rgba(148,163,184,0.35)] ${
+            placement === 'top' ? 'translate-y-[-4px]' : 'translate-y-[4px]'
+          }`}
+          style={{ top: arrowPosition.top, left: arrowPosition.left, opacity: isPositioned ? 1 : 0 }}
+        />
+      ) : null}
     </div>
-  </div>
-);
+  );
+
+  return createPortal(content, document.body);
+};
 
 interface TextElementEditorProps {
   element: EditableElementKey;
@@ -333,6 +584,7 @@ interface TextElementEditorProps {
   onClose: () => void;
   fontOptions: readonly string[];
   onAssetAdded: (asset: CustomizationAsset) => void;
+  anchor: AnchorRect | null;
 }
 
 const TextElementEditor: React.FC<TextElementEditorProps> = ({
@@ -343,6 +595,7 @@ const TextElementEditor: React.FC<TextElementEditorProps> = ({
   onClose,
   fontOptions,
   onAssetAdded,
+  anchor,
 }) => {
   const formId = `${element.replace(/\./g, '-')}-text-form`;
   const initialPlain = getPlainTextValue(draft, element);
@@ -415,7 +668,13 @@ const TextElementEditor: React.FC<TextElementEditorProps> = ({
   );
 
   return (
-    <Modal title={`Personnaliser ${label}`} onClose={onClose} footer={footer}>
+    <EditorPopover
+      title={`Personnaliser ${label}`}
+      onClose={onClose}
+      footer={footer}
+      anchor={anchor}
+      elementId={element}
+    >
       <form id={formId} onSubmit={handleSubmit} className="space-y-6">
         <div>
           <label htmlFor={`${formId}-plain`} className="block text-sm font-medium text-slate-700">
@@ -580,7 +839,7 @@ const TextElementEditor: React.FC<TextElementEditorProps> = ({
           </button>
         </div>
       </form>
-    </Modal>
+    </EditorPopover>
   );
 };
 
@@ -591,6 +850,7 @@ interface ImageElementEditorProps {
   onApply: (updater: DraftUpdater) => void;
   onClose: () => void;
   onAssetAdded: (asset: CustomizationAsset) => void;
+  anchor: AnchorRect | null;
 }
 
 const ImageElementEditor: React.FC<ImageElementEditorProps> = ({
@@ -600,6 +860,7 @@ const ImageElementEditor: React.FC<ImageElementEditorProps> = ({
   onApply,
   onClose,
   onAssetAdded,
+  anchor,
 }) => {
   const formId = `${element.replace(/\./g, '-')}-image-form`;
   const initialImage = getImageValue(draft, element) ?? '';
@@ -653,7 +914,13 @@ const ImageElementEditor: React.FC<ImageElementEditorProps> = ({
   const previewUrl = imageUrl.trim();
 
   return (
-    <Modal title={`Personnaliser ${label}`} onClose={onClose} footer={footer}>
+    <EditorPopover
+      title={`Personnaliser ${label}`}
+      onClose={onClose}
+      footer={footer}
+      anchor={anchor}
+      elementId={element}
+    >
       <form id={formId} onSubmit={handleSubmit} className="space-y-6">
         <div>
           <label htmlFor={`${formId}-input`} className="block text-sm font-medium text-slate-700">
@@ -703,7 +970,7 @@ const ImageElementEditor: React.FC<ImageElementEditorProps> = ({
           </div>
         )}
       </form>
-    </Modal>
+    </EditorPopover>
   );
 };
 
@@ -714,6 +981,7 @@ interface BackgroundElementEditorProps {
   onApply: (updater: DraftUpdater) => void;
   onClose: () => void;
   onAssetAdded: (asset: CustomizationAsset) => void;
+  anchor: AnchorRect | null;
 }
 
 const BackgroundElementEditor: React.FC<BackgroundElementEditorProps> = ({
@@ -723,6 +991,7 @@ const BackgroundElementEditor: React.FC<BackgroundElementEditorProps> = ({
   onApply,
   onClose,
   onAssetAdded,
+  anchor,
 }) => {
   const formId = `${element.replace(/\./g, '-')}-background-form`;
   const background = getSectionBackground(draft, element);
@@ -786,7 +1055,13 @@ const BackgroundElementEditor: React.FC<BackgroundElementEditorProps> = ({
   const previewUrl = imageUrl.trim();
 
   return (
-    <Modal title={`Personnaliser ${label}`} onClose={onClose} footer={footer}>
+    <EditorPopover
+      title={`Personnaliser ${label}`}
+      onClose={onClose}
+      footer={footer}
+      anchor={anchor}
+      elementId={element}
+    >
       <form id={formId} onSubmit={handleSubmit} className="space-y-6">
         <div className="flex gap-3">
           <button
@@ -886,7 +1161,7 @@ const BackgroundElementEditor: React.FC<BackgroundElementEditorProps> = ({
           </div>
         )}
       </form>
-    </Modal>
+    </EditorPopover>
   );
 };
 
@@ -896,6 +1171,7 @@ const SiteCustomization: React.FC = () => {
   const [activeElement, setActiveElement] = useState<EditableElementKey | null>(null);
   const [activeZone, setActiveZone] = useState<EditableZoneKey | null>(null);
   const [activeTab, setActiveTab] = useState<TabId>('custom');
+  const [activeAnchor, setActiveAnchor] = useState<AnchorRect | null>(null);
   const [saving, setSaving] = useState<boolean>(false);
   const [saveError, setSaveError] = useState<string | null>(null);
   const [saveSuccess, setSaveSuccess] = useState<string | null>(null);
@@ -965,9 +1241,13 @@ const SiteCustomization: React.FC = () => {
   }, []);
 
   const handleEdit = useCallback(
-    (element: EditableElementKey, meta: { zone: EditableZoneKey; anchor: DOMRect | null }) => {
+    (
+      element: EditableElementKey,
+      meta: { zone: EditableZoneKey; anchor: DOMRect | DOMRectReadOnly | null },
+    ) => {
       setActiveElement(element);
       setActiveZone(meta.zone);
+      setActiveAnchor(cloneAnchorRect(meta.anchor));
     },
     [],
   );
@@ -975,6 +1255,7 @@ const SiteCustomization: React.FC = () => {
   const closeEditor = useCallback(() => {
     setActiveElement(null);
     setActiveZone(null);
+    setActiveAnchor(null);
   }, []);
 
   const handleSave = async () => {
@@ -1126,6 +1407,7 @@ const SiteCustomization: React.FC = () => {
           onClose={closeEditor}
           fontOptions={fontOptions}
           onAssetAdded={appendAssetToDraft}
+          anchor={activeAnchor}
         />
       )}
 
@@ -1137,6 +1419,7 @@ const SiteCustomization: React.FC = () => {
           onApply={applyDraftUpdate}
           onClose={closeEditor}
           onAssetAdded={appendAssetToDraft}
+          anchor={activeAnchor}
         />
       )}
 
@@ -1148,6 +1431,7 @@ const SiteCustomization: React.FC = () => {
           onApply={applyDraftUpdate}
           onClose={closeEditor}
           onAssetAdded={appendAssetToDraft}
+          anchor={activeAnchor}
         />
       )}
     </div>


### PR DESCRIPTION
## Summary
- add an anchored EditorPopover that traps focus, repositions around the pencil icon, and replaces the full-screen modal
- persist the pencil button DOMRect in site customization state and forward it to each editor popover
- tag edit buttons with data attributes so popovers can follow them during scroll and resize

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68dd43a4a890832abbc6661008585b91