### PR TITLE
Ajuste du header et du style de la page commande en ligne

### DIFF
--- a/pages/CommandeClient.tsx
+++ b/pages/CommandeClient.tsx
@@ -325,10 +325,13 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                             <h2 className="text-xl font-bold flex items-center gap-2 mb-3 text-gray-700"><History /> ¿Repetir un pedido?</h2>
                             <div className="space-y-2">
                                 {orderHistory.slice(0, 3).map(order => (
-                                    <div key={order.id} className="flex justify-between items-center bg-gray-50 p-3 rounded-lg">
+                                    <div
+                                        key={order.id}
+                                        className="flex justify-between items-center rounded-lg border border-white/20 bg-slate-900/80 p-3 text-slate-100 backdrop-blur-sm"
+                                    >
                                         <div>
-                                            <p className="font-semibold text-gray-700">Pedido del {new Date(order.date_creation).toLocaleDateString('es-CO')}</p>
-                                            <p className="text-sm text-gray-500">{order.items.length} artículo(s) - {formatCurrencyCOP(order.total)}</p>
+                                            <p className="font-semibold text-white">Pedido del {new Date(order.date_creation).toLocaleDateString('es-CO')}</p>
+                                            <p className="text-sm text-slate-300">{order.items.length} artículo(s) - {formatCurrencyCOP(order.total)}</p>
                                         </div>
                                         <button
                                             onClick={() => handleReorder(order)}
@@ -343,13 +346,18 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                     )}
                     <div className="bg-white/95 p-4 rounded-xl shadow-xl">
                         <div className="flex space-x-2 overflow-x-auto pb-2 mb-4">
-                             <button onClick={() => setActiveCategoryId('all')}
-                                className={`px-4 py-2 rounded-full font-semibold whitespace-nowrap transition ${activeCategoryId === 'all' ? 'bg-brand-primary text-brand-secondary' : 'bg-gray-200 text-gray-700'}`}>
+                            <button
+                                onClick={() => setActiveCategoryId('all')}
+                                className={`px-4 py-2 rounded-full font-semibold whitespace-nowrap transition border ${activeCategoryId === 'all' ? 'bg-brand-primary text-slate-900 border-brand-primary shadow-lg' : 'bg-slate-900/80 text-white border-white/20'}`}
+                            >
                                 Todos
                             </button>
                             {categories.map(cat => (
-                                <button key={cat.id} onClick={() => setActiveCategoryId(cat.id)}
-                                    className={`px-4 py-2 rounded-full font-semibold whitespace-nowrap transition ${activeCategoryId === cat.id ? 'bg-brand-primary text-brand-secondary' : 'bg-gray-200 text-gray-700'}`}>
+                                <button
+                                    key={cat.id}
+                                    onClick={() => setActiveCategoryId(cat.id)}
+                                    className={`px-4 py-2 rounded-full font-semibold whitespace-nowrap transition border ${activeCategoryId === cat.id ? 'bg-brand-primary text-slate-900 border-brand-primary shadow-lg' : 'bg-slate-900/80 text-white border-white/20'}`}
+                                >
                                     {cat.nom}
                                 </button>
                             ))}
@@ -471,6 +479,7 @@ const CommandeClient: React.FC = () => {
     const activeOrderId = activeOrder?.orderId ?? null;
     const { content: siteContent } = useSiteContent();
     const { hero, navigation, assets } = siteContent;
+    const brandLogo = navigation.brandLogo ?? '/logo-brand.svg';
 
     useCustomFonts(assets.library);
 
@@ -494,8 +503,15 @@ const CommandeClient: React.FC = () => {
                 className="shadow-md backdrop-blur p-4 sticky top-0 z-40 border-b border-white/40"
                 style={navigationBackgroundStyle}
             >
-                <div className="container mx-auto flex justify-between items-center">
-                    <h1 className="text-2xl font-bold" style={navigationTextStyle}>OUIOUITACOS</h1>
+                <div className="container mx-auto flex justify-between items-center" style={navigationTextStyle}>
+                    <div className="flex items-center gap-3">
+                        <img
+                            src={brandLogo}
+                            alt={`Logo ${navigation.brand}`}
+                            className="h-10 w-10 rounded-full object-cover border border-white/30 bg-white/10"
+                        />
+                        <span className="text-2xl font-bold">{navigation.brand}</span>
+                    </div>
                     <button
                         onClick={() => navigate('/login')}
                         className="flex items-center gap-2 text-sm font-medium transition hover:opacity-80"


### PR DESCRIPTION
## Summary
- ajoute le logo de la marque dans l'entête de la page de commande client
- applique un fond sombre aux lignes d'historique de commande
- renforce le contraste et la visibilité des filtres de catégories

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dd8a87ee64832a92989e87f53a82b9