### PR TITLE
Handle null site content during initial load

### DIFF
--- a/hooks/useSiteContent.ts
+++ b/hooks/useSiteContent.ts
@@ -3,8 +3,10 @@ import { SiteContent } from '../types';
 import { api } from '../services/api';
 import { DEFAULT_SITE_CONTENT, resolveSiteContent } from '../utils/siteContent';
 
+let lastResolvedContent: SiteContent | null = null;
+
 interface UseSiteContentResult {
-  content: SiteContent;
+  content: SiteContent | null;
   loading: boolean;
   error: string | null;
   refresh: () => Promise<void>;
@@ -12,7 +14,7 @@ interface UseSiteContentResult {
 }
 
 const useSiteContent = (): UseSiteContentResult => {
-  const [content, setContent] = useState<SiteContent>(DEFAULT_SITE_CONTENT);
+  const [content, setContent] = useState<SiteContent | null>(lastResolvedContent);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
@@ -20,10 +22,13 @@ const useSiteContent = (): UseSiteContentResult => {
     setLoading(true);
     try {
       const remote = await api.getSiteContent();
-      setContent(resolveSiteContent(remote ?? undefined));
+      const resolved = resolveSiteContent(remote ?? undefined);
+      lastResolvedContent = resolved;
+      setContent(resolved);
       setError(null);
     } catch (err) {
       console.error('Failed to fetch site content', err);
+      lastResolvedContent = DEFAULT_SITE_CONTENT;
       setContent(DEFAULT_SITE_CONTENT);
       setError(err instanceof Error ? err.message : 'Impossible de charger le contenu du site.');
     } finally {
@@ -35,6 +40,7 @@ const useSiteContent = (): UseSiteContentResult => {
     const updated = await api.updateSiteContent(next);
     const resolved = resolveSiteContent(updated);
     setContent(resolved);
+    lastResolvedContent = resolved;
     return resolved;
   }, []);
 

--- a/pages/CommandeClient.tsx
+++ b/pages/CommandeClient.tsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect, useMemo, useCallback } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { api } from '../services/api';
 import { uploadPaymentReceipt } from '../services/cloudinary';
-import { Product, Category, OrderItem, Order } from '../types';
+import { Product, Category, OrderItem, Order, SiteContent } from '../types';
 import Modal from '../components/Modal';
 import { ArrowLeft, ShoppingCart, Plus, Minus, X, Upload, MessageCircle, CheckCircle, History } from 'lucide-react';
 import CustomerOrderTracker from '../components/CustomerOrderTracker';
@@ -477,11 +477,29 @@ const CommandeClient: React.FC = () => {
     const navigate = useNavigate();
     const [activeOrder, setActiveOrder] = useState(() => getActiveCustomerOrder());
     const activeOrderId = activeOrder?.orderId ?? null;
-    const { content: siteContent } = useSiteContent();
-    const { hero, navigation, assets } = siteContent;
+    const { content: siteContent, loading: siteContentLoading } = useSiteContent();
+    const [content, setContent] = useState<SiteContent | null>(() => siteContent);
+
+    useEffect(() => {
+        if (siteContent) {
+            setContent(siteContent);
+        }
+    }, [siteContent]);
+
+    if (!content) {
+        return (
+            <div className="flex min-h-screen items-center justify-center bg-slate-50">
+                <p className="text-sm text-slate-500">
+                    {siteContentLoading ? 'Chargement du contenu du site…' : 'Initialisation du contenu du site…'}
+                </p>
+            </div>
+        );
+    }
+
+    const { hero, navigation, assets } = content;
     const brandLogo = navigation.brandLogo ?? '/logo-brand.svg';
 
-    useCustomFonts(assets.library);
+    useCustomFonts(assets.library ?? []);
 
     const heroBackgroundStyle = createHeroBackgroundStyle(hero.style, hero.backgroundImage);
     const navigationBackgroundStyle = createBackgroundStyle(navigation.style);

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -3,7 +3,7 @@ import { useAuth } from '../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import Modal from '../components/Modal';
 import { api } from '../services/api';
-import { EditableElementKey, EditableZoneKey, Product, Order } from '../types';
+import { EditableElementKey, EditableZoneKey, Product, Order, SiteContent } from '../types';
 import { Clock, Mail, MapPin, Menu, X, ChevronLeft, ChevronRight, Star, Quote } from 'lucide-react';
 import CustomerOrderTracker from '../components/CustomerOrderTracker';
 import { clearActiveCustomerOrder, getActiveCustomerOrder } from '../services/customerOrderStorage';
@@ -191,7 +191,25 @@ const Login: React.FC = () => {
   const pinInputRef = useRef<HTMLInputElement>(null);
   const { login } = useAuth();
   const navigate = useNavigate();
-  const { content: siteContent } = useSiteContent();
+  const { content: siteContent, loading: siteContentLoading } = useSiteContent();
+  const [content, setContent] = useState<SiteContent | null>(() => siteContent);
+  useEffect(() => {
+    if (siteContent) {
+      setContent(siteContent);
+    }
+  }, [siteContent]);
+  useCustomFonts(content?.assets.library ?? []);
+
+  if (!content) {
+    return (
+      <div className="flex min-h-screen items-center justify-center bg-slate-50">
+        <p className="text-sm text-slate-500">
+          {siteContentLoading ? 'Chargement du contenu du site…' : 'Initialisation du contenu du site…'}
+        </p>
+      </div>
+    );
+  }
+
   const {
     navigation,
     hero,
@@ -200,8 +218,7 @@ const Login: React.FC = () => {
     instagramReviews: instagramReviewContent,
     findUs,
     footer,
-  } = siteContent;
-  useCustomFonts(siteContent.assets.library);
+  } = content;
   const brandLogo = navigation.brandLogo ?? DEFAULT_BRAND_LOGO;
   const staffTriggerLogo = navigation.brandLogo ?? DEFAULT_BRAND_LOGO;
   const navigationBackgroundStyle = createBackgroundStyle(navigation.style);
@@ -221,7 +238,7 @@ const Login: React.FC = () => {
   const footerBackgroundStyle = createBackgroundStyle(footer.style);
   const footerTextStyle = createBodyTextStyle(footer.style);
 
-  const elementStyles = siteContent.elementStyles ?? {};
+  const elementStyles = content.elementStyles ?? {};
   const zoneStyleMap: Record<EditableZoneKey, typeof navigation.style> = {
     navigation: navigation.style,
     hero: hero.style,
@@ -249,7 +266,7 @@ const Login: React.FC = () => {
     return createElementBackgroundStyle(zoneStyleMap[zone], getElementStyle(key));
   };
 
-  const elementRichText = siteContent.elementRichText ?? {};
+  const elementRichText = content.elementRichText ?? {};
 
   const getRichTextHtml = (key: EditableElementKey): string | null => {
     const entry = elementRichText[key];

--- a/pages/SiteCustomization.tsx
+++ b/pages/SiteCustomization.tsx
@@ -1162,7 +1162,9 @@ const BackgroundElementEditor: React.FC<BackgroundElementEditorProps> = ({
 
 const SiteCustomization: React.FC = () => {
   const { content, loading, error, updateContent } = useSiteContent();
-  const [draft, setDraft] = useState<SiteContent>(content);
+  const [draft, setDraft] = useState<SiteContent | null>(() =>
+    content ? cloneSiteContent(content) : null,
+  );
   const [activeElement, setActiveElement] = useState<EditableElementKey | null>(null);
   const [activeZone, setActiveZone] = useState<EditableZoneKey | null>(null);
   const [activeTab, setActiveTab] = useState<TabId>('custom');
@@ -1175,7 +1177,9 @@ const SiteCustomization: React.FC = () => {
   const [bestSellerError, setBestSellerError] = useState<string | null>(null);
 
   useEffect(() => {
-    setDraft(content);
+    if (content) {
+      setDraft(cloneSiteContent(content));
+    }
   }, [content]);
 
   useEffect(() => {
@@ -1220,6 +1224,9 @@ const SiteCustomization: React.FC = () => {
   const applyDraftUpdate = useCallback(
     (updater: DraftUpdater) => {
       setDraft(prev => {
+        if (!prev) {
+          return prev;
+        }
         const clone = cloneSiteContent(prev);
         return updater(clone);
       });
@@ -1229,6 +1236,9 @@ const SiteCustomization: React.FC = () => {
 
   const appendAssetToDraft = useCallback((asset: CustomizationAsset) => {
     setDraft(prev => {
+      if (!prev) {
+        return prev;
+      }
       const clone = cloneSiteContent(prev);
       appendAsset(clone, asset);
       return clone;
@@ -1258,6 +1268,9 @@ const SiteCustomization: React.FC = () => {
     setSaveError(null);
     setSaveSuccess(null);
     try {
+      if (!draft) {
+        throw new Error('Le brouillon est indisponible.');
+      }
       const updated = await updateContent(draft);
       setDraft(updated);
       setSaveSuccess('Modifications enregistrées avec succès.');
@@ -1272,11 +1285,14 @@ const SiteCustomization: React.FC = () => {
 
   const fontOptions = useMemo(() => {
     const base = Array.from(FONT_FAMILY_SUGGESTIONS);
+    if (!draft) {
+      return base;
+    }
     const custom = draft.assets.library
       .filter(asset => asset.type === 'font')
       .map(asset => sanitizeFontFamilyName(asset.name));
     return Array.from(new Set([...base, ...custom]));
-  }, [draft.assets.library]);
+  }, [draft]);
 
   const activeLabel = activeElement ? ELEMENT_LABELS[activeElement] ?? activeElement : null;
   const elementType = activeElement
@@ -1294,6 +1310,15 @@ const SiteCustomization: React.FC = () => {
       <div className="flex h-full min-h-[60vh] flex-col items-center justify-center gap-3">
         <Loader2 className="h-10 w-10 animate-spin text-brand-primary" aria-hidden="true" />
         <p className="text-sm text-slate-500">Chargement du contenu du site…</p>
+      </div>
+    );
+  }
+
+  if (!content || !draft) {
+    return (
+      <div className="flex h-full min-h-[60vh] flex-col items-center justify-center gap-3">
+        <AlertTriangle className="h-6 w-6 text-amber-500" aria-hidden="true" />
+        <p className="text-sm text-slate-500">Le contenu du site est en cours d'initialisation…</p>
       </div>
     );
   }


### PR DESCRIPTION
## Summary
- initialize the site content hook with a cached value or null so that default styles only appear on genuine errors
- wait for site content before computing themed styles on the login and customer order pages, falling back to a loading indicator otherwise
- delay SiteCustomization draft creation until content is ready and harden draft updates and saves against null content

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dd8e7f80d4832aa66d5a4480eba975