### PR TITLE
Refactor routing to expose public login entrypoint

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -14,71 +14,143 @@ import CommandeClient from './pages/CommandeClient';
 import NotFound from './pages/NotFound';
 import ResumeVentes from './pages/ResumeVentes';
 import SiteCustomization from './pages/SiteCustomization';
-import { NAV_LINKS, SITE_CUSTOMIZER_PERMISSION_KEY } from './constants';
+import { SITE_CUSTOMIZER_PERMISSION_KEY } from './constants';
+import { getHomeRedirectPath, isPermissionGranted } from './utils/navigation';
 
-const isPermissionGranted = (permission?: string) =>
-  permission === 'editor' || permission === 'readonly';
+const LoadingScreen: React.FC = () => (
+  <div className="flex items-center justify-center h-screen">
+    <div className="animate-spin rounded-full h-32 w-32 border-b-2 border-brand-primary" />
+  </div>
+);
 
-const PrivateRoute: React.FC<{ children: React.ReactElement; permissionKey?: string }> = ({ children, permissionKey }) => {
+const PrivateRoute: React.FC<{ children: React.ReactElement; permissionKey?: string }> = ({
+  children,
+  permissionKey,
+}) => {
   const { role, loading } = useAuth();
+
   if (loading) {
-    return <div className="flex items-center justify-center h-screen"><div className="animate-spin rounded-full h-32 w-32 border-b-2 border-brand-primary"></div></div>;
+    return <LoadingScreen />;
   }
-  const permission = permissionKey ? role?.permissions[permissionKey] : undefined;
+
+  if (!role) {
+    return <Navigate to="/" replace />;
+  }
+
+  const permission = permissionKey ? role.permissions?.[permissionKey] : undefined;
   const hasPermission = permissionKey ? isPermissionGranted(permission) : true;
-  return role && hasPermission ? children : <Navigate to="/login" replace />;
+
+  if (!hasPermission) {
+    return <Navigate to={getHomeRedirectPath(role)} replace />;
+  }
+
+  return children;
 };
 
-const AppRoutes: React.FC = () => {
-    const { role } = useAuth();
+const RootRoute: React.FC = () => {
+  const { role, loading } = useAuth();
 
-    const getHomeRedirect = () => {
-        if (!role) return '/login';
+  if (loading) {
+    return <LoadingScreen />;
+  }
 
-        if (role.homePage && isPermissionGranted(role.permissions[role.homePage])) {
-            return role.homePage;
-        }
+  if (!role) {
+    return <Login />;
+  }
 
-        const fallbackLink = NAV_LINKS.find(link => isPermissionGranted(role.permissions[link.permissionKey]));
-        if (fallbackLink) {
-            return fallbackLink.href;
-        }
-        return '/login';
-    };
-
-    return (
-        <Routes>
-            <Route path="/login" element={<Login />} />
-            <Route path="/commande-client" element={<CommandeClient />} />
-            
-            <Route path="/" element={
-                <PrivateRoute>
-                    <ProtectedLayout />
-                </PrivateRoute>
-            }>
-                <Route index element={<Navigate to={getHomeRedirect()} replace />} />
-                <Route path="dashboard" element={<PrivateRoute permissionKey="/dashboard"><Dashboard /></PrivateRoute>} />
-                <Route path="para-llevar" element={<PrivateRoute permissionKey="/para-llevar"><ParaLlevar /></PrivateRoute>} />
-                <Route path="ventes" element={<PrivateRoute permissionKey="/ventes"><Ventes /></PrivateRoute>} />
-                <Route path="commande/:tableId" element={<PrivateRoute permissionKey="/ventes"><Commande /></PrivateRoute>} />
-                <Route path="cocina" element={<PrivateRoute permissionKey="/cocina"><Cuisine /></PrivateRoute>} />
-                <Route path="resume-ventes" element={<PrivateRoute permissionKey="/resume-ventes"><ResumeVentes /></PrivateRoute>} />
-                <Route path="ingredients" element={<PrivateRoute permissionKey="/ingredients"><Ingredients /></PrivateRoute>} />
-                <Route path="produits" element={<PrivateRoute permissionKey="/produits"><Produits /></PrivateRoute>} />
-                <Route
-                  path={SITE_CUSTOMIZER_PERMISSION_KEY.slice(1)}
-                  element={
-                    <PrivateRoute permissionKey={SITE_CUSTOMIZER_PERMISSION_KEY}>
-                      <SiteCustomization />
-                    </PrivateRoute>
-                  }
-                />
-            </Route>
-            
-            <Route path="*" element={<NotFound />} />
-        </Routes>
-    );
+  return <Navigate to={getHomeRedirectPath(role)} replace />;
 };
+
+const ProtectedAppShell: React.FC = () => (
+  <PrivateRoute>
+    <ProtectedLayout />
+  </PrivateRoute>
+);
+
+const AppRoutes: React.FC = () => (
+  <Routes>
+    <Route path="/" element={<RootRoute />} />
+    <Route path="/login" element={<Navigate to="/" replace />} />
+    <Route path="/commande-client" element={<CommandeClient />} />
+
+    <Route element={<ProtectedAppShell />}>
+      <Route
+        path="/dashboard"
+        element={
+          <PrivateRoute permissionKey="/dashboard">
+            <Dashboard />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/para-llevar"
+        element={
+          <PrivateRoute permissionKey="/para-llevar">
+            <ParaLlevar />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/ventes"
+        element={
+          <PrivateRoute permissionKey="/ventes">
+            <Ventes />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/commande/:tableId"
+        element={
+          <PrivateRoute permissionKey="/ventes">
+            <Commande />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/cocina"
+        element={
+          <PrivateRoute permissionKey="/cocina">
+            <Cuisine />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/resume-ventes"
+        element={
+          <PrivateRoute permissionKey="/resume-ventes">
+            <ResumeVentes />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/ingredients"
+        element={
+          <PrivateRoute permissionKey="/ingredients">
+            <Ingredients />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path="/produits"
+        element={
+          <PrivateRoute permissionKey="/produits">
+            <Produits />
+          </PrivateRoute>
+        }
+      />
+      <Route
+        path={SITE_CUSTOMIZER_PERMISSION_KEY}
+        element={
+          <PrivateRoute permissionKey={SITE_CUSTOMIZER_PERMISSION_KEY}>
+            <SiteCustomization />
+          </PrivateRoute>
+        }
+      />
+    </Route>
+
+    <Route path="*" element={<NotFound />} />
+  </Routes>
+);
 
 
 const App: React.FC = () => {

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -26,7 +26,7 @@ const Sidebar: React.FC<SidebarProps> = ({ isOpen, onClose, notifications, onRep
 
   const handleLogout = () => {
     logout();
-    navigate('/login');
+    navigate('/');
   };
 
   const permissions = role?.permissions;

--- a/contexts/AuthContext.tsx
+++ b/contexts/AuthContext.tsx
@@ -6,7 +6,7 @@ import { api } from '../services/api';
 interface AuthContextType {
   role: Role | null;
   loading: boolean;
-  login: (pin: string) => Promise<void>;
+  login: (pin: string) => Promise<Role>;
   logout: () => void;
   refreshRole: () => Promise<void>;
 }
@@ -65,17 +65,19 @@ export const AuthProvider: React.FC<{ children: React.ReactNode }> = ({ children
     loadRoleFromStorage();
   }, []);
 
-  const login = useCallback(async (pin: string) => {
+  const login = useCallback(async (pin: string): Promise<Role> => {
     setLoading(true);
     try {
       const userRole = await api.loginWithPin(pin);
-      if (userRole) {
-        setRole(userRole);
-        localStorage.setItem('oui-oui-tacos-role', JSON.stringify(userRole));
-        localStorage.setItem('oui-oui-tacos-session', JSON.stringify({ roleId: userRole.id, authenticatedAt: Date.now() }));
-      } else {
-        throw new Error("PIN invalide");
+      if (!userRole) {
+        throw new Error('PIN invalide');
       }
+
+      setRole(userRole);
+      localStorage.setItem('oui-oui-tacos-role', JSON.stringify(userRole));
+      localStorage.setItem('oui-oui-tacos-session', JSON.stringify({ roleId: userRole.id, authenticatedAt: Date.now() }));
+
+      return userRole;
     } finally {
       setLoading(false);
     }

--- a/pages/CommandeClient.tsx
+++ b/pages/CommandeClient.tsx
@@ -531,7 +531,7 @@ const CommandeClient: React.FC = () => {
                         <span className="text-2xl font-bold">{navigation.brand}</span>
                     </div>
                     <button
-                        onClick={() => navigate('/login')}
+                        onClick={() => navigate('/')}
                         className="flex items-center gap-2 text-sm font-medium transition hover:opacity-80"
                         style={navigationTextStyle}
                     >

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -20,6 +20,7 @@ import {
   createTextStyle,
 } from '../utils/siteStyleHelpers';
 import { resolveZoneFromElement } from '../components/SitePreviewCanvas';
+import { getHomeRedirectPath } from '../utils/navigation';
 
 const DEFAULT_BRAND_LOGO = '/logo-brand.svg';
 
@@ -334,8 +335,8 @@ const Login: React.FC = () => {
     setError('');
     setLoading(true);
     try {
-      await login(pinToSubmit);
-      navigate('/');
+      const authenticatedRole = await login(pinToSubmit);
+      navigate(getHomeRedirectPath(authenticatedRole));
     } catch (err: any) {
       setError(err.message || 'PIN invalide. Veuillez réessayer.');
       setPin('');

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -1,0 +1,29 @@
+import { NAV_LINKS } from '../constants';
+import { Role } from '../types';
+
+type PermissionValue = Role['permissions'][string] | undefined;
+
+export const isPermissionGranted = (permission?: PermissionValue): boolean =>
+  permission === 'editor' || permission === 'readonly';
+
+export const getHomeRedirectPath = (role: Role | null): string => {
+  if (!role) {
+    return '/';
+  }
+
+  const { homePage, permissions } = role;
+
+  if (homePage && isPermissionGranted(permissions?.[homePage])) {
+    return homePage;
+  }
+
+  const fallbackLink = NAV_LINKS.find(link =>
+    isPermissionGranted(permissions?.[link.permissionKey]),
+  );
+
+  if (fallbackLink) {
+    return fallbackLink.href;
+  }
+
+  return '/';
+};


### PR DESCRIPTION
## Summary
- route the public homepage to the login view when no staff session is available
- guard the protected layout and child pages with a reusable auth gate and shared navigation helper
- update login/logout flows to redirect users to their assigned staff homepage

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dda97a8678832a85abbc9ea5c3f4fe