### PR TITLE
Call custom font hook before content guard in CommandeClient

### DIFF
--- a/pages/CommandeClient.tsx
+++ b/pages/CommandeClient.tsx
@@ -486,6 +486,9 @@ const CommandeClient: React.FC = () => {
         }
     }, [siteContent]);
 
+    const assetsLibrary = content?.assets.library ?? [];
+    useCustomFonts(assetsLibrary);
+
     if (!content) {
         return (
             <div className="flex min-h-screen items-center justify-center bg-slate-50">
@@ -499,7 +502,6 @@ const CommandeClient: React.FC = () => {
     const { hero, navigation, assets } = content;
     const brandLogo = navigation.brandLogo ?? '/logo-brand.svg';
 
-    useCustomFonts(assets.library ?? []);
 
     const heroBackgroundStyle = createHeroBackgroundStyle(hero.style, hero.backgroundImage);
     const navigationBackgroundStyle = createBackgroundStyle(navigation.style);


### PR DESCRIPTION
## Summary
- ensure the custom font loading hook runs on every render of CommandeClient
- keep the content guard in place by moving the hook ahead of the early return

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_b_68ddbe0dc590832a8fa358f1526c9bb6