### PR TITLE
Handle missing home redirect by showing no-access screen

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -16,6 +16,7 @@ import ResumeVentes from './pages/ResumeVentes';
 import SiteCustomization from './pages/SiteCustomization';
 import { SITE_CUSTOMIZER_PERMISSION_KEY } from './constants';
 import { getHomeRedirectPath, isPermissionGranted } from './utils/navigation';
+import NoAccess from './components/NoAccess';
 
 const LoadingScreen: React.FC = () => (
   <div className="flex items-center justify-center h-screen">
@@ -27,7 +28,7 @@ const PrivateRoute: React.FC<{ children: React.ReactElement; permissionKey?: str
   children,
   permissionKey,
 }) => {
-  const { role, loading } = useAuth();
+  const { role, loading, logout } = useAuth();
 
   if (loading) {
     return <LoadingScreen />;
@@ -41,14 +42,19 @@ const PrivateRoute: React.FC<{ children: React.ReactElement; permissionKey?: str
   const hasPermission = permissionKey ? isPermissionGranted(permission) : true;
 
   if (!hasPermission) {
-    return <Navigate to={getHomeRedirectPath(role)} replace />;
+    const redirectPath = getHomeRedirectPath(role);
+    if (redirectPath) {
+      return <Navigate to={redirectPath} replace />;
+    }
+
+    return <NoAccess onLogout={logout} />;
   }
 
   return children;
 };
 
 const RootRoute: React.FC = () => {
-  const { role, loading } = useAuth();
+  const { role, loading, logout } = useAuth();
 
   if (loading) {
     return <LoadingScreen />;
@@ -58,7 +64,12 @@ const RootRoute: React.FC = () => {
     return <Login />;
   }
 
-  return <Navigate to={getHomeRedirectPath(role)} replace />;
+  const redirectPath = getHomeRedirectPath(role);
+  if (!redirectPath) {
+    return <NoAccess onLogout={logout} />;
+  }
+
+  return <Navigate to={redirectPath} replace />;
 };
 
 const ProtectedAppShell: React.FC = () => (

--- a/components/NoAccess.tsx
+++ b/components/NoAccess.tsx
@@ -1,0 +1,39 @@
+import React from 'react';
+import { useNavigate } from 'react-router-dom';
+
+interface NoAccessProps {
+  onLogout?: () => void;
+}
+
+const NoAccess: React.FC<NoAccessProps> = ({ onLogout }) => {
+  const navigate = useNavigate();
+
+  const handleReturnToLogin = React.useCallback(() => {
+    if (onLogout) {
+      onLogout();
+    }
+
+    navigate('/login', { replace: true });
+  }, [navigate, onLogout]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center gap-6 px-4 text-center">
+      <div className="space-y-4">
+        <h1 className="text-3xl font-semibold text-gray-900">Accès non autorisé</h1>
+        <p className="text-base text-gray-600">
+          Votre rôle ne dispose actuellement d'aucune page accessible. Veuillez contacter un administrateur
+          ou revenir à l'écran de connexion.
+        </p>
+      </div>
+      <button
+        type="button"
+        onClick={handleReturnToLogin}
+        className="rounded-md bg-brand-primary px-6 py-3 text-white transition hover:bg-brand-primary/90 focus:outline-none focus:ring-2 focus:ring-brand-primary focus:ring-offset-2"
+      >
+        Retour à la connexion
+      </button>
+    </div>
+  );
+};
+
+export default NoAccess;

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -336,7 +336,8 @@ const Login: React.FC = () => {
     setLoading(true);
     try {
       const authenticatedRole = await login(pinToSubmit);
-      navigate(getHomeRedirectPath(authenticatedRole));
+      const redirectPath = getHomeRedirectPath(authenticatedRole);
+      navigate(redirectPath ?? '/');
     } catch (err: any) {
       setError(err.message || 'PIN invalide. Veuillez réessayer.');
       setPin('');

--- a/utils/navigation.ts
+++ b/utils/navigation.ts
@@ -6,9 +6,9 @@ type PermissionValue = Role['permissions'][string] | undefined;
 export const isPermissionGranted = (permission?: PermissionValue): boolean =>
   permission === 'editor' || permission === 'readonly';
 
-export const getHomeRedirectPath = (role: Role | null): string => {
+export const getHomeRedirectPath = (role: Role | null): string | null => {
   if (!role) {
-    return '/';
+    return null;
   }
 
   const { homePage, permissions } = role;
@@ -25,5 +25,5 @@ export const getHomeRedirectPath = (role: Role | null): string => {
     return fallbackLink.href;
   }
 
-  return '/';
+  return null;
 };


### PR DESCRIPTION
## Summary
- allow `getHomeRedirectPath` to return `null` when no accessible destinations exist
- show a reusable `NoAccess` screen from root/private routes when a role lacks permissions and provide a logout CTA
- guard login navigation against missing home redirects by falling back to the root route

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68de40dda174832a8f333d195abf6594