### PR TITLE
Remove CDN import map overrides

### DIFF
--- a/index.html
+++ b/index.html
@@ -27,18 +27,6 @@
       };
     </script>
     <script src="https://cdn.tailwindcss.com"></script>
-    <script type="importmap">
-      {
-        "imports": {
-          "react": "https://aistudiocdn.com/react@^19.1.1",
-          "react-dom/": "https://aistudiocdn.com/react-dom@^19.1.1/",
-          "react/": "https://aistudiocdn.com/react@^19.1.1/",
-          "react-router-dom": "https://aistudiocdn.com/react-router-dom@^7.9.1",
-          "lucide-react": "https://aistudiocdn.com/lucide-react@^0.544.0",
-          "recharts": "https://aistudiocdn.com/recharts@^3.2.1"
-        }
-      }
-    </script>
   </head>
   <body>
     <div id="root"></div>


### PR DESCRIPTION
## Summary
- remove the import map in `index.html` that forced React-related packages to load from aistudiocdn.com
- verified there are no remaining references to the CDN overrides
- built the project and ran `npm run preview` to confirm the app serves without module resolution errors

## Testing
- npm run build
- npm run preview

------
https://chatgpt.com/codex/tasks/task_b_68de42b0255c832a945c0dcd98175bcc