### PR TITLE
feat: enable detailed instagram review customization

### DIFF
--- a/components/SitePreviewCanvas.tsx
+++ b/components/SitePreviewCanvas.tsx
@@ -1,6 +1,12 @@
 import React from 'react';
 import { ChevronLeft, ChevronRight, Clock, Edit2, Mail, MapPin, Quote, Star } from 'lucide-react';
-import { EditableElementKey, EditableZoneKey, Product, SiteContent } from '../types';
+import {
+  EditableElementKey,
+  EditableZoneKey,
+  INSTAGRAM_REVIEW_IDS,
+  Product,
+  SiteContent,
+} from '../types';
 import useCustomFonts from '../hooks/useCustomFonts';
 import {
   createBackgroundStyle,
@@ -11,9 +17,12 @@ import {
   createHeroBackgroundStyle,
   createTextStyle,
 } from '../utils/siteStyleHelpers';
+import { DEFAULT_SITE_CONTENT } from '../utils/siteContent';
 import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
 
 const DEFAULT_BRAND_LOGO = '/logo-brand.svg';
+const DEFAULT_REVIEW_HIGHLIGHT_IMAGE = 'https://picsum.photos/seed/reviewpreview/160/160';
+const DEFAULT_REVIEW_POST_IMAGE = 'https://picsum.photos/seed/reviewpreview/320/320';
 
 export const resolveZoneFromElement = (element: EditableElementKey): EditableZoneKey => {
   if (element.startsWith('navigation.')) {
@@ -164,6 +173,35 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
   const menuBodyTextStyle = createBodyTextStyle(content.menu.style);
   const instagramReviewsBackgroundStyle = createBackgroundStyle(content.instagramReviews.style);
   const instagramReviewsTextStyle = createTextStyle(content.instagramReviews.style);
+  const instagramReviewDefaults = DEFAULT_SITE_CONTENT.instagramReviews.reviews;
+  const instagramReviewCards = INSTAGRAM_REVIEW_IDS.map(reviewId => {
+    const review = content.instagramReviews.reviews[reviewId] ?? instagramReviewDefaults[reviewId];
+    const fallback = instagramReviewDefaults[reviewId];
+    const avatarUrl = review.avatarUrl ?? fallback.avatarUrl;
+    const highlightImageUrl =
+      review.highlightImageUrl ??
+      review.postImageUrl ??
+      content.instagramReviews.image ??
+      fallback.highlightImageUrl ??
+      fallback.postImageUrl ??
+      DEFAULT_REVIEW_HIGHLIGHT_IMAGE;
+    const postImageUrl =
+      review.postImageUrl ??
+      content.instagramReviews.image ??
+      fallback.postImageUrl ??
+      DEFAULT_REVIEW_POST_IMAGE;
+    const postImageAlt = review.postImageAlt.trim().length > 0 ? review.postImageAlt : fallback.postImageAlt;
+    const badgeLabel = review.badgeLabel.trim().length > 0 ? review.badgeLabel : fallback.badgeLabel;
+    return {
+      reviewId,
+      review,
+      avatarUrl,
+      highlightImageUrl,
+      postImageUrl,
+      postImageAlt,
+      badgeLabel,
+    };
+  });
   const findUsBackgroundStyle = createBackgroundStyle(content.findUs.style);
   const findUsTextStyle = createTextStyle(content.findUs.style);
   const footerBackgroundStyle = createBackgroundStyle(content.footer.style);
@@ -750,54 +788,240 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
               </div>
               <div className="reviews-carousel">
                 <div className="reviews-track">
-                  <article className="review-card" aria-hidden={false}>
-                    <div className="review-card__content">
-                      <header className="review-card__header">
-                        <span className="review-card__avatar" aria-hidden="true">
-                          <img src="https://i.pravatar.cc/96?img=12" alt="" />
-                        </span>
-                        <div className="review-card__meta">
-                          <p className="review-card__name">Camila G.</p>
-                          <p className="review-card__handle">@camilafoodie • il y a 2 jours</p>
-                        </div>
-                        <span className="review-card__badge">Instagram</span>
-                      </header>
-                      <div className="review-card__stars" aria-label="Note 5 sur 5">
-                        {Array.from({ length: 5 }).map((_, index) => (
-                          <Star key={index} aria-hidden="true" />
-                        ))}
-                      </div>
-                      <blockquote className="review-card__quote">
-                        <Quote aria-hidden="true" className="review-card__quote-icon" />
-                        <p>
-                          "Des portions généreuses et des sauces incroyables. On sent que tout est préparé avec passion, vivement la prochaine commande !"
-                        </p>
-                      </blockquote>
-                      <div className="review-card__footer">
-                        <div className="review-card__highlight">
-                          <span className="review-card__story-ring" aria-hidden="true">
-                            <img
-                              src={content.instagramReviews.image ?? 'https://picsum.photos/seed/reviewpreview/160/160'}
-                              alt=""
-                            />
-                          </span>
-                          <div>
-                            <p className="review-card__highlight-title">Story highlight</p>
-                            <p className="review-card__highlight-caption">5 étoiles assurées ✨</p>
+                  {instagramReviewCards.map((card, index) => {
+                    const baseKey = `instagramReviews.reviews.${card.reviewId}` as EditableElementKey;
+                    const nameKey = `${baseKey}.name` as EditableElementKey;
+                    const handleKey = `${baseKey}.handle` as EditableElementKey;
+                    const timeKey = `${baseKey}.timeAgo` as EditableElementKey;
+                    const badgeKey = `${baseKey}.badgeLabel` as EditableElementKey;
+                    const messageKey = `${baseKey}.message` as EditableElementKey;
+                    const highlightKey = `${baseKey}.highlight` as EditableElementKey;
+                    const highlightCaptionKey = `${baseKey}.highlightCaption` as EditableElementKey;
+                    const locationKey = `${baseKey}.location` as EditableElementKey;
+                    const avatarKey = `${baseKey}.avatarUrl` as EditableElementKey;
+                    const highlightImageKey = `${baseKey}.highlightImageUrl` as EditableElementKey;
+                    const postImageKey = `${baseKey}.postImageUrl` as EditableElementKey;
+                    const postImageAltKey = `${baseKey}.postImageAlt` as EditableElementKey;
+                    const avatarUrl = card.avatarUrl ?? 'https://i.pravatar.cc/96?img=12';
+                    const highlightImageUrl = card.highlightImageUrl ?? DEFAULT_REVIEW_HIGHLIGHT_IMAGE;
+                    const postImageUrl = card.postImageUrl ?? DEFAULT_REVIEW_POST_IMAGE;
+                    return (
+                      <article key={card.reviewId} className="review-card" aria-hidden={index !== 0}>
+                        <div className="review-card__content">
+                          <header className="review-card__header">
+                            <EditableElement
+                              id={avatarKey}
+                              label={`Modifier la photo de profil de l'avis ${index + 1}`}
+                              onEdit={onEdit}
+                              className="review-card__avatar"
+                              buttonClassName="-left-3 -top-3"
+                              as="span"
+                            >
+                              <img src={avatarUrl} alt="" />
+                            </EditableElement>
+                            <div className="review-card__meta">
+                              <EditableElement
+                                id={nameKey}
+                                label={`Modifier le nom de l'avis ${index + 1}`}
+                                onEdit={onEdit}
+                                className="block"
+                                buttonClassName="right-0 -top-3"
+                              >
+                                {renderRichTextElement(
+                                  nameKey,
+                                  'p',
+                                  {
+                                    className: 'review-card__name',
+                                    style: getElementTextStyle(nameKey),
+                                  },
+                                  card.review.name,
+                                )}
+                              </EditableElement>
+                              <p className="review-card__handle">
+                                <EditableElement
+                                  id={handleKey}
+                                  label={`Modifier le pseudo de l'avis ${index + 1}`}
+                                  onEdit={onEdit}
+                                  className="inline"
+                                  buttonClassName="-left-3 -top-3"
+                                  as="span"
+                                >
+                                  {renderRichTextElement(
+                                    handleKey,
+                                    'span',
+                                    {
+                                      className: 'inline-flex items-center',
+                                      style: getElementBodyTextStyle(handleKey),
+                                    },
+                                    card.review.handle,
+                                  )}
+                                </EditableElement>
+                                <span className="mx-1 text-slate-400" aria-hidden="true">
+                                  •
+                                </span>
+                                <EditableElement
+                                  id={timeKey}
+                                  label={`Modifier le délai de publication de l'avis ${index + 1}`}
+                                  onEdit={onEdit}
+                                  className="inline"
+                                  buttonClassName="-right-3 -top-3"
+                                  as="span"
+                                >
+                                  {renderRichTextElement(
+                                    timeKey,
+                                    'span',
+                                    {
+                                      className: 'inline-flex items-center',
+                                      style: getElementBodyTextStyle(timeKey),
+                                    },
+                                    card.review.timeAgo,
+                                  )}
+                                </EditableElement>
+                              </p>
+                            </div>
+                            <EditableElement
+                              id={badgeKey}
+                              label={`Modifier le badge de l'avis ${index + 1}`}
+                              onEdit={onEdit}
+                              className="review-card__badge"
+                              buttonClassName="-right-3 -top-3"
+                              as="span"
+                            >
+                              {renderRichTextElement(
+                                badgeKey,
+                                'span',
+                                {
+                                  className: 'review-card__badge',
+                                  style: getElementTextStyle(badgeKey),
+                                },
+                                card.badgeLabel,
+                              )}
+                            </EditableElement>
+                          </header>
+                          <div className="review-card__stars" aria-label="Note 5 sur 5">
+                            {Array.from({ length: 5 }).map((_, starIndex) => (
+                              <Star key={starIndex} aria-hidden="true" />
+                            ))}
+                          </div>
+                          <blockquote className="review-card__quote">
+                            <Quote aria-hidden="true" className="review-card__quote-icon" />
+                            <EditableElement
+                              id={messageKey}
+                              label={`Modifier le message de l'avis ${index + 1}`}
+                              onEdit={onEdit}
+                              className="mt-2 block"
+                              buttonClassName="right-0 -top-3"
+                            >
+                              {renderRichTextElement(
+                                messageKey,
+                                'p',
+                                {
+                                  style: getElementBodyTextStyle(messageKey),
+                                },
+                                card.review.message,
+                              )}
+                            </EditableElement>
+                          </blockquote>
+                          <div className="review-card__footer">
+                            <div className="review-card__highlight">
+                              <EditableElement
+                                id={highlightImageKey}
+                                label={`Modifier l'image de story de l'avis ${index + 1}`}
+                                onEdit={onEdit}
+                                className="review-card__story-ring"
+                                buttonClassName="-left-3 -top-3"
+                                as="span"
+                              >
+                                <img src={highlightImageUrl} alt="" />
+                              </EditableElement>
+                              <div>
+                                <EditableElement
+                                  id={highlightKey}
+                                  label={`Modifier le titre du highlight ${index + 1}`}
+                                  onEdit={onEdit}
+                                  className="block"
+                                  buttonClassName="right-0 -top-3"
+                                >
+                                  {renderRichTextElement(
+                                    highlightKey,
+                                    'p',
+                                    {
+                                      className: 'review-card__highlight-title',
+                                      style: getElementTextStyle(highlightKey),
+                                    },
+                                    card.review.highlight,
+                                  )}
+                                </EditableElement>
+                                <EditableElement
+                                  id={highlightCaptionKey}
+                                  label={`Modifier la légende du highlight ${index + 1}`}
+                                  onEdit={onEdit}
+                                  className="block"
+                                  buttonClassName="right-0 -top-3"
+                                >
+                                  {renderRichTextElement(
+                                    highlightCaptionKey,
+                                    'p',
+                                    {
+                                      className: 'review-card__highlight-caption',
+                                      style: getElementBodyTextStyle(highlightCaptionKey),
+                                    },
+                                    card.review.highlightCaption,
+                                  )}
+                                </EditableElement>
+                              </div>
+                            </div>
+                            <EditableElement
+                              id={locationKey}
+                              label={`Modifier la localisation de l'avis ${index + 1}`}
+                              onEdit={onEdit}
+                              className="block"
+                              buttonClassName="right-0 -top-3"
+                            >
+                              {renderRichTextElement(
+                                locationKey,
+                                'p',
+                                {
+                                  className: 'review-card__location',
+                                  style: getElementBodyTextStyle(locationKey),
+                                },
+                                card.review.location,
+                              )}
+                            </EditableElement>
                           </div>
                         </div>
-                        <p className="review-card__location">Bogotá, CO</p>
-                      </div>
-                    </div>
-                    <div className="review-card__media">
-                      <span className="review-card__media-frame">
-                        <img
-                          src={content.instagramReviews.image ?? 'https://picsum.photos/seed/reviewpreview/320/320'}
-                          alt={content.instagramReviews.title}
-                        />
-                      </span>
-                    </div>
-                  </article>
+                        <div className="review-card__media">
+                          <EditableElement
+                            id={postImageKey}
+                            label={`Modifier l'image du post ${index + 1}`}
+                            onEdit={onEdit}
+                            className="review-card__media-frame"
+                            buttonClassName="-right-3 -top-3"
+                            as="span"
+                          >
+                            <img src={postImageUrl} alt={card.postImageAlt} />
+                          </EditableElement>
+                          <EditableElement
+                            id={postImageAltKey}
+                            label={`Modifier le texte alternatif de l'image ${index + 1}`}
+                            onEdit={onEdit}
+                            className="mt-3 block"
+                            buttonClassName="right-0 -top-3"
+                          >
+                            {renderRichTextElement(
+                              postImageAltKey,
+                              'p',
+                              {
+                                className: 'text-xs italic text-slate-500',
+                                style: getElementBodyTextStyle(postImageAltKey),
+                              },
+                              card.review.postImageAlt,
+                            )}
+                          </EditableElement>
+                        </div>
+                      </article>
+                    );
+                  })}
                 </div>
                 <div className="reviews-controls" aria-hidden="true">
                   <button type="button" className="reviews-control" disabled>

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -3,7 +3,15 @@ import { useAuth } from '../contexts/AuthContext';
 import { useNavigate } from 'react-router-dom';
 import Modal from '../components/Modal';
 import { api } from '../services/api';
-import { EditableElementKey, EditableZoneKey, Product, Order, SiteContent, SectionStyle } from '../types';
+import {
+  EditableElementKey,
+  EditableZoneKey,
+  Product,
+  Order,
+  SiteContent,
+  SectionStyle,
+  INSTAGRAM_REVIEW_IDS,
+} from '../types';
 import { Clock, Mail, MapPin, Menu, X, ChevronLeft, ChevronRight, Quote } from 'lucide-react';
 import CustomerOrderTracker from '../components/CustomerOrderTracker';
 import { clearActiveCustomerOrder, getActiveCustomerOrder } from '../services/customerOrderStorage';
@@ -21,6 +29,7 @@ import {
 } from '../utils/siteStyleHelpers';
 import { resolveZoneFromElement } from '../components/SitePreviewCanvas';
 import { getHomeRedirectPath } from '../utils/navigation';
+import { DEFAULT_SITE_CONTENT as BASE_SITE_CONTENT } from '../utils/siteContent';
 
 const DEFAULT_BRAND_LOGO = '/logo-brand.svg';
 
@@ -76,6 +85,26 @@ const DEFAULT_SITE_CONTENT: SiteContent = {
     subtitle: '',
     image: null,
     style: createDefaultSectionStyle(),
+    reviews: INSTAGRAM_REVIEW_IDS.reduce(
+      (acc, id) => {
+        acc[id] = {
+          name: '',
+          handle: '',
+          timeAgo: '',
+          message: '',
+          highlight: '',
+          highlightCaption: '',
+          location: '',
+          badgeLabel: '',
+          postImageAlt: '',
+          avatarUrl: null,
+          highlightImageUrl: null,
+          postImageUrl: null,
+        };
+        return acc;
+      },
+      {} as SiteContent['instagramReviews']['reviews'],
+    ),
   },
   findUs: {
     title: '',
@@ -98,79 +127,6 @@ const DEFAULT_SITE_CONTENT: SiteContent = {
     library: [],
   },
 };
-
-const INSTAGRAM_REVIEWS = [
-  {
-    id: 'review-laura',
-    name: 'Laura Méndez',
-    handle: '@laurita.eats',
-    avatarUrl: 'https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=320&q=80',
-    postImageUrl: 'https://images.unsplash.com/photo-1521305916504-4a1121188589?auto=format&fit=crop&w=640&q=80',
-    postImageAlt: "Assiette de tacos colorés garnis d'herbes fraîches.",
-    message:
-      'No puedo con la originalidad de estos tacos al pastor: cada mordisco tiene un giro gourmet brutal. La salsa cheddar queda cremosa sin empalagar y el toque crujiente lo es todo.',
-    highlight: 'Story « Taco Tuesday »',
-    highlightCaption: 'Guardado en Destacadas',
-    location: 'Bogotá · Servicio nocturno',
-    timeAgo: 'hace 2 días',
-  },
-  {
-    id: 'review-camila',
-    name: 'Camila Torres',
-    handle: '@camigoesout',
-    avatarUrl: 'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=320&q=80',
-    postImageUrl: 'https://images.unsplash.com/photo-1478145046317-39f10e56b5e9?auto=format&fit=crop&w=640&q=80',
-    postImageAlt: 'Gros plan sur des arepas dorées et une sauce maison.',
-    message:
-      'Estas arepas son lo más: combinan ingredientes súper frescos con un toque gourmet creativo. La mezcla dulce-salado y esa salsa cheddar para remojar me tuvieron feliz todo el brunch.',
-    highlight: 'Reel « Brunch entre amigas »',
-    highlightCaption: 'Comentarios llenos de antojos',
-    location: 'Medellín · Brunch de domingo',
-    timeAgo: 'hace 5 días',
-  },
-  {
-    id: 'review-sebastian',
-    name: 'Sebastián Ruiz',
-    handle: '@ruizhungry',
-    avatarUrl: 'https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=320&q=80',
-    postImageUrl: 'https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=640&q=80',
-    postImageAlt: 'Table conviviale avec plusieurs plats mexicains et des boissons fraîches.',
-    message:
-      'Armamos un afterwork aquí y fue un hit: combos originales, porciones generosas y un crunch brutal en cada bocado. La salsa cheddar se volvió tema de conversación.',
-    highlight: 'Post « Team Afterwork »',
-    highlightCaption: 'Reacciones de la oficina',
-    location: 'Barranquilla · Terraza privada',
-    timeAgo: 'hace 1 semana',
-  },
-  {
-    id: 'review-valentina',
-    name: 'Valentina Ríos',
-    handle: '@valen.foodnotes',
-    avatarUrl: 'https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?auto=format&fit=crop&w=320&q=80',
-    postImageUrl: 'https://images.unsplash.com/photo-1513104890138-7c749659a591?auto=format&fit=crop&w=640&q=80',
-    postImageAlt: 'Pizza gourmande avec fromage coulant et herbes fraîches.',
-    message:
-      'El menú tiene un mood gourmet sin perder lo reconfortante: masa crocante, cheddar fundido y combinaciones de ingredientes que se sienten pensadas con cariño. Increíble experiencia.',
-    highlight: 'Carousel « Night Out »',
-    highlightCaption: 'Comentarios fijados',
-    location: 'Cali · Cena casual',
-    timeAgo: 'hace 2 semanas',
-  },
-  {
-    id: 'review-alejandro',
-    name: 'Alejandro Pérez',
-    handle: '@alexlovesfood',
-    avatarUrl: 'https://images.unsplash.com/photo-1529665253569-6d01c0eaf7b6?auto=format&fit=crop&w=320&q=80',
-    postImageUrl: 'https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=640&q=80',
-    postImageAlt: 'Burger gourmet avec sauce et frites croustillantes.',
-    message:
-      'Vine por curiosidad y me quedé por la originalidad del menú: el cheddar baña la burger justo como me gusta y el pan crujiente aguanta toda la salsa. Asociaciones de sabores top.',
-    highlight: 'Live « Burger Night »',
-    highlightCaption: 'Chat lleno de elogios',
-    location: 'Bogotá · Servicio takeout',
-    timeAgo: 'hace 3 semanas',
-  },
-] as const;
 
 type PinInputProps = {
   pin: string;
@@ -408,12 +364,37 @@ const Login: React.FC = () => {
   const bestSellerCount = bestSellersToDisplay.length;
   const menuGridClassName = computeMenuGridClassName(bestSellerCount);
   const menuCardClassName = computeMenuCardClassName(bestSellerCount);
-  const instagramReviewSlides = INSTAGRAM_REVIEWS.map(review => {
-    const postImageUrl = instagramReviewContent.image ?? review.postImageUrl;
-    const postImageAlt = instagramReviewContent.image ? instagramReviewContent.title : review.postImageAlt;
+  const instagramReviewDefaults = BASE_SITE_CONTENT.instagramReviews.reviews;
+  const instagramReviewSlides = INSTAGRAM_REVIEW_IDS.map(reviewId => {
+    const review = instagramReviewContent.reviews[reviewId];
+    const fallbackReview = instagramReviewDefaults[reviewId];
+    const ensureText = (value: string, fallbackValue: string) =>
+      value.trim().length > 0 ? value : fallbackValue;
+    const avatarUrl = review.avatarUrl ?? fallbackReview.avatarUrl;
+    const highlightImageUrl =
+      review.highlightImageUrl ??
+      review.postImageUrl ??
+      instagramReviewContent.image ??
+      fallbackReview.highlightImageUrl ??
+      fallbackReview.postImageUrl;
+    const postImageUrl =
+      review.postImageUrl ??
+      instagramReviewContent.image ??
+      fallbackReview.postImageUrl;
+    const postImageAlt = ensureText(review.postImageAlt, fallbackReview.postImageAlt);
     return {
-      ...review,
-      postImageUrl,
+      id: reviewId,
+      name: ensureText(review.name, fallbackReview.name),
+      handle: ensureText(review.handle, fallbackReview.handle),
+      timeAgo: ensureText(review.timeAgo, fallbackReview.timeAgo),
+      message: ensureText(review.message, fallbackReview.message),
+      highlight: ensureText(review.highlight, fallbackReview.highlight),
+      highlightCaption: ensureText(review.highlightCaption, fallbackReview.highlightCaption),
+      location: ensureText(review.location, fallbackReview.location),
+      badgeLabel: ensureText(review.badgeLabel, fallbackReview.badgeLabel),
+      avatarUrl: avatarUrl ?? fallbackReview.avatarUrl,
+      highlightImageUrl: highlightImageUrl ?? fallbackReview.highlightImageUrl ?? fallbackReview.postImageUrl,
+      postImageUrl: postImageUrl ?? fallbackReview.postImageUrl,
       postImageAlt,
     };
   });
@@ -892,7 +873,7 @@ const Login: React.FC = () => {
                           <p className="review-card__name">{review.name}</p>
                           <p className="review-card__handle">{review.handle} • {review.timeAgo}</p>
                         </div>
-                        <span className="review-card__badge">Instagram</span>
+                        <span className="review-card__badge">{review.badgeLabel}</span>
                       </header>
                       <blockquote className="review-card__quote">
                         <Quote aria-hidden="true" className="review-card__quote-icon" />
@@ -901,7 +882,7 @@ const Login: React.FC = () => {
                       <div className="review-card__footer">
                         <div className="review-card__highlight">
                           <span className="review-card__story-ring" aria-hidden="true">
-                            <img src={review.postImageUrl} alt={review.postImageAlt} />
+                            <img src={review.highlightImageUrl} alt={review.highlight} />
                           </span>
                           <div>
                             <p className="review-card__highlight-title">{review.highlight}</p>

--- a/pages/SiteCustomization.tsx
+++ b/pages/SiteCustomization.tsx
@@ -23,6 +23,7 @@ import {
   SectionStyle,
   SiteContent,
   STYLE_EDITABLE_ELEMENT_KEYS,
+  INSTAGRAM_REVIEW_IDS,
 } from '../types';
 import { api } from '../services/api';
 import { normalizeCloudinaryImageUrl, uploadCustomizationAsset } from '../services/cloudinary';
@@ -72,6 +73,15 @@ const BACKGROUND_ELEMENT_KEYS = new Set<EditableElementKey>([
   'footer.style.background',
 ]);
 
+const INSTAGRAM_REVIEW_IMAGE_ELEMENT_KEYS = INSTAGRAM_REVIEW_IDS.flatMap(
+  id =>
+    [
+      `instagramReviews.reviews.${id}.avatarUrl`,
+      `instagramReviews.reviews.${id}.highlightImageUrl`,
+      `instagramReviews.reviews.${id}.postImageUrl`,
+    ] as EditableElementKey[],
+);
+
 const IMAGE_ELEMENT_KEYS = new Set<EditableElementKey>([
   'hero.backgroundImage',
   'about.image',
@@ -79,9 +89,10 @@ const IMAGE_ELEMENT_KEYS = new Set<EditableElementKey>([
   'instagramReviews.image',
   'navigation.brandLogo',
   'navigation.staffLogo',
+  ...INSTAGRAM_REVIEW_IMAGE_ELEMENT_KEYS,
 ]);
 
-const ELEMENT_LABELS: Partial<Record<EditableElementKey, string>> = {
+const BASE_ELEMENT_LABELS: Partial<Record<EditableElementKey, string>> = {
   'navigation.brand': 'Nom de la marque',
   'navigation.brandLogo': 'Logo principal',
   'navigation.staffLogo': "Logo d'accès équipe",
@@ -122,6 +133,32 @@ const ELEMENT_LABELS: Partial<Record<EditableElementKey, string>> = {
   'findUs.style.background': 'Fond Encuéntranos',
   'footer.text': 'Texte du pied de page',
   'footer.style.background': 'Fond du pied de page',
+};
+
+const instagramReviewElementLabels = INSTAGRAM_REVIEW_IDS.reduce(
+  (acc, id, index) => {
+    const reviewNumber = index + 1;
+    const prefix = `instagramReviews.reviews.${id}`;
+    acc[`${prefix}.name` as EditableElementKey] = `Nom avis Instagram ${reviewNumber}`;
+    acc[`${prefix}.handle` as EditableElementKey] = `Pseudo avis Instagram ${reviewNumber}`;
+    acc[`${prefix}.timeAgo` as EditableElementKey] = `Temps écoulé avis Instagram ${reviewNumber}`;
+    acc[`${prefix}.message` as EditableElementKey] = `Message avis Instagram ${reviewNumber}`;
+    acc[`${prefix}.highlight` as EditableElementKey] = `Titre highlight avis Instagram ${reviewNumber}`;
+    acc[`${prefix}.highlightCaption` as EditableElementKey] = `Sous-titre highlight avis Instagram ${reviewNumber}`;
+    acc[`${prefix}.location` as EditableElementKey] = `Localisation avis Instagram ${reviewNumber}`;
+    acc[`${prefix}.badgeLabel` as EditableElementKey] = `Badge avis Instagram ${reviewNumber}`;
+    acc[`${prefix}.postImageAlt` as EditableElementKey] = `Texte alternatif image avis Instagram ${reviewNumber}`;
+    acc[`${prefix}.avatarUrl` as EditableElementKey] = `Avatar avis Instagram ${reviewNumber}`;
+    acc[`${prefix}.highlightImageUrl` as EditableElementKey] = `Image de story avis Instagram ${reviewNumber}`;
+    acc[`${prefix}.postImageUrl` as EditableElementKey] = `Image du post avis Instagram ${reviewNumber}`;
+    return acc;
+  },
+  {} as Partial<Record<EditableElementKey, string>>,
+);
+
+const ELEMENT_LABELS: Partial<Record<EditableElementKey, string>> = {
+  ...BASE_ELEMENT_LABELS,
+  ...instagramReviewElementLabels,
 };
 
 const TABS = [

--- a/types/index.ts
+++ b/types/index.ts
@@ -23,6 +23,32 @@ export interface SectionStyle {
   textColor: string;
 }
 
+export const INSTAGRAM_REVIEW_IDS = ['review1', 'review2', 'review3', 'review4', 'review5'] as const;
+
+export type InstagramReviewId = (typeof INSTAGRAM_REVIEW_IDS)[number];
+
+export const INSTAGRAM_REVIEW_TEXT_FIELDS = [
+  'name',
+  'handle',
+  'timeAgo',
+  'message',
+  'highlight',
+  'highlightCaption',
+  'location',
+  'badgeLabel',
+  'postImageAlt',
+] as const;
+
+export const INSTAGRAM_REVIEW_IMAGE_FIELDS = ['avatarUrl', 'highlightImageUrl', 'postImageUrl'] as const;
+
+export type InstagramReviewTextField = (typeof INSTAGRAM_REVIEW_TEXT_FIELDS)[number];
+export type InstagramReviewImageField = (typeof INSTAGRAM_REVIEW_IMAGE_FIELDS)[number];
+export type InstagramReviewField = InstagramReviewTextField | InstagramReviewImageField;
+
+export type InstagramReviewElementKey<
+  Field extends InstagramReviewField = InstagramReviewField,
+> = `instagramReviews.reviews.${InstagramReviewId}.${Field}`;
+
 export const EDITABLE_ZONE_KEYS = ['navigation', 'hero', 'about', 'menu', 'instagramReviews', 'findUs', 'footer'] as const;
 
 export type EditableZoneKey = (typeof EDITABLE_ZONE_KEYS)[number];
@@ -56,6 +82,66 @@ export const EDITABLE_ELEMENT_KEYS = [
   'instagramReviews.subtitle',
   'instagramReviews.image',
   'instagramReviews.style.background',
+  'instagramReviews.reviews.review1.name',
+  'instagramReviews.reviews.review1.handle',
+  'instagramReviews.reviews.review1.timeAgo',
+  'instagramReviews.reviews.review1.message',
+  'instagramReviews.reviews.review1.highlight',
+  'instagramReviews.reviews.review1.highlightCaption',
+  'instagramReviews.reviews.review1.location',
+  'instagramReviews.reviews.review1.badgeLabel',
+  'instagramReviews.reviews.review1.postImageAlt',
+  'instagramReviews.reviews.review1.avatarUrl',
+  'instagramReviews.reviews.review1.highlightImageUrl',
+  'instagramReviews.reviews.review1.postImageUrl',
+  'instagramReviews.reviews.review2.name',
+  'instagramReviews.reviews.review2.handle',
+  'instagramReviews.reviews.review2.timeAgo',
+  'instagramReviews.reviews.review2.message',
+  'instagramReviews.reviews.review2.highlight',
+  'instagramReviews.reviews.review2.highlightCaption',
+  'instagramReviews.reviews.review2.location',
+  'instagramReviews.reviews.review2.badgeLabel',
+  'instagramReviews.reviews.review2.postImageAlt',
+  'instagramReviews.reviews.review2.avatarUrl',
+  'instagramReviews.reviews.review2.highlightImageUrl',
+  'instagramReviews.reviews.review2.postImageUrl',
+  'instagramReviews.reviews.review3.name',
+  'instagramReviews.reviews.review3.handle',
+  'instagramReviews.reviews.review3.timeAgo',
+  'instagramReviews.reviews.review3.message',
+  'instagramReviews.reviews.review3.highlight',
+  'instagramReviews.reviews.review3.highlightCaption',
+  'instagramReviews.reviews.review3.location',
+  'instagramReviews.reviews.review3.badgeLabel',
+  'instagramReviews.reviews.review3.postImageAlt',
+  'instagramReviews.reviews.review3.avatarUrl',
+  'instagramReviews.reviews.review3.highlightImageUrl',
+  'instagramReviews.reviews.review3.postImageUrl',
+  'instagramReviews.reviews.review4.name',
+  'instagramReviews.reviews.review4.handle',
+  'instagramReviews.reviews.review4.timeAgo',
+  'instagramReviews.reviews.review4.message',
+  'instagramReviews.reviews.review4.highlight',
+  'instagramReviews.reviews.review4.highlightCaption',
+  'instagramReviews.reviews.review4.location',
+  'instagramReviews.reviews.review4.badgeLabel',
+  'instagramReviews.reviews.review4.postImageAlt',
+  'instagramReviews.reviews.review4.avatarUrl',
+  'instagramReviews.reviews.review4.highlightImageUrl',
+  'instagramReviews.reviews.review4.postImageUrl',
+  'instagramReviews.reviews.review5.name',
+  'instagramReviews.reviews.review5.handle',
+  'instagramReviews.reviews.review5.timeAgo',
+  'instagramReviews.reviews.review5.message',
+  'instagramReviews.reviews.review5.highlight',
+  'instagramReviews.reviews.review5.highlightCaption',
+  'instagramReviews.reviews.review5.location',
+  'instagramReviews.reviews.review5.badgeLabel',
+  'instagramReviews.reviews.review5.postImageAlt',
+  'instagramReviews.reviews.review5.avatarUrl',
+  'instagramReviews.reviews.review5.highlightImageUrl',
+  'instagramReviews.reviews.review5.postImageUrl',
   'findUs.title',
   'findUs.addressLabel',
   'findUs.address',
@@ -75,6 +161,9 @@ export const STYLE_EDITABLE_ELEMENT_KEYS = EDITABLE_ELEMENT_KEYS.filter(
   key =>
     !key.endsWith('.style.background') &&
     !key.endsWith('.image') &&
+    !key.endsWith('.avatarUrl') &&
+    !key.endsWith('.highlightImageUrl') &&
+    !key.endsWith('.postImageUrl') &&
     key !== 'hero.backgroundImage' &&
     key !== 'navigation.brandLogo' &&
     key !== 'navigation.staffLogo',
@@ -155,6 +244,7 @@ export interface SiteContent {
     subtitle: string;
     image: string | null;
     style: SectionStyle;
+    reviews: Record<InstagramReviewId, InstagramReview>;
   };
   findUs: {
     title: string;
@@ -174,6 +264,21 @@ export interface SiteContent {
   elementStyles: ElementStyles;
   elementRichText: ElementRichText;
   assets: SiteAssets;
+}
+
+export interface InstagramReview {
+  name: string;
+  handle: string;
+  timeAgo: string;
+  message: string;
+  highlight: string;
+  highlightCaption: string;
+  location: string;
+  badgeLabel: string;
+  postImageAlt: string;
+  avatarUrl: string | null;
+  highlightImageUrl: string | null;
+  postImageUrl: string | null;
 }
 
 export interface Ingredient {

--- a/utils/siteContent.ts
+++ b/utils/siteContent.ts
@@ -5,13 +5,100 @@ import {
   ElementRichText,
   ElementStyle,
   ElementStyles,
+  InstagramReview,
+  InstagramReviewId,
   SectionStyle,
   SiteAssets,
   SiteContent,
   EDITABLE_ELEMENT_KEYS,
+  INSTAGRAM_REVIEW_IDS,
 } from '../types';
 import { normalizeCloudinaryImageUrl } from '../services/cloudinary';
 import { sanitizeRichTextValue } from './richText';
+
+const DEFAULT_INSTAGRAM_REVIEW_ITEMS: Record<InstagramReviewId, InstagramReview> = {
+  review1: {
+    name: 'Laura Méndez',
+    handle: '@laurita.eats',
+    timeAgo: 'hace 2 días',
+    message:
+      'No puedo con la originalidad de estos tacos al pastor: cada mordisco tiene un giro gourmet brutal. La salsa cheddar queda cremosa sin empalagar y el toque crujiente lo es todo.',
+    highlight: 'Story « Taco Tuesday »',
+    highlightCaption: 'Guardado en Destacadas',
+    location: 'Bogotá · Servicio nocturno',
+    badgeLabel: 'Instagram',
+    postImageAlt: "Assiette de tacos colorés garnis d'herbes fraîches.",
+    avatarUrl:
+      'https://images.unsplash.com/photo-1544723795-3fb6469f5b39?auto=format&fit=crop&w=320&q=80',
+    highlightImageUrl: 'https://images.unsplash.com/photo-1521305916504-4a1121188589?auto=format&fit=crop&w=320&q=80',
+    postImageUrl: 'https://images.unsplash.com/photo-1521305916504-4a1121188589?auto=format&fit=crop&w=640&q=80',
+  },
+  review2: {
+    name: 'Camila Torres',
+    handle: '@camigoesout',
+    timeAgo: 'hace 5 días',
+    message:
+      'Estas arepas son lo más: combinan ingredientes súper frescos con un toque gourmet creativo. La mezcla dulce-salado y esa salsa cheddar para remojar me tuvieron feliz todo el brunch.',
+    highlight: 'Reel « Brunch entre amigas »',
+    highlightCaption: 'Comentarios llenos de antojos',
+    location: 'Medellín · Brunch de domingo',
+    badgeLabel: 'Instagram',
+    postImageAlt: 'Gros plan sur des arepas dorées et une sauce maison.',
+    avatarUrl:
+      'https://images.unsplash.com/photo-1524504388940-b1c1722653e1?auto=format&fit=crop&w=320&q=80',
+    highlightImageUrl: 'https://images.unsplash.com/photo-1478145046317-39f10e56b5e9?auto=format&fit=crop&w=320&q=80',
+    postImageUrl: 'https://images.unsplash.com/photo-1478145046317-39f10e56b5e9?auto=format&fit=crop&w=640&q=80',
+  },
+  review3: {
+    name: 'Sebastián Ruiz',
+    handle: '@ruizhungry',
+    timeAgo: 'hace 1 semana',
+    message:
+      'Armamos un afterwork aquí y fue un hit: combos originales, porciones generosas y un crunch brutal en cada bocado. La salsa cheddar se volvió tema de conversación.',
+    highlight: 'Post « Team Afterwork »',
+    highlightCaption: 'Reacciones de la oficina',
+    location: 'Barranquilla · Terraza privada',
+    badgeLabel: 'Instagram',
+    postImageAlt:
+      'Table conviviale avec plusieurs plats mexicains et des boissons fraîches.',
+    avatarUrl:
+      'https://images.unsplash.com/photo-1521572267360-ee0c2909d518?auto=format&fit=crop&w=320&q=80',
+    highlightImageUrl: 'https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=320&q=80',
+    postImageUrl: 'https://images.unsplash.com/photo-1504674900247-0877df9cc836?auto=format&fit=crop&w=640&q=80',
+  },
+  review4: {
+    name: 'Valentina Ríos',
+    handle: '@valen.foodnotes',
+    timeAgo: 'hace 2 semanas',
+    message:
+      'El menú tiene un mood gourmet sin perder lo reconfortante: masa crocante, cheddar fundido y combinaciones de ingredientes que se sienten pensadas con cariño. Increíble experiencia.',
+    highlight: 'Carousel « Night Out »',
+    highlightCaption: 'Comentarios fijados',
+    location: 'Cali · Cena casual',
+    badgeLabel: 'Instagram',
+    postImageAlt: 'Pizza gourmande avec fromage coulant et herbes fraîches.',
+    avatarUrl:
+      'https://images.unsplash.com/photo-1535713875002-d1d0cf377fde?auto=format&fit=crop&w=320&q=80',
+    highlightImageUrl: 'https://images.unsplash.com/photo-1513104890138-7c749659a591?auto=format&fit=crop&w=320&q=80',
+    postImageUrl: 'https://images.unsplash.com/photo-1513104890138-7c749659a591?auto=format&fit=crop&w=640&q=80',
+  },
+  review5: {
+    name: 'Alejandro Pérez',
+    handle: '@alexlovesfood',
+    timeAgo: 'hace 3 semanas',
+    message:
+      'Vine por curiosidad y me quedé por la originalidad del menú: el cheddar baña la burger justo como me gusta y el pan crujiente aguanta toda la salsa. Asociaciones de sabores top.',
+    highlight: 'Live « Burger Night »',
+    highlightCaption: 'Chat lleno de elogios',
+    location: 'Bogotá · Servicio takeout',
+    badgeLabel: 'Instagram',
+    postImageAlt: 'Burger gourmet avec sauce et frites croustillantes.',
+    avatarUrl:
+      'https://images.unsplash.com/photo-1529665253569-6d01c0eaf7b6?auto=format&fit=crop&w=320&q=80',
+    highlightImageUrl: 'https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=320&q=80',
+    postImageUrl: 'https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=640&q=80',
+  },
+};
 
 const trimOrEmpty = (value: string): string => value.trim();
 
@@ -52,6 +139,62 @@ const resolveImage = (value: string | null | undefined, fallback: string | null)
 const sanitizeImage = (value: string | null | undefined): string | null => {
   const normalized = normalizeCloudinaryImageUrl(value);
   return normalized ?? null;
+};
+
+const resolveInstagramReviewRecords = (
+  reviews: Partial<Record<InstagramReviewId, Partial<InstagramReview>>> | null | undefined,
+  fallback: Record<InstagramReviewId, InstagramReview>,
+): Record<InstagramReviewId, InstagramReview> => {
+  const resolved: Record<InstagramReviewId, InstagramReview> = {} as Record<
+    InstagramReviewId,
+    InstagramReview
+  >;
+  INSTAGRAM_REVIEW_IDS.forEach(id => {
+    const base = fallback[id];
+    const source = reviews?.[id] ?? {};
+    resolved[id] = {
+      name: resolveString(source?.name, base.name),
+      handle: resolveString(source?.handle, base.handle),
+      timeAgo: resolveString(source?.timeAgo, base.timeAgo),
+      message: resolveString(source?.message, base.message),
+      highlight: resolveString(source?.highlight, base.highlight),
+      highlightCaption: resolveString(source?.highlightCaption, base.highlightCaption),
+      location: resolveString(source?.location, base.location),
+      badgeLabel: resolveString(source?.badgeLabel, base.badgeLabel),
+      postImageAlt: resolveString(source?.postImageAlt, base.postImageAlt),
+      avatarUrl: resolveImage(source?.avatarUrl, base.avatarUrl),
+      highlightImageUrl: resolveImage(source?.highlightImageUrl, base.highlightImageUrl),
+      postImageUrl: resolveImage(source?.postImageUrl, base.postImageUrl),
+    };
+  });
+  return resolved;
+};
+
+const sanitizeInstagramReviewRecords = (
+  reviews: Partial<Record<InstagramReviewId, Partial<InstagramReview>>> | null | undefined,
+): Record<InstagramReviewId, InstagramReview> => {
+  const sanitized: Record<InstagramReviewId, InstagramReview> = {} as Record<
+    InstagramReviewId,
+    InstagramReview
+  >;
+  INSTAGRAM_REVIEW_IDS.forEach(id => {
+    const source = reviews?.[id] ?? {};
+    sanitized[id] = {
+      name: trimOrEmpty(source?.name ?? ''),
+      handle: trimOrEmpty(source?.handle ?? ''),
+      timeAgo: trimOrEmpty(source?.timeAgo ?? ''),
+      message: trimOrEmpty(source?.message ?? ''),
+      highlight: trimOrEmpty(source?.highlight ?? ''),
+      highlightCaption: trimOrEmpty(source?.highlightCaption ?? ''),
+      location: trimOrEmpty(source?.location ?? ''),
+      badgeLabel: trimOrEmpty(source?.badgeLabel ?? ''),
+      postImageAlt: trimOrEmpty(source?.postImageAlt ?? ''),
+      avatarUrl: sanitizeImage(source?.avatarUrl),
+      highlightImageUrl: sanitizeImage(source?.highlightImageUrl),
+      postImageUrl: sanitizeImage(source?.postImageUrl),
+    };
+  });
+  return sanitized;
 };
 
 const sanitizeElementStyleValue = (value: string | null | undefined): string | undefined => {
@@ -405,6 +548,13 @@ export const DEFAULT_SITE_CONTENT: SiteContent = {
       'Des foodies de toute la Colombie partagent leur coup de cœur pour notre cuisine : ambiance solaire, service attentionné et assiettes qui brillent autant que leurs stories.',
     image: 'https://picsum.photos/seed/instagramreviews/600/600',
     style: DEFAULT_INSTAGRAM_REVIEWS_STYLE,
+    reviews: INSTAGRAM_REVIEW_IDS.reduce(
+      (acc, id) => {
+        acc[id] = { ...DEFAULT_INSTAGRAM_REVIEW_ITEMS[id] };
+        return acc;
+      },
+      {} as Record<InstagramReviewId, InstagramReview>,
+    ),
   },
   findUs: {
     title: 'Encuéntranos',
@@ -469,6 +619,10 @@ export const resolveSiteContent = (content?: Partial<SiteContent> | null): SiteC
       subtitle: resolveString(content?.instagramReviews?.subtitle, base.instagramReviews.subtitle),
       image: resolveImage(content?.instagramReviews?.image, base.instagramReviews.image),
       style: resolveSectionStyle(content?.instagramReviews?.style, base.instagramReviews.style),
+      reviews: resolveInstagramReviewRecords(
+        content?.instagramReviews?.reviews ?? null,
+        base.instagramReviews.reviews,
+      ),
     },
     findUs: {
       title: resolveString(content?.findUs?.title, base.findUs.title),
@@ -532,6 +686,7 @@ export const sanitizeSiteContentInput = (content: SiteContent): SiteContent => (
     subtitle: trimOrEmpty(content.instagramReviews.subtitle),
     image: sanitizeImage(content.instagramReviews.image),
     style: sanitizeSectionStyle(content.instagramReviews.style, DEFAULT_INSTAGRAM_REVIEWS_STYLE),
+    reviews: sanitizeInstagramReviewRecords(content.instagramReviews.reviews ?? null),
   },
   findUs: {
     title: trimOrEmpty(content.findUs.title),


### PR DESCRIPTION
## Summary
- extend the site content schema with per-review instagram data and defaults
- expose every instagram review field in the personalization preview for text and media editing
- render the login carousel from customized reviews with appropriate fallbacks

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68de5988fb14832aadef250152f28463