### PR TITLE
Retire les éléments de mise en avant dans les avis

### DIFF
--- a/components/SitePreviewCanvas.tsx
+++ b/components/SitePreviewCanvas.tsx
@@ -947,11 +947,6 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                               )}
                             </EditableElement>
                           </header>
-                          <div className="review-card__stars" aria-label="Note 5 sur 5">
-                            {Array.from({ length: 5 }).map((_, starIndex) => (
-                              <Star key={starIndex} aria-hidden="true" />
-                            ))}
-                          </div>
                           <blockquote className="review-card__quote">
                             <Quote aria-hidden="true" className="review-card__quote-icon" />
                             <EditableElement
@@ -971,73 +966,6 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                               )}
                             </EditableElement>
                           </blockquote>
-                          <div className="review-card__footer">
-                            <div className="review-card__highlight">
-                              <EditableElement
-                                id={highlightImageKey}
-                                label={`Modifier l'image de story de l'avis ${index + 1}`}
-                                onEdit={onEdit}
-                                className="review-card__story-ring"
-                                buttonClassName="-left-3 -top-3"
-                                as="span"
-                              >
-                                <img src={highlightImageUrl} alt="" />
-                              </EditableElement>
-                              <div>
-                                <EditableElement
-                                  id={highlightKey}
-                                  label={`Modifier le titre du highlight ${index + 1}`}
-                                  onEdit={onEdit}
-                                  className="block"
-                                  buttonClassName="right-0 -top-3"
-                                >
-                                  {renderRichTextElement(
-                                    highlightKey,
-                                    'p',
-                                    {
-                                      className: 'review-card__highlight-title',
-                                      style: getElementTextStyle(highlightKey),
-                                    },
-                                    card.review.highlight,
-                                  )}
-                                </EditableElement>
-                                <EditableElement
-                                  id={highlightCaptionKey}
-                                  label={`Modifier la légende du highlight ${index + 1}`}
-                                  onEdit={onEdit}
-                                  className="block"
-                                  buttonClassName="right-0 -top-3"
-                                >
-                                  {renderRichTextElement(
-                                    highlightCaptionKey,
-                                    'p',
-                                    {
-                                      className: 'review-card__highlight-caption',
-                                      style: getElementBodyTextStyle(highlightCaptionKey),
-                                    },
-                                    card.review.highlightCaption,
-                                  )}
-                                </EditableElement>
-                              </div>
-                            </div>
-                            <EditableElement
-                              id={locationKey}
-                              label={`Modifier la localisation de l'avis ${index + 1}`}
-                              onEdit={onEdit}
-                              className="block"
-                              buttonClassName="right-0 -top-3"
-                            >
-                              {renderRichTextElement(
-                                locationKey,
-                                'p',
-                                {
-                                  className: 'review-card__location',
-                                  style: getElementBodyTextStyle(locationKey),
-                                },
-                                card.review.location,
-                              )}
-                            </EditableElement>
-                          </div>
                         </div>
                         <div className="review-card__media">
                           <EditableElement

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -879,18 +879,6 @@ const Login: React.FC = () => {
                         <Quote aria-hidden="true" className="review-card__quote-icon" />
                         <p>{review.message}</p>
                       </blockquote>
-                      <div className="review-card__footer">
-                        <div className="review-card__highlight">
-                          <span className="review-card__story-ring" aria-hidden="true">
-                            <img src={review.highlightImageUrl} alt={review.highlight} />
-                          </span>
-                          <div>
-                            <p className="review-card__highlight-title">{review.highlight}</p>
-                            <p className="review-card__highlight-caption">{review.highlightCaption}</p>
-                          </div>
-                        </div>
-                        <p className="review-card__location">{review.location}</p>
-                      </div>
                     </div>
                     <div className="review-card__media">
                       <span className="review-card__media-frame">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -168,6 +168,7 @@ body {
   display: flex;
   flex-direction: column;
   gap: clamp(1rem, 2.5vw, 1.75rem);
+  padding-bottom: clamp(1rem, 2.5vw, 1.5rem);
 }
 
 .review-card__header {
@@ -242,59 +243,6 @@ body {
   width: 1.15rem;
   height: 1.15rem;
   color: color-mix(in srgb, var(--color-heading) 40%, transparent);
-}
-
-.review-card__footer {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 1rem;
-  align-items: center;
-  justify-content: space-between;
-}
-
-.review-card__highlight {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.75rem;
-}
-
-.review-card__story-ring {
-  width: 3.25rem;
-  height: 3.25rem;
-  border-radius: 999px;
-  display: inline-flex;
-  padding: 0.22rem;
-  background: conic-gradient(from 0deg, #f97316, #fbbf24, #ec4899, #6366f1, #f97316);
-  box-shadow: 0 10px 22px rgba(236, 72, 153, 0.2);
-}
-
-.review-card__story-ring img {
-  border-radius: inherit;
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-}
-
-.review-card__highlight-title {
-  margin: 0;
-  font-size: clamp(0.85rem, 1.8vw, 0.95rem);
-  font-weight: 700;
-  color: var(--color-heading);
-}
-
-.review-card__highlight-caption {
-  margin: 0;
-  font-size: clamp(0.75rem, 1.6vw, 0.85rem);
-  color: color-mix(in srgb, var(--color-heading) 55%, transparent);
-}
-
-.review-card__location {
-  margin: 0;
-  font-size: clamp(0.75rem, 1.6vw, 0.85rem);
-  font-weight: 600;
-  letter-spacing: 0.04em;
-  text-transform: uppercase;
-  color: color-mix(in srgb, var(--color-heading) 58%, transparent);
 }
 
 .review-card__media {


### PR DESCRIPTION
## Summary
- supprime l'affichage des étoiles et du bloc highlight/localisation dans les cartes d'avis
- ajuste l'espacement vertical du contenu pour conserver une mise en page cohérente
- nettoie les règles CSS obsolètes liées aux highlights et à la localisation

## Testing
- npm test -- --run

------
https://chatgpt.com/codex/tasks/task_b_68de683d6788832aa1789190f850324c