### PR TITLE
Affiche 7 avis dans un carrousel compact

### DIFF
--- a/components/SitePreviewCanvas.tsx
+++ b/components/SitePreviewCanvas.tsx
@@ -212,6 +212,7 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
   const elementStyles = content.elementStyles ?? {};
   const elementRichText = content.elementRichText ?? {};
   const [customActiveReviewIndex, setCustomActiveReviewIndex] = React.useState(0);
+  const REVIEWS_VISIBLE_COUNT = 2.5;
   const reviewCount = instagramReviewCards.length;
   const isCustomizationMode = showEditButtons;
   const activeReviewIndex = isCustomizationMode ? customActiveReviewIndex : 0;
@@ -254,7 +255,7 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
   );
 
   const trackStyle = isCustomizationMode
-    ? { transform: `translateX(-${activeReviewIndex * 100}%)` }
+    ? { transform: `translateX(calc(-${activeReviewIndex} * var(--review-slide-offset)))` }
     : undefined;
 
   const getRichTextHtml = (key: EditableElementKey): string | null => {
@@ -831,7 +832,12 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                   )}
                 </EditableElement>
               </div>
-              <div className="reviews-carousel">
+              <div
+                className="reviews-carousel"
+                style={{
+                  '--reviews-visible-count': REVIEWS_VISIBLE_COUNT,
+                } as React.CSSProperties}
+              >
                 <div className="reviews-track" style={trackStyle}>
                   {instagramReviewCards.map((card, index) => {
                     const baseKey = `instagramReviews.reviews.${card.reviewId}` as EditableElementKey;
@@ -851,11 +857,7 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                     const highlightImageUrl = card.highlightImageUrl ?? DEFAULT_REVIEW_HIGHLIGHT_IMAGE;
                     const postImageUrl = card.postImageUrl ?? DEFAULT_REVIEW_POST_IMAGE;
                     return (
-                      <article
-                        key={card.reviewId}
-                        className="review-card"
-                        aria-hidden={index !== activeReviewIndex}
-                      >
+                      <article key={card.reviewId} className="review-card" aria-hidden={false}>
                         <div className="review-card__content">
                           <header className="review-card__header">
                             <EditableElement

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -398,6 +398,7 @@ const Login: React.FC = () => {
       postImageAlt,
     };
   });
+  const REVIEWS_VISIBLE_COUNT = 2.5;
   const reviewCount = instagramReviewSlides.length;
   const isSingleReview = reviewCount <= 1;
 
@@ -860,10 +861,20 @@ const Login: React.FC = () => {
                 instagramReviewContent.subtitle,
               )}
             </div>
-            <div className="reviews-carousel">
-              <div className="reviews-track" style={{ transform: `translateX(-${activeReviewIndex * 100}%)` }}>
-                {instagramReviewSlides.map((review, index) => (
-                  <article key={review.id} className="review-card" aria-hidden={index !== activeReviewIndex}>
+            <div
+              className="reviews-carousel"
+              style={{
+                '--reviews-visible-count': REVIEWS_VISIBLE_COUNT,
+              } as React.CSSProperties}
+            >
+              <div
+                className="reviews-track"
+                style={{
+                  transform: `translateX(calc(-${activeReviewIndex} * var(--review-slide-offset)))`,
+                }}
+              >
+                {instagramReviewSlides.map(review => (
+                  <article key={review.id} className="review-card" aria-hidden={false}>
                     <div className="review-card__content">
                       <header className="review-card__header">
                         <span className="review-card__avatar" aria-hidden="true">

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -139,10 +139,12 @@ body {
 .reviews-carousel {
   position: relative;
   overflow: hidden;
-  border-radius: clamp(2rem, 5vw, 2.75rem);
+  border-radius: clamp(1.75rem, 4vw, 2.5rem);
   background: #ffffff;
-  box-shadow: 0 28px 80px rgba(15, 23, 42, 0.15);
-  padding: clamp(1.75rem, 5vw, 3rem);
+  box-shadow: 0 20px 60px rgba(15, 23, 42, 0.12);
+  padding: clamp(1.5rem, 4vw, 2.5rem);
+  --reviews-visible-count: 2.5;
+  --review-slide-offset: calc(100% / var(--reviews-visible-count));
 }
 
 .reviews-track {
@@ -152,9 +154,12 @@ body {
 }
 
 .review-card {
-  min-width: 100%;
+  box-sizing: border-box;
+  flex: 0 0 calc(100% / var(--reviews-visible-count));
+  min-width: calc(100% / var(--reviews-visible-count));
+  padding: 0 clamp(0.85rem, 2vw, 1.35rem);
   display: grid;
-  gap: clamp(1.25rem, 3.5vw, 2.25rem);
+  gap: clamp(1.1rem, 3vw, 2rem);
   align-items: center;
 }
 

--- a/types/index.ts
+++ b/types/index.ts
@@ -23,7 +23,15 @@ export interface SectionStyle {
   textColor: string;
 }
 
-export const INSTAGRAM_REVIEW_IDS = ['review1', 'review2', 'review3', 'review4', 'review5'] as const;
+export const INSTAGRAM_REVIEW_IDS = [
+  'review1',
+  'review2',
+  'review3',
+  'review4',
+  'review5',
+  'review6',
+  'review7',
+] as const;
 
 export type InstagramReviewId = (typeof INSTAGRAM_REVIEW_IDS)[number];
 

--- a/utils/siteContent.ts
+++ b/utils/siteContent.ts
@@ -98,6 +98,38 @@ const DEFAULT_INSTAGRAM_REVIEW_ITEMS: Record<InstagramReviewId, InstagramReview>
     highlightImageUrl: 'https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=320&q=80',
     postImageUrl: 'https://images.unsplash.com/photo-1517248135467-4c7edcad34c4?auto=format&fit=crop&w=640&q=80',
   },
+  review6: {
+    name: 'Juliana Gómez',
+    handle: '@julie.foodstories',
+    timeAgo: 'hace 1 mes',
+    message:
+      'Pedimos catering para un cumpleaños y fue éxito total: tacos mini, dips calientes y una mesa que se veía divina para fotos. Todo llegó puntual y con instrucciones claras.',
+    highlight: 'Story « Fiesta privada »',
+    highlightCaption: 'Reseñas con confeti',
+    location: 'Cartagena · Evento privado',
+    badgeLabel: 'Instagram',
+    postImageAlt: 'Buffet coloré avec tacos, dips et accompagnements.',
+    avatarUrl:
+      'https://images.unsplash.com/photo-1517841905240-472988babdf9?auto=format&fit=crop&w=320&q=80',
+    highlightImageUrl: 'https://images.unsplash.com/photo-1528715471579-d1bcf0ba5e83?auto=format&fit=crop&w=320&q=80',
+    postImageUrl: 'https://images.unsplash.com/photo-1466978913421-dad2ebd01d17?auto=format&fit=crop&w=640&q=80',
+  },
+  review7: {
+    name: 'Manuela Herrera',
+    handle: '@manuelatryit',
+    timeAgo: 'hace 6 semanas',
+    message:
+      'Amo que tengan opciones veggies sin perder el toque cheddar: las quesadillas con hongos y maíz dulce son mi nueva obsesión. Además, la atención es rapidísima.',
+    highlight: 'Reel « Veggie Lovers »',
+    highlightCaption: 'Comentarios verdes y felices',
+    location: 'Bogotá · Servicio para llevar',
+    badgeLabel: 'Instagram',
+    postImageAlt: 'Quesadillas dorées servies avec salsa verde.',
+    avatarUrl:
+      'https://images.unsplash.com/photo-1506794778202-cad84cf45f1d?auto=format&fit=crop&w=320&q=80',
+    highlightImageUrl: 'https://images.unsplash.com/photo-1528712306091-ed0763094c98?auto=format&fit=crop&w=320&q=80',
+    postImageUrl: 'https://images.unsplash.com/photo-1528712306091-ed0763094c98?auto=format&fit=crop&w=640&q=80',
+  },
 };
 
 const trimOrEmpty = (value: string): string => value.trim();


### PR DESCRIPTION
## Summary
- élargir la liste d'avis Instagram à 7 entrées avec du contenu par défaut supplémentaire
- réduire le carrousel pour afficher 2,5 cartes à la fois via de nouvelles variables CSS et styles mis à jour
- harmoniser la prévisualisation de personnalisation avec le nouveau comportement du carrousel

## Testing
- npm run lint *(échoue : script manquant)*

------
https://chatgpt.com/codex/tasks/task_b_68de6deba884832aa72ac19e2160305e