### PR TITLE
Restore Instagram carousel images and reduce height

### DIFF
--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -379,19 +379,33 @@ const Login: React.FC = () => {
       fallbackReview.postImageUrl;
     const postImageUrl =
       review.postImageUrl ??
-      instagramReviewContent.image ??
-      fallbackReview.postImageUrl;
-    const postImageAlt = ensureText(review.postImageAlt, fallbackReview.postImageAlt);
+      review.highlightImageUrl ??
+      fallbackReview.postImageUrl ??
+      fallbackReview.highlightImageUrl ??
+      instagramReviewContent.image;
+    const name = ensureText(review.name, fallbackReview.name);
+    const handle = ensureText(review.handle, fallbackReview.handle);
+    const timeAgo = ensureText(review.timeAgo, fallbackReview.timeAgo);
+    const message = ensureText(review.message, fallbackReview.message);
+    const highlight = ensureText(review.highlight, fallbackReview.highlight);
+    const highlightCaption = ensureText(review.highlightCaption, fallbackReview.highlightCaption);
+    const location = ensureText(review.location, fallbackReview.location);
+    const badgeLabel = ensureText(review.badgeLabel, fallbackReview.badgeLabel);
+    const fallbackPostImageAlt = ensureText(review.postImageAlt, fallbackReview.postImageAlt);
+    const postImageAlt =
+      postImageUrl && postImageUrl === (review.highlightImageUrl ?? fallbackReview.highlightImageUrl ?? null)
+        ? highlightCaption
+        : fallbackPostImageAlt;
     return {
       id: reviewId,
-      name: ensureText(review.name, fallbackReview.name),
-      handle: ensureText(review.handle, fallbackReview.handle),
-      timeAgo: ensureText(review.timeAgo, fallbackReview.timeAgo),
-      message: ensureText(review.message, fallbackReview.message),
-      highlight: ensureText(review.highlight, fallbackReview.highlight),
-      highlightCaption: ensureText(review.highlightCaption, fallbackReview.highlightCaption),
-      location: ensureText(review.location, fallbackReview.location),
-      badgeLabel: ensureText(review.badgeLabel, fallbackReview.badgeLabel),
+      name,
+      handle,
+      timeAgo,
+      message,
+      highlight,
+      highlightCaption,
+      location,
+      badgeLabel,
       avatarUrl: avatarUrl ?? fallbackReview.avatarUrl,
       highlightImageUrl: highlightImageUrl ?? fallbackReview.highlightImageUrl ?? fallbackReview.postImageUrl,
       postImageUrl: postImageUrl ?? fallbackReview.postImageUrl,

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -264,8 +264,8 @@ body {
 
 .review-card__media-frame img {
   display: block;
-  width: clamp(240px, 32vw, 360px);
-  height: clamp(240px, 32vw, 360px);
+  width: clamp(168px, 22.4vw, 252px);
+  height: clamp(168px, 22.4vw, 252px);
   object-fit: cover;
   border-radius: clamp(1.1rem, 3vw, 1.5rem);
 }
@@ -350,8 +350,8 @@ body {
   }
 
   .review-card__media-frame img {
-    width: clamp(200px, 68vw, 280px);
-    height: clamp(200px, 68vw, 280px);
+    width: clamp(140px, 47.6vw, 196px);
+    height: clamp(140px, 47.6vw, 196px);
   }
 }
 


### PR DESCRIPTION
## Summary
- ensure Instagram carousel slides fall back to review highlight photos when post images are missing so visuals reappear
- shrink the carousel media dimensions by roughly 30% to reduce the section height on the landing page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68de75f248d4832abb925a4be78f8d62