### PR TITLE
Refactor Instagram review carousel layout

### DIFF
--- a/components/SitePreviewCanvas.tsx
+++ b/components/SitePreviewCanvas.tsx
@@ -1,5 +1,18 @@
 import React from 'react';
-import { ChevronLeft, ChevronRight, Clock, Edit2, Mail, MapPin, Quote, Star } from 'lucide-react';
+import {
+  ChevronLeft,
+  ChevronRight,
+  Clock,
+  Edit2,
+  Mail,
+  MapPin,
+  Quote,
+  Star,
+  Heart,
+  MessageCircle,
+  Send,
+  Bookmark,
+} from 'lucide-react';
 import {
   EditableElementKey,
   EditableZoneKey,
@@ -856,148 +869,243 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                     const avatarUrl = card.avatarUrl ?? 'https://i.pravatar.cc/96?img=12';
                     const highlightImageUrl = card.highlightImageUrl ?? DEFAULT_REVIEW_HIGHLIGHT_IMAGE;
                     const postImageUrl = card.postImageUrl ?? DEFAULT_REVIEW_POST_IMAGE;
+                    const highlightText = card.review.highlight ?? '';
+                    const highlightCaption = card.review.highlightCaption ?? '';
+                    const locationText = card.review.location ?? '';
+                    const timeAgoText = card.review.timeAgo ?? '';
+                    const highlightAltText =
+                      highlightText.trim().length > 0 ? highlightText : highlightCaption;
+                    const showHighlight =
+                      isCustomizationMode ||
+                      highlightText.trim().length > 0 ||
+                      highlightCaption.trim().length > 0 ||
+                      Boolean(highlightImageUrl);
+                    const showLocation = isCustomizationMode || locationText.trim().length > 0;
+                    const showTimestamp = isCustomizationMode || timeAgoText.trim().length > 0;
                     return (
                       <article key={card.reviewId} className="review-card" aria-hidden={false}>
-                        <div className="review-card__content">
-                          <header className="review-card__header">
+                        <header className="review-card__header">
+                          <EditableElement
+                            id={avatarKey}
+                            label={`Modifier la photo de profil de l'avis ${index + 1}`}
+                            onEdit={onEdit}
+                            className="review-card__avatar"
+                            buttonClassName="-left-3 -top-3"
+                            as="span"
+                          >
+                            <img src={avatarUrl} alt="" />
+                          </EditableElement>
+                          <div className="review-card__meta">
                             <EditableElement
-                              id={avatarKey}
-                              label={`Modifier la photo de profil de l'avis ${index + 1}`}
+                              id={nameKey}
+                              label={`Modifier le nom de l'avis ${index + 1}`}
                               onEdit={onEdit}
-                              className="review-card__avatar"
-                              buttonClassName="-left-3 -top-3"
-                              as="span"
+                              className="block"
+                              buttonClassName="right-0 -top-3"
                             >
-                              <img src={avatarUrl} alt="" />
+                              {renderRichTextElement(
+                                nameKey,
+                                'p',
+                                {
+                                  className: 'review-card__name',
+                                  style: getElementTextStyle(nameKey),
+                                },
+                                card.review.name,
+                              )}
                             </EditableElement>
-                            <div className="review-card__meta">
+                            <p className="review-card__handle">
                               <EditableElement
-                                id={nameKey}
-                                label={`Modifier le nom de l'avis ${index + 1}`}
+                                id={handleKey}
+                                label={`Modifier le pseudo de l'avis ${index + 1}`}
                                 onEdit={onEdit}
-                                className="block"
+                                className="inline"
+                                buttonClassName="-left-3 -top-3"
+                                as="span"
+                              >
+                                {renderRichTextElement(
+                                  handleKey,
+                                  'span',
+                                  {
+                                    className: 'inline-flex items-center',
+                                    style: getElementBodyTextStyle(handleKey),
+                                  },
+                                  card.review.handle,
+                                )}
+                              </EditableElement>
+                            </p>
+                          </div>
+                          <EditableElement
+                            id={badgeKey}
+                            label={`Modifier le badge de l'avis ${index + 1}`}
+                            onEdit={onEdit}
+                            className="review-card__badge"
+                            buttonClassName="-right-3 -top-3"
+                            as="span"
+                          >
+                            {renderRichTextElement(
+                              badgeKey,
+                              'span',
+                              {
+                                className: 'review-card__badge',
+                                style: getElementTextStyle(badgeKey),
+                              },
+                              card.badgeLabel,
+                            )}
+                          </EditableElement>
+                        </header>
+                        <div className="review-card__layout">
+                          <div className="review-card__content">
+                            {showHighlight && (
+                              <div className="review-card__highlight">
+                                <EditableElement
+                                  id={highlightImageKey}
+                                  label={`Modifier l'image à la une de l'avis ${index + 1}`}
+                                  onEdit={onEdit}
+                                  className="review-card__highlight-thumb"
+                                  buttonClassName="-left-3 -top-3"
+                                  as="span"
+                                >
+                                  <img src={highlightImageUrl} alt={highlightAltText ?? ''} />
+                                </EditableElement>
+                                <div className="review-card__highlight-copy">
+                                  <EditableElement
+                                    id={highlightKey}
+                                    label={`Modifier le titre du highlight de l'avis ${index + 1}`}
+                                    onEdit={onEdit}
+                                    className="block"
+                                    buttonClassName="right-0 -top-3"
+                                  >
+                                    {renderRichTextElement(
+                                      highlightKey,
+                                      'p',
+                                      {
+                                        className: 'review-card__highlight-title',
+                                        style: getElementTextStyle(highlightKey),
+                                      },
+                                      card.review.highlight,
+                                    )}
+                                  </EditableElement>
+                                  <EditableElement
+                                    id={highlightCaptionKey}
+                                    label={`Modifier la description du highlight de l'avis ${index + 1}`}
+                                    onEdit={onEdit}
+                                    className="mt-1 block"
+                                    buttonClassName="right-0 -top-3"
+                                  >
+                                    {renderRichTextElement(
+                                      highlightCaptionKey,
+                                      'p',
+                                      {
+                                        className: 'review-card__highlight-caption',
+                                        style: getElementBodyTextStyle(highlightCaptionKey),
+                                      },
+                                      card.review.highlightCaption,
+                                    )}
+                                  </EditableElement>
+                                </div>
+                              </div>
+                            )}
+                            <blockquote className="review-card__quote">
+                              <Quote aria-hidden="true" className="review-card__quote-icon" />
+                              <EditableElement
+                                id={messageKey}
+                                label={`Modifier le message de l'avis ${index + 1}`}
+                                onEdit={onEdit}
+                                className="mt-2 block"
                                 buttonClassName="right-0 -top-3"
                               >
                                 {renderRichTextElement(
-                                  nameKey,
+                                  messageKey,
                                   'p',
                                   {
-                                    className: 'review-card__name',
-                                    style: getElementTextStyle(nameKey),
+                                    style: getElementBodyTextStyle(messageKey),
                                   },
-                                  card.review.name,
+                                  card.review.message,
                                 )}
                               </EditableElement>
-                              <p className="review-card__handle">
+                            </blockquote>
+                            {showLocation && (
+                              <p className="review-card__location">
+                                <MapPin aria-hidden="true" />
                                 <EditableElement
-                                  id={handleKey}
-                                  label={`Modifier le pseudo de l'avis ${index + 1}`}
+                                  id={locationKey}
+                                  label={`Modifier le lieu de l'avis ${index + 1}`}
                                   onEdit={onEdit}
                                   className="inline"
                                   buttonClassName="-left-3 -top-3"
                                   as="span"
                                 >
                                   {renderRichTextElement(
-                                    handleKey,
+                                    locationKey,
                                     'span',
                                     {
-                                      className: 'inline-flex items-center',
-                                      style: getElementBodyTextStyle(handleKey),
+                                      style: getElementBodyTextStyle(locationKey),
                                     },
-                                    card.review.handle,
+                                    card.review.location,
                                   )}
                                 </EditableElement>
-                                <span className="mx-1 text-slate-400" aria-hidden="true">
-                                  •
-                                </span>
+                              </p>
+                            )}
+                            {showTimestamp && (
+                              <p className="review-card__timestamp">
                                 <EditableElement
                                   id={timeKey}
                                   label={`Modifier le délai de publication de l'avis ${index + 1}`}
                                   onEdit={onEdit}
                                   className="inline"
-                                  buttonClassName="-right-3 -top-3"
+                                  buttonClassName="-left-3 -top-3"
                                   as="span"
                                 >
                                   {renderRichTextElement(
                                     timeKey,
                                     'span',
                                     {
-                                      className: 'inline-flex items-center',
                                       style: getElementBodyTextStyle(timeKey),
                                     },
                                     card.review.timeAgo,
                                   )}
                                 </EditableElement>
                               </p>
-                            </div>
+                            )}
+                          </div>
+                          <div className="review-card__media">
                             <EditableElement
-                              id={badgeKey}
-                              label={`Modifier le badge de l'avis ${index + 1}`}
+                              id={postImageKey}
+                              label={`Modifier l'image du post ${index + 1}`}
                               onEdit={onEdit}
-                              className="review-card__badge"
+                              className="review-card__media-frame"
                               buttonClassName="-right-3 -top-3"
                               as="span"
                             >
-                              {renderRichTextElement(
-                                badgeKey,
-                                'span',
-                                {
-                                  className: 'review-card__badge',
-                                  style: getElementTextStyle(badgeKey),
-                                },
-                                card.badgeLabel,
-                              )}
+                              <img src={postImageUrl} alt={card.postImageAlt} />
                             </EditableElement>
-                          </header>
-                          <blockquote className="review-card__quote">
-                            <Quote aria-hidden="true" className="review-card__quote-icon" />
                             <EditableElement
-                              id={messageKey}
-                              label={`Modifier le message de l'avis ${index + 1}`}
+                              id={postImageAltKey}
+                              label={`Modifier le texte alternatif de l'image ${index + 1}`}
                               onEdit={onEdit}
-                              className="mt-2 block"
+                              className="mt-3 block"
                               buttonClassName="right-0 -top-3"
                             >
                               {renderRichTextElement(
-                                messageKey,
+                                postImageAltKey,
                                 'p',
                                 {
-                                  style: getElementBodyTextStyle(messageKey),
+                                  className: 'text-xs italic text-slate-500',
+                                  style: getElementBodyTextStyle(postImageAltKey),
                                 },
-                                card.review.message,
+                                card.review.postImageAlt,
                               )}
                             </EditableElement>
-                          </blockquote>
+                          </div>
                         </div>
-                        <div className="review-card__media">
-                          <EditableElement
-                            id={postImageKey}
-                            label={`Modifier l'image du post ${index + 1}`}
-                            onEdit={onEdit}
-                            className="review-card__media-frame"
-                            buttonClassName="-right-3 -top-3"
-                            as="span"
-                          >
-                            <img src={postImageUrl} alt={card.postImageAlt} />
-                          </EditableElement>
-                          <EditableElement
-                            id={postImageAltKey}
-                            label={`Modifier le texte alternatif de l'image ${index + 1}`}
-                            onEdit={onEdit}
-                            className="mt-3 block"
-                            buttonClassName="right-0 -top-3"
-                          >
-                            {renderRichTextElement(
-                              postImageAltKey,
-                              'p',
-                              {
-                                className: 'text-xs italic text-slate-500',
-                                style: getElementBodyTextStyle(postImageAltKey),
-                              },
-                              card.review.postImageAlt,
-                            )}
-                          </EditableElement>
-                        </div>
+                        <footer className="review-card__footer" aria-hidden="true">
+                          <div className="review-card__actions">
+                            <Heart />
+                            <MessageCircle />
+                            <Send />
+                          </div>
+                          <Bookmark className="review-card__save" />
+                        </footer>
                       </article>
                     );
                   })}

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -12,7 +12,20 @@ import {
   SectionStyle,
   INSTAGRAM_REVIEW_IDS,
 } from '../types';
-import { Clock, Mail, MapPin, Menu, X, ChevronLeft, ChevronRight, Quote } from 'lucide-react';
+import {
+  Clock,
+  Mail,
+  MapPin,
+  Menu,
+  X,
+  ChevronLeft,
+  ChevronRight,
+  Quote,
+  Heart,
+  MessageCircle,
+  Send,
+  Bookmark,
+} from 'lucide-react';
 import CustomerOrderTracker from '../components/CustomerOrderTracker';
 import { clearActiveCustomerOrder, getActiveCustomerOrder } from '../services/customerOrderStorage';
 import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
@@ -889,27 +902,57 @@ const Login: React.FC = () => {
               >
                 {instagramReviewSlides.map(review => (
                   <article key={review.id} className="review-card" aria-hidden={false}>
-                    <div className="review-card__content">
-                      <header className="review-card__header">
-                        <span className="review-card__avatar" aria-hidden="true">
-                          <img src={review.avatarUrl} alt="" />
-                        </span>
-                        <div className="review-card__meta">
-                          <p className="review-card__name">{review.name}</p>
-                          <p className="review-card__handle">{review.handle} • {review.timeAgo}</p>
-                        </div>
-                        <span className="review-card__badge">{review.badgeLabel}</span>
-                      </header>
-                      <blockquote className="review-card__quote">
-                        <Quote aria-hidden="true" className="review-card__quote-icon" />
-                        <p>{review.message}</p>
-                      </blockquote>
-                    </div>
-                    <div className="review-card__media">
-                      <span className="review-card__media-frame">
-                        <img src={review.postImageUrl} alt={review.postImageAlt} />
+                    <header className="review-card__header">
+                      <span className="review-card__avatar" aria-hidden="true">
+                        <img src={review.avatarUrl} alt="" />
                       </span>
+                      <div className="review-card__meta">
+                        <p className="review-card__name">{review.name}</p>
+                        <p className="review-card__handle">{review.handle}</p>
+                      </div>
+                      <span className="review-card__badge">{review.badgeLabel}</span>
+                    </header>
+                    <div className="review-card__layout">
+                      <div className="review-card__content">
+                        {(review.highlight || review.highlightCaption) && (
+                          <div className="review-card__highlight">
+                            <span className="review-card__highlight-thumb" aria-hidden="true">
+                              <img src={review.highlightImageUrl} alt={review.highlight} />
+                            </span>
+                            <div className="review-card__highlight-copy">
+                              <p className="review-card__highlight-title">{review.highlight}</p>
+                              {review.highlightCaption && (
+                                <p className="review-card__highlight-caption">{review.highlightCaption}</p>
+                              )}
+                            </div>
+                          </div>
+                        )}
+                        <blockquote className="review-card__quote">
+                          <Quote aria-hidden="true" className="review-card__quote-icon" />
+                          <p>{review.message}</p>
+                        </blockquote>
+                        {review.location && (
+                          <p className="review-card__location">
+                            <MapPin aria-hidden="true" />
+                            <span>{review.location}</span>
+                          </p>
+                        )}
+                        <p className="review-card__timestamp">{review.timeAgo}</p>
+                      </div>
+                      <div className="review-card__media">
+                        <span className="review-card__media-frame">
+                          <img src={review.postImageUrl} alt={review.postImageAlt} />
+                        </span>
+                      </div>
                     </div>
+                    <footer className="review-card__footer" aria-hidden="true">
+                      <div className="review-card__actions">
+                        <Heart />
+                        <MessageCircle />
+                        <Send />
+                      </div>
+                      <Bookmark className="review-card__save" />
+                    </footer>
                   </article>
                 ))}
               </div>

--- a/styles/globals.css
+++ b/styles/globals.css
@@ -157,15 +157,37 @@ body {
   box-sizing: border-box;
   flex: 0 0 calc(100% / var(--reviews-visible-count));
   min-width: calc(100% / var(--reviews-visible-count));
-  padding: 0 clamp(0.65rem, 1.8vw, 1.1rem);
+  padding: clamp(1.15rem, 3.2vw, 1.85rem);
   display: grid;
-  gap: clamp(0.85rem, 2.4vw, 1.6rem);
-  align-items: center;
+  gap: clamp(1rem, 2.8vw, 1.8rem);
+  grid-template-areas:
+    'header'
+    'layout'
+    'footer';
+  align-items: start;
+  border-radius: clamp(1.5rem, 3vw, 2rem);
+  background: color-mix(in srgb, #ffffff 82%, transparent);
+  border: 1px solid color-mix(in srgb, var(--color-heading) 12%, transparent);
+  box-shadow: 0 24px 60px rgba(15, 23, 42, 0.14);
 }
 
-@media (min-width: 960px) {
-  .review-card {
-    grid-template-columns: 1.05fr 0.95fr;
+.review-card__header {
+  grid-area: header;
+  display: flex;
+  align-items: center;
+  gap: clamp(0.85rem, 2vw, 1.15rem);
+}
+
+.review-card__layout {
+  grid-area: layout;
+  display: grid;
+  gap: clamp(1rem, 2.6vw, 1.6rem);
+}
+
+@media (min-width: 768px) {
+  .review-card__layout {
+    grid-template-columns: minmax(0, 1fr) minmax(200px, clamp(230px, 24vw, 320px));
+    align-items: stretch;
   }
 }
 
@@ -173,13 +195,6 @@ body {
   display: flex;
   flex-direction: column;
   gap: clamp(0.85rem, 2.2vw, 1.5rem);
-  padding-bottom: clamp(0.85rem, 2.2vw, 1.25rem);
-}
-
-.review-card__header {
-  display: flex;
-  align-items: center;
-  gap: 1rem;
 }
 
 .review-card__avatar {
@@ -232,6 +247,50 @@ body {
   text-transform: uppercase;
 }
 
+.review-card__highlight {
+  display: flex;
+  align-items: center;
+  gap: clamp(0.75rem, 2vw, 1rem);
+  padding: 0.65rem 0.9rem;
+  border-radius: clamp(1.25rem, 3vw, 1.75rem);
+  background: color-mix(in srgb, rgba(236, 72, 153, 0.16) 55%, rgba(99, 102, 241, 0.12));
+}
+
+.review-card__highlight-thumb {
+  display: inline-flex;
+  width: clamp(2.8rem, 5vw, 3.4rem);
+  height: clamp(2.8rem, 5vw, 3.4rem);
+  border-radius: 999px;
+  padding: 0.2rem;
+  background: conic-gradient(from 180deg at 50% 50%, #f97316, #ec4899, #6366f1, #f97316);
+}
+
+.review-card__highlight-thumb img {
+  border-radius: inherit;
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+}
+
+.review-card__highlight-copy {
+  display: flex;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.review-card__highlight-title {
+  margin: 0;
+  font-size: clamp(0.85rem, 2vw, 1rem);
+  font-weight: 700;
+  color: var(--color-heading);
+}
+
+.review-card__highlight-caption {
+  margin: 0;
+  font-size: clamp(0.7rem, 1.8vw, 0.85rem);
+  color: color-mix(in srgb, var(--color-heading) 55%, transparent);
+}
+
 .review-card__quote {
   position: relative;
   margin: 0;
@@ -250,8 +309,38 @@ body {
   color: color-mix(in srgb, var(--color-heading) 40%, transparent);
 }
 
+.review-card__location,
+.review-card__timestamp {
+  margin: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: clamp(0.7rem, 1.8vw, 0.85rem);
+  color: color-mix(in srgb, var(--color-heading) 55%, transparent);
+}
+
+.review-card__location svg {
+  width: 1rem;
+  height: 1rem;
+}
+
+.review-card__timestamp {
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .review-card__media {
-  justify-self: center;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+@media (min-width: 768px) {
+  .review-card__media {
+    align-items: flex-end;
+    justify-content: center;
+  }
 }
 
 .review-card__media-frame {
@@ -260,8 +349,8 @@ body {
   padding: 0.4rem;
   background: linear-gradient(135deg, rgba(236, 72, 153, 0.65), rgba(99, 102, 241, 0.5));
   box-shadow: 0 24px 60px rgba(99, 102, 241, 0.25);
-  width: clamp(150px, 18vw, 210px);
-  aspect-ratio: 1 / 1;
+  width: clamp(180px, 22vw, 260px);
+  aspect-ratio: 4 / 5;
 }
 
 .review-card__media-frame img {
@@ -270,6 +359,26 @@ body {
   height: 100%;
   object-fit: cover;
   border-radius: clamp(1.1rem, 3vw, 1.5rem);
+}
+
+.review-card__footer {
+  grid-area: footer;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  color: color-mix(in srgb, var(--color-heading) 65%, transparent);
+}
+
+.review-card__actions {
+  display: inline-flex;
+  align-items: center;
+  gap: clamp(0.8rem, 2vw, 1.1rem);
+}
+
+.review-card__actions svg,
+.review-card__save {
+  width: clamp(1.05rem, 2vw, 1.25rem);
+  height: clamp(1.05rem, 2vw, 1.25rem);
 }
 
 .reviews-controls {


### PR DESCRIPTION
## Summary
- restyle the Instagram review carousel with a social-inspired layout that keeps copy before media
- surface highlight, location, and timestamp details alongside social actions in both the live and preview views
- refresh carousel styling to support the new structure and proportions

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68deb89e567c832aa0449d19c35c9bf0