### PR TITLE
Generate Instagram review element keys dynamically

### DIFF
--- a/types/index.ts
+++ b/types/index.ts
@@ -61,7 +61,7 @@ export const EDITABLE_ZONE_KEYS = ['navigation', 'hero', 'about', 'menu', 'insta
 
 export type EditableZoneKey = (typeof EDITABLE_ZONE_KEYS)[number];
 
-export const EDITABLE_ELEMENT_KEYS = [
+const BASE_EDITABLE_ELEMENT_KEYS = [
   'navigation.brand',
   'navigation.brandLogo',
   'navigation.staffLogo',
@@ -90,66 +90,6 @@ export const EDITABLE_ELEMENT_KEYS = [
   'instagramReviews.subtitle',
   'instagramReviews.image',
   'instagramReviews.style.background',
-  'instagramReviews.reviews.review1.name',
-  'instagramReviews.reviews.review1.handle',
-  'instagramReviews.reviews.review1.timeAgo',
-  'instagramReviews.reviews.review1.message',
-  'instagramReviews.reviews.review1.highlight',
-  'instagramReviews.reviews.review1.highlightCaption',
-  'instagramReviews.reviews.review1.location',
-  'instagramReviews.reviews.review1.badgeLabel',
-  'instagramReviews.reviews.review1.postImageAlt',
-  'instagramReviews.reviews.review1.avatarUrl',
-  'instagramReviews.reviews.review1.highlightImageUrl',
-  'instagramReviews.reviews.review1.postImageUrl',
-  'instagramReviews.reviews.review2.name',
-  'instagramReviews.reviews.review2.handle',
-  'instagramReviews.reviews.review2.timeAgo',
-  'instagramReviews.reviews.review2.message',
-  'instagramReviews.reviews.review2.highlight',
-  'instagramReviews.reviews.review2.highlightCaption',
-  'instagramReviews.reviews.review2.location',
-  'instagramReviews.reviews.review2.badgeLabel',
-  'instagramReviews.reviews.review2.postImageAlt',
-  'instagramReviews.reviews.review2.avatarUrl',
-  'instagramReviews.reviews.review2.highlightImageUrl',
-  'instagramReviews.reviews.review2.postImageUrl',
-  'instagramReviews.reviews.review3.name',
-  'instagramReviews.reviews.review3.handle',
-  'instagramReviews.reviews.review3.timeAgo',
-  'instagramReviews.reviews.review3.message',
-  'instagramReviews.reviews.review3.highlight',
-  'instagramReviews.reviews.review3.highlightCaption',
-  'instagramReviews.reviews.review3.location',
-  'instagramReviews.reviews.review3.badgeLabel',
-  'instagramReviews.reviews.review3.postImageAlt',
-  'instagramReviews.reviews.review3.avatarUrl',
-  'instagramReviews.reviews.review3.highlightImageUrl',
-  'instagramReviews.reviews.review3.postImageUrl',
-  'instagramReviews.reviews.review4.name',
-  'instagramReviews.reviews.review4.handle',
-  'instagramReviews.reviews.review4.timeAgo',
-  'instagramReviews.reviews.review4.message',
-  'instagramReviews.reviews.review4.highlight',
-  'instagramReviews.reviews.review4.highlightCaption',
-  'instagramReviews.reviews.review4.location',
-  'instagramReviews.reviews.review4.badgeLabel',
-  'instagramReviews.reviews.review4.postImageAlt',
-  'instagramReviews.reviews.review4.avatarUrl',
-  'instagramReviews.reviews.review4.highlightImageUrl',
-  'instagramReviews.reviews.review4.postImageUrl',
-  'instagramReviews.reviews.review5.name',
-  'instagramReviews.reviews.review5.handle',
-  'instagramReviews.reviews.review5.timeAgo',
-  'instagramReviews.reviews.review5.message',
-  'instagramReviews.reviews.review5.highlight',
-  'instagramReviews.reviews.review5.highlightCaption',
-  'instagramReviews.reviews.review5.location',
-  'instagramReviews.reviews.review5.badgeLabel',
-  'instagramReviews.reviews.review5.postImageAlt',
-  'instagramReviews.reviews.review5.avatarUrl',
-  'instagramReviews.reviews.review5.highlightImageUrl',
-  'instagramReviews.reviews.review5.postImageUrl',
   'findUs.title',
   'findUs.addressLabel',
   'findUs.address',
@@ -161,6 +101,22 @@ export const EDITABLE_ELEMENT_KEYS = [
   'findUs.style.background',
   'footer.text',
   'footer.style.background',
+] as const;
+
+const INSTAGRAM_REVIEW_FIELDS = [
+  ...INSTAGRAM_REVIEW_TEXT_FIELDS,
+  ...INSTAGRAM_REVIEW_IMAGE_FIELDS,
+] as readonly InstagramReviewField[];
+
+const INSTAGRAM_REVIEW_ELEMENT_KEYS = INSTAGRAM_REVIEW_IDS.flatMap(id =>
+  INSTAGRAM_REVIEW_FIELDS.map(
+    field => `instagramReviews.reviews.${id}.${field}` as InstagramReviewElementKey,
+  ),
+) as readonly InstagramReviewElementKey[];
+
+export const EDITABLE_ELEMENT_KEYS = [
+  ...BASE_EDITABLE_ELEMENT_KEYS,
+  ...INSTAGRAM_REVIEW_ELEMENT_KEYS,
 ] as const;
 
 export type EditableElementKey = (typeof EDITABLE_ELEMENT_KEYS)[number];

--- a/utils/siteContent.test.ts
+++ b/utils/siteContent.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  DEFAULT_SITE_CONTENT,
+  resolveSiteContent,
+  sanitizeSiteContentInput,
+} from './siteContent';
+import {
+  EDITABLE_ELEMENT_KEYS,
+  STYLE_EDITABLE_ELEMENT_KEYS,
+} from '../types';
+
+const REVIEW6_MESSAGE_KEY = 'instagramReviews.reviews.review6.message' as const;
+const REVIEW7_MESSAGE_KEY = 'instagramReviews.reviews.review7.message' as const;
+const REVIEW6_POST_IMAGE_KEY = 'instagramReviews.reviews.review6.postImageUrl' as const;
+
+const createRichTextValue = (html: string, plainText: string) => ({
+  html,
+  plainText,
+});
+
+describe('siteContent instagram review element maps', () => {
+  it('includes review6 and review7 keys in editable collections', () => {
+    expect(EDITABLE_ELEMENT_KEYS).toContain(REVIEW6_MESSAGE_KEY);
+    expect(EDITABLE_ELEMENT_KEYS).toContain(REVIEW7_MESSAGE_KEY);
+    expect(EDITABLE_ELEMENT_KEYS).toContain(REVIEW6_POST_IMAGE_KEY);
+    expect(STYLE_EDITABLE_ELEMENT_KEYS).toContain(REVIEW6_MESSAGE_KEY);
+    expect(STYLE_EDITABLE_ELEMENT_KEYS).toContain(REVIEW7_MESSAGE_KEY);
+  });
+
+  it('sanitizes element maps while preserving review6 and review7 entries', () => {
+    const dirtyContent = {
+      ...DEFAULT_SITE_CONTENT,
+      elementStyles: {
+        ...DEFAULT_SITE_CONTENT.elementStyles,
+        [REVIEW6_MESSAGE_KEY]: { textColor: '  #ff00aa  ' },
+        [REVIEW7_MESSAGE_KEY]: { fontFamily: '  Custom Font  ' },
+      },
+      elementRichText: {
+        ...DEFAULT_SITE_CONTENT.elementRichText,
+        [REVIEW6_MESSAGE_KEY]: createRichTextValue('<p>Review 6</p>', 'Review 6'),
+        [REVIEW7_MESSAGE_KEY]: createRichTextValue('<strong>Review 7</strong>', 'Review 7'),
+      },
+    };
+
+    const sanitized = sanitizeSiteContentInput(dirtyContent);
+
+    expect(sanitized.elementStyles[REVIEW6_MESSAGE_KEY]).toEqual({ textColor: '#ff00aa' });
+    expect(sanitized.elementStyles[REVIEW7_MESSAGE_KEY]).toEqual({ fontFamily: 'Custom Font' });
+    expect(sanitized.elementRichText[REVIEW6_MESSAGE_KEY]).toMatchObject({
+      plainText: 'Review 6',
+    });
+    expect(sanitized.elementRichText[REVIEW7_MESSAGE_KEY]).toMatchObject({
+      plainText: 'Review 7',
+    });
+  });
+
+  it('resolves element maps while preserving review6 and review7 entries', () => {
+    const resolved = resolveSiteContent({
+      elementStyles: {
+        [REVIEW6_MESSAGE_KEY]: { textColor: '#00ffaa' },
+        [REVIEW7_MESSAGE_KEY]: { fontSize: ' 18px ' },
+      },
+      elementRichText: {
+        [REVIEW6_MESSAGE_KEY]: { html: '<p>Resolved 6</p>', plainText: '' },
+        [REVIEW7_MESSAGE_KEY]: { html: '<em>Resolved 7</em>', plainText: '' },
+      },
+    });
+
+    expect(resolved.elementStyles[REVIEW6_MESSAGE_KEY]).toEqual({ textColor: '#00ffaa' });
+    expect(resolved.elementStyles[REVIEW7_MESSAGE_KEY]).toEqual({ fontSize: '18px' });
+    expect(resolved.elementRichText[REVIEW6_MESSAGE_KEY]).toMatchObject({
+      plainText: 'Resolved 6',
+    });
+    expect(resolved.elementRichText[REVIEW7_MESSAGE_KEY]).toMatchObject({
+      plainText: 'Resolved 7',
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- derive instagram review element editable keys from the list of review ids to avoid omissions when new reviews are added
- add tests that ensure sanitize/resolve helpers preserve review6 and review7 element styles and rich text entries

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68dee8314178832aabd665a426b1ce59