### PR TITLE
Restore customer features on landing page

### DIFF
--- a/components/SitePreviewCanvas.tsx
+++ b/components/SitePreviewCanvas.tsx
@@ -17,6 +17,7 @@ import {
   createTextStyle,
 } from '../utils/siteStyleHelpers';
 import { formatCurrencyCOP } from '../utils/formatIntegerAmount';
+import { withAppendedQueryParam } from '../utils/url';
 
 const DEFAULT_BRAND_LOGO = '/logo-brand.svg';
 
@@ -228,13 +229,24 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
   };
 
   const findUsMapQuery = content.findUs.address.trim();
-  const encodedFindUsQuery = findUsMapQuery.length > 0 ? encodeURIComponent(findUsMapQuery) : '';
-  const findUsMapUrl = encodedFindUsQuery
-    ? `https://www.google.com/maps?q=${encodedFindUsQuery}`
-    : 'https://www.google.com/maps';
-  const findUsMapEmbedUrl = encodedFindUsQuery
-    ? `https://www.google.com/maps?q=${encodedFindUsQuery}&output=embed`
-    : 'about:blank';
+  const customFindUsMapUrlRaw = content.findUs.mapUrl;
+  const customFindUsMapUrl = typeof customFindUsMapUrlRaw === 'string' ? customFindUsMapUrlRaw.trim() : '';
+  const hasCustomMapUrl = customFindUsMapUrl.length > 0;
+  const encodedFindUsQuery = !hasCustomMapUrl && findUsMapQuery.length > 0
+    ? encodeURIComponent(findUsMapQuery)
+    : '';
+  const findUsMapUrl = hasCustomMapUrl
+    ? customFindUsMapUrl
+    : encodedFindUsQuery
+      ? `https://www.google.com/maps?q=${encodedFindUsQuery}`
+      : 'https://www.google.com/maps';
+  const findUsMapEmbedUrl = hasCustomMapUrl
+    ? withAppendedQueryParam(customFindUsMapUrl, 'output', 'embed')
+    : encodedFindUsQuery
+      ? `https://www.google.com/maps?q=${encodedFindUsQuery}&output=embed`
+      : 'about:blank';
+  const hasMapLocation = hasCustomMapUrl || encodedFindUsQuery.length > 0;
+  const findUsMapTitle = findUsMapQuery.length > 0 ? findUsMapQuery : content.findUs.title;
 
   return (
     <EditButtonVisibilityContext.Provider value={showEditButtons}>
@@ -853,10 +865,10 @@ const SitePreviewCanvas: React.FC<SitePreviewCanvasProps> = ({
                 </div>
               </div>
               <div className="find-us-map" style={findUsTextStyle}>
-                {encodedFindUsQuery ? (
+                {hasMapLocation ? (
                   <div className="find-us-map__frame">
                     <iframe
-                      title={`Carte Google Maps pour ${findUsMapQuery}`}
+                      title={`Carte Google Maps pour ${findUsMapTitle}`}
                       src={findUsMapEmbedUrl}
                       loading="lazy"
                       allowFullScreen

--- a/pages/Login.tsx
+++ b/pages/Login.tsx
@@ -22,6 +22,7 @@ import {
 import { resolveZoneFromElement } from '../components/SitePreviewCanvas';
 import { getHomeRedirectPath } from '../utils/navigation';
 import { DEFAULT_SITE_CONTENT as BASE_SITE_CONTENT } from '../utils/siteContent';
+import { withAppendedQueryParam } from '../utils/url';
 
 const DEFAULT_BRAND_LOGO = '/logo-brand.svg';
 
@@ -82,6 +83,7 @@ const DEFAULT_SITE_CONTENT: SiteContent = {
     hoursLabel: '',
     hours: '',
     mapLabel: '',
+    mapUrl: '',
     style: createDefaultSectionStyle(),
   },
   footer: {
@@ -307,14 +309,70 @@ const Login: React.FC = () => {
   const [isMobileMenuOpen, setMobileMenuOpen] = useState(false);
   const [activeOrder, setActiveOrder] = useState(() => getActiveCustomerOrder());
 
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    try {
+      const historyJSON = window.localStorage.getItem('customer-order-history');
+      if (!historyJSON) {
+        return;
+      }
+
+      const parsed = JSON.parse(historyJSON) as Order[];
+      if (Array.isArray(parsed)) {
+        setOrderHistory(parsed);
+      }
+    } catch (error) {
+      console.error('Could not load order history', error);
+    }
+  }, []);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    const fetchBestSellers = async () => {
+      try {
+        const products = await api.getBestSellerProducts();
+        if (isMounted) {
+          setBestSellers(products);
+        }
+      } catch (error) {
+        console.error('Could not load best seller products', error);
+      } finally {
+        if (isMounted) {
+          setMenuLoading(false);
+        }
+      }
+    };
+
+    fetchBestSellers();
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   const findUsMapQuery = findUs.address.trim();
-  const encodedFindUsQuery = findUsMapQuery.length > 0 ? encodeURIComponent(findUsMapQuery) : '';
-  const findUsMapUrl = encodedFindUsQuery
-    ? `https://www.google.com/maps?q=${encodedFindUsQuery}`
-    : 'https://www.google.com/maps';
-  const findUsMapEmbedUrl = encodedFindUsQuery
-    ? `https://www.google.com/maps?q=${encodedFindUsQuery}&output=embed`
-    : 'about:blank';
+  const customFindUsMapUrlRaw = findUs.mapUrl;
+  const customFindUsMapUrl = typeof customFindUsMapUrlRaw === 'string' ? customFindUsMapUrlRaw.trim() : '';
+  const hasCustomMapUrl = customFindUsMapUrl.length > 0;
+  const encodedFindUsQuery = !hasCustomMapUrl && findUsMapQuery.length > 0
+    ? encodeURIComponent(findUsMapQuery)
+    : '';
+  const findUsMapUrl = hasCustomMapUrl
+    ? customFindUsMapUrl
+    : encodedFindUsQuery
+      ? `https://www.google.com/maps?q=${encodedFindUsQuery}`
+      : 'https://www.google.com/maps';
+  const findUsMapEmbedUrl = hasCustomMapUrl
+    ? withAppendedQueryParam(customFindUsMapUrl, 'output', 'embed')
+    : encodedFindUsQuery
+      ? `https://www.google.com/maps?q=${encodedFindUsQuery}&output=embed`
+      : 'about:blank';
+  const hasMapLocation = hasCustomMapUrl || encodedFindUsQuery.length > 0;
+  const findUsMapTitle = findUsMapQuery.length > 0 ? findUsMapQuery : findUs.title;
   const activeOrderId = activeOrder?.orderId ?? null;
   const bestSellersToDisplay = bestSellers.slice(0, 6);
   const bestSellerCount = bestSellersToDisplay.length;
@@ -623,7 +681,7 @@ const Login: React.FC = () => {
                 },
                 menuContent.loadingLabel,
               )
-            ) : (
+            ) : bestSellersToDisplay.length > 0 ? (
               <div className={menuGridClassName}>
                 {bestSellersToDisplay.map(product => (
                   <article key={product.id} className={menuCardClassName}>
@@ -642,6 +700,10 @@ const Login: React.FC = () => {
                   </article>
                 ))}
               </div>
+            ) : (
+              <p className="section-text section-text--muted" style={menuBodyTextStyle}>
+                Aucun produit best seller n'est disponible pour le moment.
+              </p>
             )}
             <div className="section-actions">
               <button
@@ -756,10 +818,10 @@ const Login: React.FC = () => {
               </div>
             </div>
             <div className="find-us-map" style={findUsTextStyle}>
-              {encodedFindUsQuery ? (
+              {hasMapLocation ? (
                 <div className="find-us-map__frame">
                   <iframe
-                    title={`Carte Google Maps pour ${findUsMapQuery}`}
+                    title={`Carte Google Maps pour ${findUsMapTitle}`}
                     src={findUsMapEmbedUrl}
                     loading="lazy"
                     allowFullScreen

--- a/types/index.ts
+++ b/types/index.ts
@@ -219,6 +219,7 @@ export interface SiteContent {
     hoursLabel: string;
     hours: string;
     mapLabel: string;
+    mapUrl: string;
     style: SectionStyle;
   };
   footer: {

--- a/utils/siteContent.ts
+++ b/utils/siteContent.ts
@@ -597,6 +597,8 @@ export const DEFAULT_SITE_CONTENT: SiteContent = {
     hoursLabel: 'Horarios',
     hours: 'Lunes a domingo · 11h00 - 23h00',
     mapLabel: 'Ver en Google Maps',
+    mapUrl:
+      'https://www.google.com/maps/place/OuiOuiTacos/@11.002146,-74.8076539,17z/data=!3m1!4b1!4m6!3m5!1s0x8ef42df1d75b2ca7:0xeb86955accff816d!8m2!3d11.002146!4d-74.805079!16s%2Fg%2F11vs3882q9?authuser=1&entry=ttu&g_ep=EgoyMDI1MDkzMC4wIKXMDSoASAFQAw%3D%3D',
     style: DEFAULT_FIND_US_STYLE,
   },
   footer: {
@@ -665,6 +667,7 @@ export const resolveSiteContent = (content?: Partial<SiteContent> | null): SiteC
       hoursLabel: resolveString(content?.findUs?.hoursLabel, base.findUs.hoursLabel),
       hours: resolveString(content?.findUs?.hours, base.findUs.hours),
       mapLabel: resolveString(content?.findUs?.mapLabel, base.findUs.mapLabel),
+      mapUrl: resolveString(content?.findUs?.mapUrl, base.findUs.mapUrl),
       style: resolveSectionStyle(content?.findUs?.style, base.findUs.style),
     },
     footer: {
@@ -729,6 +732,7 @@ export const sanitizeSiteContentInput = (content: SiteContent): SiteContent => (
     hoursLabel: trimOrEmpty(content.findUs.hoursLabel),
     hours: trimOrEmpty(content.findUs.hours),
     mapLabel: trimOrEmpty(content.findUs.mapLabel),
+    mapUrl: trimOrEmpty(content.findUs.mapUrl),
     style: sanitizeSectionStyle(content.findUs.style, DEFAULT_FIND_US_STYLE),
   },
   footer: {

--- a/utils/url.ts
+++ b/utils/url.ts
@@ -1,0 +1,16 @@
+export const withAppendedQueryParam = (url: string, key: string, value: string): string => {
+  if (!url) {
+    return url;
+  }
+
+  try {
+    const urlObject = new URL(url);
+    urlObject.searchParams.set(key, value);
+    return urlObject.toString();
+  } catch (error) {
+    const separator = url.includes('?') ? '&' : '?';
+    const encodedKey = encodeURIComponent(key);
+    const encodedValue = encodeURIComponent(value);
+    return `${url}${separator}${encodedKey}=${encodedValue}`;
+  }
+};


### PR DESCRIPTION
## Summary
- restore the past order history section under the hero call to action by loading stored customer orders
- fetch and render best seller products again on the menu section, including a message when none are configured
- add support for a dedicated Google Maps link using the OuiOuiTacos location and reuse it for embeds

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68def5f7da60832abe4f79e586a11645