### PR TITLE
Adjust cart panel height to fit order contents

### DIFF
--- a/pages/CommandeClient.tsx
+++ b/pages/CommandeClient.tsx
@@ -410,7 +410,7 @@ const OrderMenuView: React.FC<{ onOrderSubmitted: (order: Order) => void }> = ({
                     <div className="bg-white/95 p-4 rounded-xl shadow-xl">
                         <h2 className="text-2xl font-bold flex items-center gap-2 mb-4 text-gray-700"><ShoppingCart/> Mi carrito</h2>
                         {cart.length === 0 ? <p className="text-gray-500">Tu carrito está vacío.</p> :
-                            <div className="space-y-3 max-h-48 overflow-y-auto pr-2">
+                            <div className="space-y-3">
                                 {cart.map(item => (
                                     <div key={item.id} className="flex justify-between items-start">
                                         <div>


### PR DESCRIPTION
## Summary
- remove the fixed height and overflow styling from the cart item list on the customer order page
- let the cart section expand with the items instead of showing an internal scrollbar

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_b_68dfd45b7eb0832aaf3e31a937d24b8d