### PR TITLE
Fix takeaway order product display and kitchen sync

### DIFF
--- a/pages/ParaLlevar.tsx
+++ b/pages/ParaLlevar.tsx
@@ -70,16 +70,30 @@ const TakeawayCard: React.FC<{ order: Order, onValidate?: (orderId: string) => v
 
                     <div className="space-y-3">
                         <h5 className="text-xs font-semibold uppercase tracking-[0.2em] text-gray-500">Artículos</h5>
-                        <ul className="space-y-2">
-                            {order.items.map((item: OrderItem) => (
-                                <li key={item.id} className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-900 shadow-sm">
-                                    <div className="flex items-baseline justify-between gap-3 text-gray-900">
-                                        <span className="font-semibold text-gray-900">{item.nom_produit}</span>
-                                        <span className="text-base sm:text-lg font-bold text-gray-900">{item.quantite}×</span>
-                                    </div>
-                                </li>
-                            ))}
-                        </ul>
+                        {order.items.length > 0 ? (
+                            <ul className="space-y-2">
+                                {order.items.map((item: OrderItem) => {
+                                    const note = item.commentaire?.trim();
+                                    return (
+                                        <li key={item.id} className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-900 shadow-sm">
+                                            <div className="flex items-baseline justify-between gap-3 text-gray-900">
+                                                <span className="font-semibold text-gray-900">{item.quantite}× {item.nom_produit}</span>
+                                                <span className="text-sm sm:text-base font-semibold text-gray-900">{formatCurrencyCOP(item.prix_unitaire * item.quantite)}</span>
+                                            </div>
+                                            {note && (
+                                                <p className="mt-2 rounded-md border border-dashed border-blue-200 bg-blue-50 px-3 py-2 text-xs font-medium italic text-blue-800">
+                                                    {note}
+                                                </p>
+                                            )}
+                                        </li>
+                                    );
+                                })}
+                            </ul>
+                        ) : (
+                            <p className="rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-xs text-gray-500 shadow-sm">
+                                Este pedido aún no tiene artículos registrados.
+                            </p>
+                        )}
                     </div>
 
                     <div className="flex items-center justify-between rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 font-semibold text-gray-900 shadow-sm">

--- a/services/api.ts
+++ b/services/api.ts
@@ -706,6 +706,15 @@ const fetchOrderById = async (orderId: string): Promise<Order | null> => {
   return row ? mapOrderRow(row) : null;
 };
 
+const ensureOrderHasItems = async (order: Order): Promise<Order> => {
+  if (order.items.length > 0) {
+    return order;
+  }
+
+  const enrichedOrder = await fetchOrderById(order.id);
+  return enrichedOrder ?? order;
+};
+
 const fetchIngredients = async (): Promise<Ingredient[]> => {
   const response = await supabase
     .from('ingredients')
@@ -1336,21 +1345,43 @@ export const api = {
   },
 
   getKitchenOrders: async (): Promise<KitchenTicket[]> => {
-    const response = await selectOrdersQuery()
-      .eq('estado_cocina', 'recibido')
-      .or('statut.eq.en_cours,type.eq.a_emporter');
+    const response = await selectOrdersQuery().or(
+      [
+        'and(estado_cocina.eq.recibido,statut.eq.en_cours)',
+        'and(type.eq.a_emporter,statut.eq.en_cours)',
+      ].join(','),
+    );
     const rows = unwrap<SupabaseOrderRow[]>(response as SupabaseResponse<SupabaseOrderRow[]>);
-    const orders = rows.map(mapOrderRow);
+    const orders = await Promise.all(rows.map(row => ensureOrderHasItems(mapOrderRow(row))));
+
+    const eligibleOrders = orders.filter(order => {
+      if (order.type === 'a_emporter') {
+        if (order.statut !== 'en_cours') {
+          return false;
+        }
+
+        return order.estado_cocina !== 'entregada' && order.estado_cocina !== 'listo';
+      }
+
+      return order.statut === 'en_cours' && order.estado_cocina === 'recibido';
+    });
 
     const tickets: KitchenTicket[] = [];
 
-    orders.forEach(order => {
+    eligibleOrders.forEach(order => {
       const sentItems = order.items.filter(item => item.estado === 'enviado');
-      if (sentItems.length === 0) {
+      const itemsForTicket =
+        sentItems.length > 0
+          ? sentItems
+          : order.type === 'a_emporter'
+            ? order.items
+            : [];
+
+      if (itemsForTicket.length === 0) {
         return;
       }
 
-      const groups = sentItems.reduce((acc, item) => {
+      const groups = itemsForTicket.reduce((acc, item) => {
         const key = item.date_envoi ?? order.date_envoi_cuisine ?? order.date_creation;
         const group = acc.get(key) ?? [];
         group.push(item);
@@ -1378,7 +1409,7 @@ export const api = {
   getTakeawayOrders: async (): Promise<{ pending: Order[]; ready: Order[] }> => {
     const response = await selectOrdersQuery().eq('type', 'a_emporter');
     const rows = unwrap<SupabaseOrderRow[]>(response as SupabaseResponse<SupabaseOrderRow[]>);
-    const orders = rows.map(mapOrderRow);
+    const orders = await Promise.all(rows.map(row => ensureOrderHasItems(mapOrderRow(row))));
     return {
       pending: orders.filter(order => order.statut === 'pendiente_validacion'),
       ready: orders.filter(order => order.estado_cocina === 'listo'),


### PR DESCRIPTION
## Summary
- show detailed takeaway order items in the validation cards, including prices and notes
- ensure takeaway API responses always include order items
- allow validated takeaway orders to generate kitchen tickets even when item statuses are pending
- include validated takeaway orders in the kitchen queue until they are marked ready or delivered

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e2f5a0a6c4832abed4d0bbee2e5060