### PR TITLE
Fix kitchen ticket filtering for cuisine view

### DIFF
--- a/services/api.ts
+++ b/services/api.ts
@@ -1356,6 +1356,14 @@ export const api = {
 
     const tickets: KitchenTicket[] = [];
 
+    const eligibleOrders = orders.filter(order => {
+      if (order.type === 'a_emporter') {
+        return true;
+      }
+
+      return order.items.some(item => item.estado === 'enviado');
+    });
+
     eligibleOrders.forEach(order => {
       const sentItems = order.items.filter(item => item.estado === 'enviado');
       const itemsForTicket =


### PR DESCRIPTION
## Summary
- prevent `getKitchenOrders` from referencing an undefined variable by filtering orders explicitly
- ensure kitchen tickets include sent table items or all takeaway items so the cuisine tab renders correctly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68e2fe709fc0832aae84f98027fe9f13