### PR TITLE
Ensure takeaway orders show up in kitchen view

### DIFF
--- a/services/api.ts
+++ b/services/api.ts
@@ -1345,12 +1345,9 @@ export const api = {
   },
 
   getKitchenOrders: async (): Promise<KitchenTicket[]> => {
-    const response = await selectOrdersQuery().or(
-      [
-        'and(estado_cocina.eq.recibido,statut.eq.en_cours)',
-        'and(type.eq.a_emporter,statut.eq.en_cours)',
-      ].join(','),
-    );
+    const response = await selectOrdersQuery()
+      .eq('estado_cocina', 'recibido')
+      .neq('statut', 'finalisee');
     const rows = unwrap<SupabaseOrderRow[]>(response as SupabaseResponse<SupabaseOrderRow[]>);
     const orders = await Promise.all(rows.map(row => ensureOrderHasItems(mapOrderRow(row))));
 


### PR DESCRIPTION
## Summary
- fetch kitchen tickets by kitchen status so takeaway orders marked as received appear

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e37c4d65c4832a8744b818775e8810