### PR TITLE
Fix missing items in takeaway order cards

### DIFF
--- a/services/api.ts
+++ b/services/api.ts
@@ -706,13 +706,55 @@ const fetchOrderById = async (orderId: string): Promise<Order | null> => {
   return row ? mapOrderRow(row) : null;
 };
 
+const fetchOrderItemsByOrderId = async (orderId: string): Promise<OrderItem[]> => {
+  const response = await supabase
+    .from('order_items')
+    .select(
+      `
+        id,
+        order_id,
+        produit_id,
+        nom_produit,
+        prix_unitaire,
+        quantite,
+        excluded_ingredients,
+        commentaire,
+        estado,
+        date_envoi
+      `,
+    )
+    .eq('order_id', orderId);
+
+  const rows = unwrap<SupabaseOrderItemRow[]>(response as SupabaseResponse<SupabaseOrderItemRow[]>);
+  return rows.map(mapOrderItemRow);
+};
+
 const ensureOrderHasItems = async (order: Order): Promise<Order> => {
   if (order.items.length > 0) {
     return order;
   }
 
   const enrichedOrder = await fetchOrderById(order.id);
-  return enrichedOrder ?? order;
+  if (enrichedOrder?.items.length) {
+    return enrichedOrder;
+  }
+
+  const fallbackItems = await fetchOrderItemsByOrderId(order.id);
+  if (fallbackItems.length === 0) {
+    return enrichedOrder ?? order;
+  }
+
+  const baseOrder = enrichedOrder ?? order;
+  const computedTotal = fallbackItems.reduce(
+    (sum, item) => sum + item.prix_unitaire * item.quantite,
+    0,
+  );
+
+  return {
+    ...baseOrder,
+    items: fallbackItems,
+    total: baseOrder.total > 0 ? baseOrder.total : computedTotal,
+  };
 };
 
 const fetchIngredients = async (): Promise<Ingredient[]> => {


### PR DESCRIPTION
## Summary
- add a direct fallback query to load order items when the initial join returns empty data
- ensure takeaway orders recompute their totals when items are filled from the fallback query

## Testing
- npm run test

------
https://chatgpt.com/codex/tasks/task_b_68e381823534832a940e763b62db76b8