### PR TITLE
Include online takeaway orders in kitchen view

### DIFF
--- a/services/api.ts
+++ b/services/api.ts
@@ -757,6 +757,24 @@ const ensureOrderHasItems = async (order: Order): Promise<Order> => {
   };
 };
 
+const TAKEAWAY_ORDER_TYPES: Order['type'][] = ['a_emporter', 'pedir_en_linea'];
+
+const isTakeawayLikeOrder = (order: Order): boolean => TAKEAWAY_ORDER_TYPES.includes(order.type);
+
+const isKitchenEligibleOrder = (order: Order): boolean => {
+  if (isTakeawayLikeOrder(order)) {
+    const isValidated = order.statut === 'en_cours';
+    const awaitingKitchen = order.estado_cocina === 'recibido' || order.estado_cocina === 'no_enviado';
+    return isValidated && awaitingKitchen && order.items.length > 0;
+  }
+
+  if (order.estado_cocina !== 'recibido') {
+    return false;
+  }
+
+  return order.items.some(item => item.estado === 'enviado');
+};
+
 const fetchIngredients = async (): Promise<Ingredient[]> => {
   const response = await supabase
     .from('ingredients')
@@ -1388,27 +1406,21 @@ export const api = {
 
   getKitchenOrders: async (): Promise<KitchenTicket[]> => {
     const response = await selectOrdersQuery()
-      .eq('estado_cocina', 'recibido')
+      .in('estado_cocina', ['recibido', 'no_enviado'])
       .neq('statut', 'finalisee');
     const rows = unwrap<SupabaseOrderRow[]>(response as SupabaseResponse<SupabaseOrderRow[]>);
     const orders = await Promise.all(rows.map(row => ensureOrderHasItems(mapOrderRow(row))));
 
     const tickets: KitchenTicket[] = [];
 
-    const eligibleOrders = orders.filter(order => {
-      if (order.type === 'a_emporter') {
-        return true;
-      }
-
-      return order.items.some(item => item.estado === 'enviado');
-    });
+    const eligibleOrders = orders.filter(isKitchenEligibleOrder);
 
     eligibleOrders.forEach(order => {
       const sentItems = order.items.filter(item => item.estado === 'enviado');
       const itemsForTicket =
         sentItems.length > 0
           ? sentItems
-          : order.type === 'a_emporter'
+          : isTakeawayLikeOrder(order)
             ? order.items
             : [];
 
@@ -1442,7 +1454,7 @@ export const api = {
   },
 
   getTakeawayOrders: async (): Promise<{ pending: Order[]; ready: Order[] }> => {
-    const response = await selectOrdersQuery().eq('type', 'a_emporter');
+    const response = await selectOrdersQuery().in('type', TAKEAWAY_ORDER_TYPES);
     const rows = unwrap<SupabaseOrderRow[]>(response as SupabaseResponse<SupabaseOrderRow[]>);
     const orders = await Promise.all(rows.map(row => ensureOrderHasItems(mapOrderRow(row))));
     return {
@@ -1876,9 +1888,9 @@ export const api = {
     const orders = rows.map(mapOrderRow);
 
     return {
-      pendingTakeaway: orders.filter(order => order.type === 'a_emporter' && order.statut === 'pendiente_validacion').length,
-      readyTakeaway: orders.filter(order => order.type === 'a_emporter' && order.estado_cocina === 'listo').length,
-      kitchenOrders: orders.filter(order => order.estado_cocina === 'recibido').length,
+      pendingTakeaway: orders.filter(order => isTakeawayLikeOrder(order) && order.statut === 'pendiente_validacion').length,
+      readyTakeaway: orders.filter(order => isTakeawayLikeOrder(order) && order.estado_cocina === 'listo').length,
+      kitchenOrders: orders.filter(isKitchenEligibleOrder).length,
       lowStockIngredients: (await fetchIngredients()).filter(
         ingredient => ingredient.stock_actuel <= ingredient.stock_minimum,
       ).length,

--- a/types/index.ts
+++ b/types/index.ts
@@ -304,7 +304,7 @@ export interface OrderItem {
 
 export interface Order {
   id: string;
-  type: 'sur_place' | 'a_emporter';
+  type: 'sur_place' | 'a_emporter' | 'pedir_en_linea';
   table_id?: string;
   table_nom?: string;
   couverts: number;


### PR DESCRIPTION
## Summary
- treat online takeaway orders like other takeaway tickets when building the kitchen view
- include online order types when retrieving takeaway queues and computing notification counts

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e38496488c832a9446d715f0c955f4