### PR TITLE
Ensure fetched orders include item details

### DIFF
--- a/services/api.ts
+++ b/services/api.ts
@@ -703,7 +703,11 @@ const runProductsQueryWithFallback = async <T>(
 const fetchOrderById = async (orderId: string): Promise<Order | null> => {
   const response = await selectOrdersQuery().eq('id', orderId).maybeSingle();
   const row = unwrapMaybe<SupabaseOrderRow>(response as SupabaseResponse<SupabaseOrderRow | null>);
-  return row ? mapOrderRow(row) : null;
+  if (!row) {
+    return null;
+  }
+
+  return ensureOrderHasItems(mapOrderRow(row));
 };
 
 const fetchOrderItemsByOrderId = async (orderId: string): Promise<OrderItem[]> => {


### PR DESCRIPTION
## Summary
- ensure customer order fetches always return their items by reusing the fallback loader

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_b_68e397393930832a9420c21d3aa5dc1c